### PR TITLE
fix(macos): keep window within visibleFrame so the Dock can't clip it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,9 @@ Flutter is **not on PATH**; this machine uses **fvm, Flutter 3.35.2**:
 - **Signing secrets/keys: `docs/SIGNING.md`** is the map of where every value/file lives
   (Bitwarden masters, GitHub Actions secrets, gitignored local files, the match certs repo).
   No secret values are committed. Apple setup details: `docs/PUBLISHING-APPLE.md`.
+- **Version bumps happen ONLY on `main`, after a feature branch is merged** — never
+  bump `version:` in `pubspec.yaml` on a feature branch (avoids merge churn/conflicts
+  on the build number). Bump + tag as a dedicated step on `main` when cutting a release.
 
 ## Architecture
 

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -7,16 +7,34 @@ class MainFlutterWindow: NSWindow {
     self.contentViewController = flutterViewController
 
     // Lock the window to a portrait phone-like size so the UI only ever has to
-    // deal with one (mobile) layout. Fixed, non-resizable, centered.
-    let phoneSize = NSSize(width: 420, height: 880)
-    self.setContentSize(phoneSize)
-    self.contentMinSize = phoneSize
-    self.contentMaxSize = phoneSize
+    // deal with one (mobile) layout. Fixed, non-resizable. Prefer 420x880 but
+    // never exceed the screen's visible area (excludes menu bar + Dock) or the
+    // window ends up clipped behind the Dock — App Review rejects that (G4).
+    let preferred = NSSize(width: 420, height: 880)
+    let visible = self.screen?.visibleFrame
+      ?? NSScreen.main?.visibleFrame
+      ?? NSRect(x: 0, y: 0, width: preferred.width, height: preferred.height)
+
+    self.setContentSize(preferred)
+    let titleBarOverhead = self.frame.height - preferred.height
+    let size = NSSize(
+      width: min(preferred.width, visible.width),
+      height: min(preferred.height, visible.height - titleBarOverhead))
+    self.setContentSize(size)
+    self.contentMinSize = size
+    self.contentMaxSize = size
     self.styleMask.remove(.resizable)
-    self.center()
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+
+    // Center within the *visible* frame (not the full screen) so the Dock/menu
+    // bar never clips the window. Done after super so the frame is settled.
+    if let vf = self.screen?.visibleFrame {
+      self.setFrameOrigin(NSPoint(
+        x: vf.midX - self.frame.width / 2,
+        y: vf.midY - self.frame.height / 2))
+    }
   }
 }


### PR DESCRIPTION
App Review rejected the macOS build (G4) — on a 14" MacBook Pro the fixed 420x880 window sat partly behind the Dock, clipping the bottom. center() centers against the full screen frame (spans menu bar + Dock), and 880pt content + title bar exceeds the visible area once the Dock shows.

Cap the content size to the screen's visibleFrame (minus title-bar overhead) and center within visibleFrame instead of the full screen, so the window never overlaps the menu bar or Dock on any display size.

Also document: version bumps happen only on main after merge, not on feature branches.