### PR TITLE
feat(profiles): warn at creation + apply re-entrancy guard

### DIFF
--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -90,6 +90,33 @@ class _State extends ConsumerState<ProfileCreateScreen> {
             ),
           ),
           Gap.l,
+          Card(
+            margin: EdgeInsets.zero,
+            color: theme.colorScheme.surfaceContainerHighest,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.info_outline,
+                      size: 20, color: theme.colorScheme.onSurfaceVariant),
+                  Gap.s,
+                  Expanded(
+                    child: Text(
+                      'Applying a profile later rebuilds these speakers into this '
+                      'layout. Any speaker that’s part of a different setup at that '
+                      'time is removed from it first — which can dissolve another '
+                      'stereo pair or zone and free its other speakers.',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Gap.l,
           Text('Include', style: theme.textTheme.titleSmall),
           Text(
             'Pick which of your current home theaters, pairs and '

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -133,6 +133,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     required Map<SonosChannel, SonosDevice> layout,
     List<SonosDevice> subs = const [],
   }) async {
+    if (state.isLoading) return; // ponytail: single in-flight op; queue only if users hit it
     // The layout IS the target — no `preserveExisting` overlay, so deselected
     // roles drop out and get unbonded. Subs go via [subUuids] (repeatable channel).
     final target = front_layout.buildLayoutMap(
@@ -177,6 +178,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   /// conflicting speakers, re-bonds (staged for HT), and restores its room
   /// names. Emits per-step progress via [applyProgressProvider].
   Future<void> applyProfile(Profile profile, {Set<String> skip = const {}}) async {
+    if (state.isLoading) return; // ponytail: single in-flight op; queue only if users hit it
     final current = state.value;
     if (current == null) return;
     final entities =


### PR DESCRIPTION
## What

Hardening around profiles that snapshot **different/overlapping speaker sets**. Applying a profile is destructive by design: any speaker it needs is first freed from whatever it's currently bonded into — which dissolves the *entire* other stereo pair/zone (orphaning its unmentioned members) or silently degrades another HT.

- **Profile create screen**: static info card explaining that a later apply pulls speakers out of whatever setup they're in at that time (can dissolve another pair/zone).
- **Controller**: re-entrancy guard (`state.isLoading`) on `applyProfile` / `applyHomeTheaterLayout` so a second apply can't race a stale pre-flight snapshot.
- The apply confirm dialog is **unchanged** (kept for now).

No engine/bonding logic changes — `freeSpeaker`, `_applyEntity`, `preflightProfile` untouched.

## Verified

- `flutter analyze` clean, all 101 tests pass.
- Manually on Android emulator against the real Sonos system: warning card renders; created a real Gym+Eetkamer stereo pair, applied a profile that has them standalone → conflict path freed the pair live, all entities applied, system fully restored (HT intact, names restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)