### PR TITLE
chore: project review remediation (docs, CI/CD, code cleanup)

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,32 @@
+name: Setup Flutter
+description: Install Flutter (SDK cached), optionally cache CocoaPods, and run pub get.
+# NOTE: the caller must `actions/checkout` FIRST — a local composite action can't
+# be resolved until the repo is on disk, so checkout can't live in here.
+
+inputs:
+  flutter-version:
+    description: Flutter SDK version
+    required: true
+  cache-pods:
+    description: Cache CocoaPods (set 'true' for iOS/macOS jobs)
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+      with:
+        flutter-version: ${{ inputs.flutter-version }}
+        channel: stable
+        cache: true
+    - if: inputs.cache-pods == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: |
+          ~/Library/Caches/CocoaPods
+          ios/Pods
+          macos/Pods
+        key: pods-${{ runner.os }}-${{ hashFiles('ios/Podfile.lock', 'macos/Podfile.lock') }}
+        restore-keys: pods-${{ runner.os }}-
+    - run: flutter pub get
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+# Enforces `flutter analyze` + `flutter test` on every PR and push to main —
+# the release workflow only runs on tags, so without this nothing gates green.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: '3.35.2'
+
+jobs:
+  analyze-test:
+    name: Analyze & test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup-flutter
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+      - run: flutter analyze
+      - run: flutter test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,11 @@ name: Release
 # Signing/publishing steps are gated on secrets, so secret-less forks stay green
 # (with unsigned fallbacks). All Apple jobs run on macos-26 — App Store Connect
 # rejects uploads built with an older SDK (needs Xcode 26 / iOS 26 SDK).
+#
+# The common "install Flutter + pub get (+ CocoaPods cache)" block lives in the
+# local composite action .github/actions/setup-flutter (checkout must precede it).
+# Third-party actions are pinned to a commit SHA (the trailing # vX.Y.Z is the
+# human-readable version) so a maintainer's tag move can't change our build.
 
 on:
   push:
@@ -45,17 +50,15 @@ jobs:
       HAS_KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
       HAS_PLAY_SA: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: '17'
-      - uses: subosito/flutter-action@v2
+          cache: gradle
+      - uses: ./.github/actions/setup-flutter
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-          cache: true
-      - run: flutter pub get
 
       - name: Decode upload keystore
         if: env.HAS_KEYSTORE == 'true'
@@ -79,7 +82,7 @@ jobs:
           cp build/app/outputs/flutter-apk/app-release.apk \
              "dist/Sonority-${{ github.ref_name }}.apk"
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: android
           path: dist/*.apk
@@ -87,7 +90,7 @@ jobs:
 
       - name: Publish AAB → Google Play (open testing)
         if: env.HAS_PLAY_SA == 'true'
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: be.casperverswijvelt.sonority
@@ -104,13 +107,11 @@ jobs:
     # Apple build uses one toolchain.
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup-flutter
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-          cache: true
-      - run: flutter pub get
+          cache-pods: 'true'
 
       - name: Build unsigned iOS .ipa
         run: |
@@ -123,7 +124,7 @@ jobs:
           zip -qry "$GITHUB_WORKSPACE/dist/Sonority-${{ github.ref_name }}-ios-unsigned.ipa" Payload
 
       - name: Upload .ipa artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ios-unsigned
           path: dist/*.ipa
@@ -140,17 +141,15 @@ jobs:
     env:
       HAS_SIGNING: ${{ secrets.MATCH_PASSWORD != '' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup-flutter
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-          cache: true
-      - uses: ruby/setup-ruby@v1
+          cache-pods: 'true'
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
-      - run: flutter pub get
 
       - name: Decode App Store Connect API key
         if: env.HAS_SIGNING == 'true'
@@ -177,17 +176,15 @@ jobs:
     env:
       HAS_DEVID: ${{ secrets.MACOS_DEVID_P12_BASE64 != '' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup-flutter
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-          cache: true
-      - uses: ruby/setup-ruby@v1
+          cache-pods: 'true'
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
-      - run: flutter pub get
 
       - name: Decode App Store Connect API key
         if: env.HAS_DEVID == 'true'
@@ -215,7 +212,7 @@ jobs:
             "dist/Sonority-${{ github.ref_name }}-macos.dmg"
 
       - name: Upload .dmg artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: macos-dmg
           path: dist/*.dmg
@@ -228,17 +225,15 @@ jobs:
     env:
       HAS_SIGNING: ${{ secrets.MATCH_PASSWORD != '' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: ./.github/actions/setup-flutter
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
-          channel: stable
-          cache: true
-      - uses: ruby/setup-ruby@v1
+          cache-pods: 'true'
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
-      - run: flutter pub get
 
       - name: Decode App Store Connect API key
         if: env.HAS_SIGNING == 'true'
@@ -267,24 +262,14 @@ jobs:
     if: ${{ always() && needs.android.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # needed so body_path (release notes) resolves
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1 — needed so body_path (release notes) resolves
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
       - name: Delete existing release for this tag (clean re-runs)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          id=$(curl -s -H "Authorization: token $GH_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ github.ref_name }}" \
-            | grep -m1 '"id":' | sed 's/[^0-9]//g')
-          if [ -n "$id" ]; then
-            curl -s -X DELETE -H "Authorization: token $GH_TOKEN" \
-              "https://api.github.com/repos/${{ github.repository }}/releases/$id"
-            echo "Deleted existing release $id"
-          else
-            echo "No existing release to delete"
-          fi
+        run: gh release delete "${{ github.ref_name }}" --yes --cleanup-tag=false || true
       - name: Compose release notes (changelog section + install notes)
         run: |
           version="${GITHUB_REF_NAME#v}"
@@ -306,7 +291,7 @@ jobs:
           echo "----- release-body.md -----"
           cat release-body.md
       - name: Publish release (APK + .ipa + .dmg)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: artifacts/**/*
           # NOTE: do not enable generate_release_notes — it overrides body_path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ the engine headlessly against real hardware via `tool/*.dart`.
 
 ```
 lib/
-  core/            result.dart, theme.dart (M3), tone_generator.dart (chime WAV)
+  core/            theme.dart (M3), tone_generator.dart (chime WAV)
   data/models/     sonos_models.dart — SonosDevice, ZoneGroupMember, SonosSystem, SonosChannel
   data/sonos/      THE ENGINE (pure Dart, no Flutter):
                      ssdp_discovery · device_description · soap_client
@@ -227,6 +227,15 @@ Note: CLI tools must NOT import `sonos_repository.dart` (it pulls in
     catch-22 (the official app refuses to tune the very fronts config you want).
     Reddit reports of it working are firmware/model-specific. Sonority reads and
     reports this honestly but cannot restore a tuning Sonos has cleared.
+
+### Terminology (the same thing has three names — don't get lost)
+- **zone group** = Sonos' API/topology term (`ZoneGroupTopology`, `ZoneGroupMember`)
+  — a playback group, NOT our feature. **bond** = any hardware pairing at the
+  `AddHTSatellite`/`AddBondedZones` level (HT, stereo pair, zone). **group** =
+  *our* model/UI name for the `AddBondedZones` speaker bond (`createGroup`,
+  `EntityKind.zone/stereoPair/custom`); the UI label is "speaker groups". So
+  `ZoneGroupMember` (API) ≠ our "group"; `isZone`/`isStereoPair` classify what a
+  bond is, `bondAndVerify` writes any bond.
 
 ### Channel maps (`channel_map.dart`)
 `HTSatChanMapSet` format: `UUID:CH[,CH];UUID:CH;…`. Tokens: `LF RF CC LR RR SW`.

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -46,7 +46,7 @@ the portal on import — both awkward in CI). The identity is a single p12 secre
 | Item | Bitwarden | GitHub secret | Local file |
 |---|---|---|---|
 | `devid.p12` (Developer ID cert + private key) | ✓ (attach) | `MACOS_DEVID_P12_BASE64` (base64) | `fastlane/devid.p12` |
-| its export password (`yeet`) | ✓ | `MACOS_DEVID_P12_PASSWORD` | — |
+| its export password (`<export-password>`) | ✓ | `MACOS_DEVID_P12_PASSWORD` | — |
 
 Created manually in **Xcode** (Account Holder only — the ASC API can't mint Developer ID
 certs) and exported from Keychain. Full steps: `docs/PUBLISHING-APPLE.md`.

--- a/lib/data/models/sonos_models.dart
+++ b/lib/data/models/sonos_models.dart
@@ -356,25 +356,25 @@ class SonosSystem {
   List<ZoneGroupMember> get allMembers => groups
       .expand((g) => g.members)
       .where((m) => !m.invisible)
-      .toList(growable: false);
+      .toList();
 
   /// Home theaters present in the system (e.g. an Arc with surrounds).
   List<ZoneGroupMember> get homeTheaters =>
-      allMembers.where((m) => m.isHomeTheater).toList(growable: false);
+      allMembers.where((m) => m.isHomeTheater).toList();
 
   /// Stereo pairs present in the system.
   List<ZoneGroupMember> get stereoPairs =>
-      allMembers.where((m) => m.isStereoPair).toList(growable: false);
+      allMembers.where((m) => m.isStereoPair).toList();
 
   /// Sonos zones present in the system (multi-speaker bonds).
   List<ZoneGroupMember> get zones =>
-      allMembers.where((m) => m.isZone).toList(growable: false);
+      allMembers.where((m) => m.isZone).toList();
 
   /// All bonded **speaker groups** (stereo pairs, zones, and custom L-R layouts)
   /// — every visible member carrying a `ChannelMapSet`. The overview's unified
   /// "Speaker groups" section.
   List<ZoneGroupMember> get speakerGroups =>
-      allMembers.where((m) => m.isGroup).toList(growable: false);
+      allMembers.where((m) => m.isGroup).toList();
 
   /// UUIDs already committed to a role (HT primary/satellite, or either half of
   /// a stereo pair) and therefore not free to bond elsewhere.
@@ -400,7 +400,7 @@ class SonosSystem {
     final bonded = _bondedUuids;
     return devicesByUuid.values
         .where((d) => !bonded.contains(d.uuid) && !d.isSoundbar && !d.isSub)
-        .toList(growable: false);
+        .toList();
   }
 
   /// Standalone speakers eligible to form a zone: bondable individual speakers,
@@ -409,14 +409,14 @@ class SonosSystem {
   /// Sonos' official list) zones fine, so we don't gate on the model list —
   /// create polls to confirm and surfaces a clear error if Sonos rejects it.
   List<SonosDevice> get zoneableSpeakers =>
-      bondableSpeakers.where((d) => !d.isAmp).toList(growable: false);
+      bondableSpeakers.where((d) => !d.isAmp).toList();
 
   /// Standalone Sonos Subs free to bond as the `SW` channel of a home theater.
   List<SonosDevice> get bondableSubs {
     final bonded = _bondedUuids;
     return devicesByUuid.values
         .where((d) => d.isSub && !bonded.contains(d.uuid))
-        .toList(growable: false);
+        .toList();
   }
 
   SonosDevice? device(String uuid) => devicesByUuid[uuid];

--- a/lib/data/sonos/device_properties.dart
+++ b/lib/data/sonos/device_properties.dart
@@ -1,5 +1,3 @@
-import 'package:xml/xml.dart';
-
 import 'channel_map.dart';
 import 'soap_client.dart';
 
@@ -103,15 +101,10 @@ class DevicePropertiesClient {
       serviceType: _service,
       action: 'GetZoneAttributes',
     );
-    String val(String tag) {
-      final els = body.findAllElements(tag);
-      return els.isEmpty ? '' : els.first.innerText;
-    }
-
     return ZoneAttributes(
-      zoneName: val('CurrentZoneName'),
-      icon: val('CurrentIcon'),
-      configuration: val('CurrentConfiguration'),
+      zoneName: body.childText('CurrentZoneName') ?? '',
+      icon: body.childText('CurrentIcon') ?? '',
+      configuration: body.childText('CurrentConfiguration') ?? '',
     );
   }
 

--- a/lib/data/sonos/identify_service.dart
+++ b/lib/data/sonos/identify_service.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:xml/xml.dart';
-
 import '../../core/tone_generator.dart';
 import 'soap_client.dart';
 
@@ -14,10 +12,10 @@ import 'soap_client.dart';
 /// speaker's `AVTransport` service to set that URL and play it. The speaker must
 /// be standalone (our front candidates are), and the phone must be on the same
 /// LAN as the speaker (it always is — that's how discovery worked).
-class IdentifyService {
+class IdentifyServiceClient {
   final SonosSoapClient _soap;
   final void Function(String message)? onLog;
-  IdentifyService([SonosSoapClient? client, this.onLog])
+  IdentifyServiceClient([SonosSoapClient? client, this.onLog])
       : _soap = client ?? SonosSoapClient();
 
   static const _service = 'urn:schemas-upnp-org:service:AVTransport:1';
@@ -114,8 +112,7 @@ class IdentifyService {
       action: 'GetVolume',
       args: {'InstanceID': '0', 'Channel': 'Master'},
     );
-    final els = body.findAllElements('CurrentVolume');
-    return els.isEmpty ? null : int.tryParse(els.first.innerText.trim());
+    return int.tryParse(body.childText('CurrentVolume') ?? '');
   }
 
   Future<bool?> _getMute(String ip) async {
@@ -126,8 +123,8 @@ class IdentifyService {
       action: 'GetMute',
       args: {'InstanceID': '0', 'Channel': 'Master'},
     );
-    final els = body.findAllElements('CurrentMute');
-    return els.isEmpty ? null : els.first.innerText.trim() == '1';
+    final t = body.childText('CurrentMute');
+    return t == null ? null : t == '1';
   }
 
   Future<void> _setVolume(String ip, int volume) => _soap.call(

--- a/lib/data/sonos/led_identify.dart
+++ b/lib/data/sonos/led_identify.dart
@@ -3,7 +3,7 @@ import 'package:xml/xml.dart';
 import 'soap_client.dart';
 
 /// Identifies a speaker by **blinking its white status LED** — an alternative to
-/// the audio chime ([IdentifyService]) that needs no in-app HTTP server and so
+/// the audio chime ([IdentifyServiceClient]) that needs no in-app HTTP server and so
 /// works everywhere, including the sandboxed macOS app (it's a plain outbound
 /// SOAP call to the speaker, not an inbound LAN connection).
 ///

--- a/lib/data/sonos/room_calibration.dart
+++ b/lib/data/sonos/room_calibration.dart
@@ -1,5 +1,3 @@
-import 'package:xml/xml.dart';
-
 import 'soap_client.dart';
 
 /// Trueplay / room-calibration state for one speaker, read from the
@@ -40,14 +38,9 @@ class RoomCalibrationClient {
       action: 'GetRoomCalibrationStatus',
       args: const {'InstanceID': '0'},
     );
-    bool flag(String name) {
-      final els = body.findAllElements(name);
-      return els.isNotEmpty && els.first.innerText.trim() == '1';
-    }
-
     return RoomCalibration(
-      available: flag('RoomCalibrationAvailable'),
-      enabled: flag('RoomCalibrationEnabled'),
+      available: body.childText('RoomCalibrationAvailable') == '1',
+      enabled: body.childText('RoomCalibrationEnabled') == '1',
     );
   }
 

--- a/lib/data/sonos/soap_client.dart
+++ b/lib/data/sonos/soap_client.dart
@@ -89,6 +89,18 @@ class SonosSoapClient {
       .replaceAll("'", '&apos;');
 }
 
+/// Reading values out of a SOAP response body (the [XmlElement] returned by
+/// [SonosSoapClient.call]). Response fields are flat children, so descendant
+/// search is fine — unlike `device_description.xml`, which nests sub-devices and
+/// must use scoped direct-child lookup instead.
+extension SoapBodyText on XmlElement {
+  /// First matching element's trimmed text, or null if absent.
+  String? childText(String tag) {
+    final els = findAllElements(tag);
+    return els.isEmpty ? null : els.first.innerText.trim();
+  }
+}
+
 /// Raised when a Sonos device returns a SOAP fault.
 class SonosSoapException implements Exception {
   final String action;

--- a/lib/data/sonos/sonos_repository.dart
+++ b/lib/data/sonos/sonos_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/sonos_models.dart';
@@ -51,7 +52,10 @@ class SonosRepository {
       locations.map((loc) async {
         try {
           return await _descriptions.fetch(loc);
-        } catch (_) {
+        } catch (e) {
+          // Non-fatal: a device that fails its description fetch is dropped here
+          // and recovered topology-only later. Log so it's diagnosable.
+          debugPrint('Sonority: device_description fetch failed for $loc: $e');
           return null;
         }
       }),
@@ -116,9 +120,15 @@ class SonosRepository {
   Future<void> setRoomCalibration(String ip, bool on) =>
       _calibration.setEnabled(ip, on);
 
+  // A full 5.1 rebuild from a bare bar measured a steady 6 re-asserts on
+  // hardware (single-call beat staged, which needed up to 24 — see CLAUDE.md);
+  // 10 leaves headroom. Incremental adds converge in 1–2.
+  static const _bondRetries = 10;
+  static const _bondSettle = Duration(seconds: 16);
+
   /// Writes [target] to the coordinator and VERIFIES every requested channel
-  /// actually landed, RE-ASSERTING up to [retries] times if Sonos silently drops
-  /// satellites that don't finish joining (the Phase 0 finding — see
+  /// actually landed, RE-ASSERTING up to [_bondRetries] times if Sonos silently
+  /// drops satellites that don't finish joining (the Phase 0 finding — see
   /// [[phase0-ht-bonding-finding]]). The 8s SOAP timeout fires on big bonding
   /// calls but the write still takes effect, so a timeout is treated as "go
   /// verify", not "failed". Returns the verified [SonosSystem]; throws naming the
@@ -130,11 +140,6 @@ class SonosRepository {
     required SonosDevice coordinator,
     required ChannelMap target,
     required SonosSystem? previous,
-    // A full 5.1 rebuild from a bare bar measured a steady 6 re-asserts on
-    // hardware (single-call beat staged, which needed up to 24 — see CLAUDE.md);
-    // 10 leaves headroom. Incremental adds converge in 1–2.
-    int retries = 10,
-    Duration settle = const Duration(seconds: 16),
     void Function(String note)? onNote,
     CancellationToken? cancel,
   }) async {
@@ -153,7 +158,7 @@ class SonosRepository {
 
     SonosSystem? system = previous;
     List<SonosChannel> missing = wanted.keys.toList();
-    for (var attempt = 1; attempt <= retries; attempt++) {
+    for (var attempt = 1; attempt <= _bondRetries; attempt++) {
       cancel?.throwIfCancelled();
       try {
         await _deviceProps.addHtSatellite(soundbarIp: ip, map: target);
@@ -169,7 +174,7 @@ class SonosRepository {
         // and only fail if the topology never reaches the target.
         onNote?.call('attempt $attempt: write error, re-asserting');
       }
-      await interruptibleDelay(settle, cancel);
+      await interruptibleDelay(_bondSettle, cancel);
       try {
         system = system == null ? await discover() : await refresh(system, ip);
       } catch (_) {

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -51,8 +51,8 @@ final operationLogProvider =
 
 /// Plays a chime on a speaker to help identify Left vs Right. Holds a local
 /// HTTP server, so it's torn down when the provider is disposed.
-final identifyServiceProvider = Provider<IdentifyService>((ref) {
-  final service = IdentifyService(
+final identifyServiceProvider = Provider<IdentifyServiceClient>((ref) {
+  final service = IdentifyServiceClient(
     null,
     kDebugMode ? (m) => debugPrint('[identify] $m') : null,
   );
@@ -461,7 +461,10 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     SonosDevice? sub,
     String? name,
   }) async {
-    if (members.length < 2) return;
+    assert(members.length >= 2, 'createGroup needs ≥2 members (UI must gate this)');
+    if (members.length < 2) {
+      throw Exception('A group needs at least 2 speakers.');
+    }
     final coord = members.first.device;
     final involved = [
       for (final m in members) m.device.uuid,

--- a/test/soap_envelope_test.dart
+++ b/test/soap_envelope_test.dart
@@ -1,7 +1,30 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonority/data/sonos/soap_client.dart';
+import 'package:xml/xml.dart';
 
 void main() {
+  group('SoapBodyText.childText', () {
+    final body = XmlDocument.parse(
+      '<Body><CurrentVolume> 30 </CurrentVolume>'
+      '<CurrentMute>1</CurrentMute><Empty></Empty></Body>',
+    ).rootElement;
+
+    test('returns first match, trimmed', () {
+      expect(body.childText('CurrentVolume'), '30');
+      expect(body.childText('CurrentMute'), '1');
+    });
+    test('empty element trims to empty string, missing tag is null', () {
+      expect(body.childText('Empty'), '');
+      expect(body.childText('Nope'), isNull);
+    });
+    test('composes for int/bool parsing like the call sites', () {
+      expect(int.tryParse(body.childText('CurrentVolume') ?? ''), 30);
+      expect(int.tryParse(body.childText('Nope') ?? ''), isNull);
+      expect(body.childText('CurrentMute') == '1', isTrue);
+    });
+  });
+
+
   test('builds a valid AddHTSatellite envelope with escaped args', () {
     final xml = SonosSoapClient.buildEnvelope(
       serviceType: 'urn:schemas-upnp-org:service:DeviceProperties:1',

--- a/tool/chirp.dart
+++ b/tool/chirp.dart
@@ -1,4 +1,4 @@
-// Plays the identify chime on one speaker — validates the IdentifyService path
+// Plays the identify chime on one speaker — validates the IdentifyServiceClient path
 // (in-app HTTP server + AVTransport) against real hardware.
 //
 //   dart run tool/chirp.dart <room name | RINCON_uuid | ip>
@@ -25,7 +25,7 @@ Future<void> main(List<String> argv) async {
   final (:ip, :label) = resolved;
 
   print('🔊 Chiming on $label ($ip)…');
-  final svc = IdentifyService(null, (m) => print('   · $m'));
+  final svc = IdentifyServiceClient(null, (m) => print('   · $m'));
   try {
     await svc.chirp(ip);
     print('   Sent. You should hear a ding-dong now.');


### PR DESCRIPTION
Docs:
- CLAUDE.md: drop stale core/result.dart ref; add zone/bond/group glossary
- SIGNING.md: replace plaintext p12 password with a placeholder

CI/CD (release.yml -79 lines net):
- extract .github/actions/setup-flutter composite (flutter + pod cache + pub get)
- Gradle cache via setup-java; CocoaPods cache on the 4 macOS jobs
- replace curl+grep+sed release-delete with `gh release delete --cleanup-tag=false`
- pin all third-party actions to current-major commit SHAs
- add ci.yml: flutter analyze + test on PR/main

Code:
- new SoapBodyText.childText extension; dedups val/flag/inline SOAP parsers across device_properties/identify_service/room_calibration
- log failed device_description fetches instead of swallowing silently
- rename IdentifyService -> IdentifyServiceClient (matches the other *Clients)
- bondAndVerify retries/settle -> consts; createGroup asserts+throws vs no-op
- drop 8x growable:false noise
- test: cover childText parsing