### PR TITLE
feat(profiles): capture & restore per-speaker EQ/volume settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,16 @@ inside Sonority (otherwise you snapshot a half-config and still bounce to the
 Sonos app). Justified by "finish a setup in one app, then save it." Keep this the
 *only* exception; don't widen it to EQ/volume/grouping/etc.
 
+**Same reasoning extends to profiles capturing EQ/volume (deliberate, narrow):**
+a profile can *snapshot each speaker's current EQ (bass/treble/loudness/night/
+speech/sub/surround level) and optionally volume* and re-apply them — a
+save/restore capability the Sonos app has no equivalent for. This does NOT
+duplicate the app because we only **read the live values at snapshot and write
+them back on apply** — there are **no EQ/volume editing sliders** in Sonority
+(that WOULD duplicate the app). Keep it that way: capture+restore only, never
+standalone editing. (`speaker_settings.dart`, two per-profile toggles — EQ, and
+volume separately since restoring volume is surprising.)
+
 The app does **no audio processing** — it only issues the bonding/config SOAP
 calls the official app blocks. Audio quality comes from the real speakers.
 
@@ -74,6 +84,7 @@ lib/
                      channel_map    · front_layout (buildLayoutMap + diffHtLayout — any role)
                      apply_progress (ApplyStep/ApplyProgress — per-step status)
                      identify_service (chime)
+                     speaker_settings (RenderingControl EQ/volume read+apply for profiles)
                      sonos_repository (orchestrates; bondAndVerify write+retry;
                        removeHtSatellites; freeSpeaker; setRoomName; + shared_preferences ⇒ Flutter dep)
   state/           sonos_controller.dart — AsyncNotifier<SonosSystem?>; applyHomeTheaterLayout,
@@ -81,7 +92,7 @@ lib/
   features/        discovery / home_theater / front_surrounds (full HT setup) /
                      group (unified Stereo/Zone/Custom) / profiles / room / widgets
   app.dart, main.dart — go_router StatefulShellRoute (System|Profiles tabs), ProviderScope
-tool/              spike, roundtrip, full_layout, diff_apply_spike, chirp, dump_chime, zone_probe, lr_audiotest
+tool/              spike, roundtrip, full_layout, diff_apply_spike, chirp, dump_chime, zone_probe, lr_audiotest, eq_probe
 ```
 Note: CLI tools must NOT import `sonos_repository.dart` (it pulls in
 `shared_preferences` → Flutter). The pure recipes live in `front_layout.dart` /
@@ -316,6 +327,10 @@ Run on the same Wi-Fi as the Sonos system:
 - `tool/dump_chime.dart <path>` — write the generated WAV to disk.
 - `tool/trueplay_probe.dart` — read-only Trueplay/room-calibration status per
   speaker (+ SCPD dump); `--enable/--disable <room|uuid>` to toggle (reversible).
+- `tool/eq_probe.dart` — read-only per-speaker EQ/audio settings dump
+  (Bass/Treble/Loudness/GetEQ EQTypes + SCPD ranges); `--test <room|uuid>`
+  round-trips Bass (bump + restore). Run FIRST to confirm action names / EQType
+  tokens / ranges before trusting `speaker_settings.dart`.
 
 ## Platform notes
 - iOS: `Info.plist` has `NSLocalNetworkUsageDescription` + `NSBonjourServices`
@@ -353,6 +368,12 @@ Run on the same Wi-Fi as the Sonos system:
   (missing/conflicting speakers), frees conflicts, re-bonds via the diff-based
   `_applyHtTarget` (no-op if unchanged, else add only what's missing), restores
   names, and reports per-step progress. Sub-on-stereo-pair is out (hardware-rejected).
+  Optionally **captures per-speaker EQ (+ volume, separate toggle)** at create and
+  restores it last on apply (after the bond settles, since bonding resets EQ) —
+  `speaker_settings.dart`, `SonosController.captureSettings` + `_restoreSettings`,
+  `EntitySnapshot.settings` (empty for pre-feature profiles ⇒ zero extra writes).
+  ⚠️ action names/EQType tokens assumed standard-UPnP — **verify with
+  `tool/eq_probe.dart` on hardware** before shipping.
 - ✅ **Room renaming** from the room / HT detail pages (`renameRoom` + `rename_dialog`).
 - ✅ Trueplay read + toggle (`room_calibration.dart` + `trueplay_control.dart`) on
   all speakers/HTs — toggles the iOS-measured calibration the Sonos app won't

--- a/lib/data/sonos/speaker_settings.dart
+++ b/lib/data/sonos/speaker_settings.dart
@@ -1,0 +1,204 @@
+import 'package:xml/xml.dart';
+
+import 'soap_client.dart';
+
+/// A snapshot of one speaker's audio settings, read from the `RenderingControl`
+/// service. Every field is nullable: `null` means "not captured" (the profile
+/// toggle was off) OR "this speaker doesn't support it" (e.g. a plain Play:1 has
+/// no `SubGain`). Reading and applying are both best-effort per field — one
+/// setting faulting never sinks the rest.
+///
+/// EQ fields (`bass`…`surroundLevel`) are stable configuration and pair well
+/// with a saved layout. `volume`/`mute` are transient playback state, captured
+/// only when the user opts in via the separate volume toggle.
+///
+/// Action/arg shapes follow the RenderingControl SCPD (confirm with
+/// `tool/eq_probe.dart`): Get/SetBass, Get/SetTreble, Get/SetLoudness(Channel),
+/// Get/SetEQ(EQType), Get/SetVolume(Channel), Get/SetMute(Channel).
+class SpeakerSettings {
+  final int? bass;
+  final int? treble;
+  final bool? loudness;
+  final bool? nightMode; // EQType NightMode
+  final int? dialogLevel; // EQType DialogLevel (speech enhancement)
+  final int? subGain; // EQType SubGain
+  final int? surroundLevel; // EQType SurroundLevel
+  final int? volume;
+  final bool? mute;
+
+  const SpeakerSettings({
+    this.bass,
+    this.treble,
+    this.loudness,
+    this.nightMode,
+    this.dialogLevel,
+    this.subGain,
+    this.surroundLevel,
+    this.volume,
+    this.mute,
+  });
+
+  static const empty = SpeakerSettings();
+
+  bool get hasEq =>
+      bass != null ||
+      treble != null ||
+      loudness != null ||
+      nightMode != null ||
+      dialogLevel != null ||
+      subGain != null ||
+      surroundLevel != null;
+
+  bool get hasVolume => volume != null || mute != null;
+
+  bool get isEmpty => !hasEq && !hasVolume;
+
+  /// Serializes only the non-null fields, so an EQ-only capture doesn't store
+  /// bogus volume keys and old profiles round-trip cleanly.
+  Map<String, dynamic> toJson() => {
+        if (bass != null) 'bass': bass,
+        if (treble != null) 'treble': treble,
+        if (loudness != null) 'loudness': loudness,
+        if (nightMode != null) 'nightMode': nightMode,
+        if (dialogLevel != null) 'dialogLevel': dialogLevel,
+        if (subGain != null) 'subGain': subGain,
+        if (surroundLevel != null) 'surroundLevel': surroundLevel,
+        if (volume != null) 'volume': volume,
+        if (mute != null) 'mute': mute,
+      };
+
+  factory SpeakerSettings.fromJson(Map<String, dynamic> j) => SpeakerSettings(
+        bass: j['bass'] as int?,
+        treble: j['treble'] as int?,
+        loudness: j['loudness'] as bool?,
+        nightMode: j['nightMode'] as bool?,
+        dialogLevel: j['dialogLevel'] as int?,
+        subGain: j['subGain'] as int?,
+        surroundLevel: j['surroundLevel'] as int?,
+        volume: j['volume'] as int?,
+        mute: j['mute'] as bool?,
+      );
+}
+
+/// Reads and applies per-speaker audio settings. Both directions are
+/// best-effort: a field that faults (unsupported action, transient error) is
+/// skipped, never fatal — settings restore is a nicety layered on top of the
+/// authoritative layout, not a hard requirement.
+class SpeakerSettingsClient {
+  final SonosSoapClient _soap;
+  SpeakerSettingsClient([SonosSoapClient? client])
+      : _soap = client ?? SonosSoapClient();
+
+  static const _service = 'urn:schemas-upnp-org:service:RenderingControl:1';
+  static const _control = '/MediaRenderer/RenderingControl/Control';
+
+  /// Reads a settings snapshot for the speaker at [ip]. [eq] captures the EQ
+  /// bundle (bass/treble/loudness/night/speech/sub/surround); [volume] captures
+  /// volume/mute. The two are independent toggles.
+  Future<SpeakerSettings> read(String ip,
+      {bool eq = true, bool volume = false}) async {
+    return SpeakerSettings(
+      bass: eq ? await _readInt(ip, 'GetBass', 'CurrentBass') : null,
+      treble: eq ? await _readInt(ip, 'GetTreble', 'CurrentTreble') : null,
+      loudness: eq
+          ? await _readBool(ip, 'GetLoudness', 'CurrentLoudness',
+              extra: const {'Channel': 'Master'})
+          : null,
+      nightMode: eq ? await _readEqBool(ip, 'NightMode') : null,
+      dialogLevel: eq ? await _readEqInt(ip, 'DialogLevel') : null,
+      subGain: eq ? await _readEqInt(ip, 'SubGain') : null,
+      surroundLevel: eq ? await _readEqInt(ip, 'SurroundLevel') : null,
+      volume: volume
+          ? await _readInt(ip, 'GetVolume', 'CurrentVolume',
+              extra: const {'Channel': 'Master'})
+          : null,
+      mute: volume
+          ? await _readBool(ip, 'GetMute', 'CurrentMute',
+              extra: const {'Channel': 'Master'})
+          : null,
+    );
+  }
+
+  /// Writes every non-null field of [s]. Each write is independent; a failure is
+  /// swallowed so the remaining settings still apply.
+  Future<void> apply(String ip, SpeakerSettings s) async {
+    if (s.bass != null) {
+      await _set(ip, 'SetBass', {'DesiredBass': '${s.bass}'});
+    }
+    if (s.treble != null) {
+      await _set(ip, 'SetTreble', {'DesiredTreble': '${s.treble}'});
+    }
+    if (s.loudness != null) {
+      await _set(ip, 'SetLoudness',
+          {'Channel': 'Master', 'DesiredLoudness': s.loudness! ? '1' : '0'});
+    }
+    if (s.nightMode != null) {
+      await _setEq(ip, 'NightMode', s.nightMode! ? '1' : '0');
+    }
+    if (s.dialogLevel != null) await _setEq(ip, 'DialogLevel', '${s.dialogLevel}');
+    if (s.subGain != null) await _setEq(ip, 'SubGain', '${s.subGain}');
+    if (s.surroundLevel != null) {
+      await _setEq(ip, 'SurroundLevel', '${s.surroundLevel}');
+    }
+    if (s.volume != null) {
+      await _set(ip, 'SetVolume',
+          {'Channel': 'Master', 'DesiredVolume': '${s.volume}'});
+    }
+    if (s.mute != null) {
+      await _set(
+          ip, 'SetMute', {'Channel': 'Master', 'DesiredMute': s.mute! ? '1' : '0'});
+    }
+  }
+
+  // ---- read helpers (null on any fault so unsupported settings are skipped) ----
+
+  Future<String?> _rawRead(String ip, String action, String outEl,
+      Map<String, String> extra) async {
+    try {
+      final body = await _soap.call(
+        ip: ip,
+        controlPath: _control,
+        serviceType: _service,
+        action: action,
+        args: {'InstanceID': '0', ...extra},
+      );
+      final els = body.findAllElements(outEl);
+      return els.isEmpty ? null : els.first.innerText.trim();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<int?> _readInt(String ip, String action, String outEl,
+          {Map<String, String> extra = const {}}) async =>
+      int.tryParse(await _rawRead(ip, action, outEl, extra) ?? '');
+
+  Future<bool?> _readBool(String ip, String action, String outEl,
+      {Map<String, String> extra = const {}}) async {
+    final v = await _rawRead(ip, action, outEl, extra);
+    return v == null ? null : v == '1';
+  }
+
+  Future<int?> _readEqInt(String ip, String type) =>
+      _readInt(ip, 'GetEQ', 'CurrentValue', extra: {'EQType': type});
+
+  Future<bool?> _readEqBool(String ip, String type) =>
+      _readBool(ip, 'GetEQ', 'CurrentValue', extra: {'EQType': type});
+
+  // ---- write helpers (swallow faults; one setting must not block the rest) ----
+
+  Future<void> _set(String ip, String action, Map<String, String> extra) async {
+    try {
+      await _soap.call(
+        ip: ip,
+        controlPath: _control,
+        serviceType: _service,
+        action: action,
+        args: {'InstanceID': '0', ...extra},
+      );
+    } catch (_) {/* best-effort */}
+  }
+
+  Future<void> _setEq(String ip, String type, String value) =>
+      _set(ip, 'SetEQ', {'EQType': type, 'DesiredValue': value});
+}

--- a/lib/features/profiles/profile.dart
+++ b/lib/features/profiles/profile.dart
@@ -1,4 +1,5 @@
 import '../../data/models/sonos_models.dart';
+import '../../data/sonos/speaker_settings.dart';
 
 /// What kind of bonded entity a snapshot captures. One visible
 /// [ZoneGroupMember] == one selectable entity.
@@ -19,11 +20,18 @@ class EntitySnapshot {
   /// UUID → desired room name (restored on apply). Always includes [primaryUuid].
   final Map<String, String> names;
 
+  /// UUID → captured audio settings (EQ, optionally volume), restored on apply.
+  /// Empty when the profile was created without the "save speaker settings"
+  /// toggle (or from an older app version) — an empty map means zero extra
+  /// writes on apply.
+  final Map<String, SpeakerSettings> settings;
+
   const EntitySnapshot({
     required this.kind,
     required this.primaryUuid,
     required this.mapSet,
     required this.names,
+    this.settings = const {},
   });
 
   /// Captures the visible [member]'s current layout.
@@ -81,18 +89,38 @@ class EntitySnapshot {
     ].where((u) => u.isNotEmpty).toList();
   }
 
-  EntitySnapshot copyWith({Map<String, String>? names}) => EntitySnapshot(
+  EntitySnapshot copyWith({
+    Map<String, String>? names,
+    Map<String, SpeakerSettings>? settings,
+  }) =>
+      EntitySnapshot(
         kind: kind,
         primaryUuid: primaryUuid,
         mapSet: mapSet,
         names: names ?? this.names,
+        settings: settings ?? this.settings,
       );
+
+  /// A short label for the UI describing what audio settings are captured, or
+  /// `''` when none — appended to [entitySummary] on the tiles.
+  String get settingsSummary {
+    final vals = settings.values;
+    final eq = vals.any((s) => s.hasEq);
+    final vol = vals.any((s) => s.hasVolume);
+    if (eq && vol) return 'EQ + volume saved';
+    if (eq) return 'EQ saved';
+    if (vol) return 'Volume saved';
+    return '';
+  }
 
   Map<String, dynamic> toJson() => {
         'kind': kind.name,
         'primaryUuid': primaryUuid,
         'mapSet': mapSet,
         'names': names,
+        // Omit when empty so profiles without settings stay compact.
+        if (settings.isNotEmpty)
+          'settings': {for (final e in settings.entries) e.key: e.value.toJson()},
       };
 
   factory EntitySnapshot.fromJson(Map<String, dynamic> j) => EntitySnapshot(
@@ -100,6 +128,12 @@ class EntitySnapshot {
         primaryUuid: j['primaryUuid'] as String,
         mapSet: j['mapSet'] as String?,
         names: Map<String, String>.from(j['names'] as Map),
+        // Absent in older profiles → empty (no settings restored).
+        settings: {
+          for (final e in ((j['settings'] as Map?) ?? const {}).entries)
+            e.key as String:
+                SpeakerSettings.fromJson(Map<String, dynamic>.from(e.value as Map)),
+        },
       );
 }
 
@@ -110,6 +144,18 @@ class Profile {
   final List<EntitySnapshot> entities;
 
   const Profile({required this.id, required this.name, required this.entities});
+
+  /// Aggregated across entities: what audio settings this profile carries, or
+  /// `''` when none.
+  String get settingsSummary {
+    final all = entities.expand((e) => e.settings.values);
+    final eq = all.any((s) => s.hasEq);
+    final vol = all.any((s) => s.hasVolume);
+    if (eq && vol) return 'EQ + volume saved';
+    if (eq) return 'EQ saved';
+    if (vol) return 'Volume saved';
+    return '';
+  }
 
   Profile copyWith({String? name, List<EntitySnapshot>? entities}) => Profile(
         id: id,

--- a/lib/features/profiles/profile_controller.dart
+++ b/lib/features/profiles/profile_controller.dart
@@ -71,14 +71,19 @@ List<EntityIssue> preflightProfile(Profile profile, SonosSystem system) {
             if (system.device(u) == null || system.device(u)!.reachable == false)
               label(u),
         ],
-        // A speaker is conflicting if it's currently bonded into ANY other
-        // entity — HT satellite, stereo-pair half, OR zone/custom group member.
-        // Uses the shared [SonosSystem.ownerOf] so pre-flight and apply agree.
+        // A speaker is conflicting only if it's currently bonded into a
+        // DIFFERENT entity — i.e. its owner is outside this entity. A speaker
+        // already bonded to this entity's own coordinator is NOT a conflict
+        // (apply is a no-op for it). Mirrors the exact owner checks in
+        // [SonosController._applyEntity] so pre-flight and apply agree.
         conflicts: [
           for (final u in e.involvedUuids)
             if (u != e.primaryUuid &&
                 system.device(u) != null &&
-                system.ownerOf(u) != null)
+                switch (system.ownerOf(u)) {
+                  null => false,
+                  final owner => !e.involvedUuids.contains(owner),
+                })
               label(u),
         ],
       ),

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -25,6 +25,9 @@ class _State extends ConsumerState<ProfileCreateScreen> {
   final List<EntitySnapshot> _entities = [];
   final Map<String, bool> _included = {};
   bool _seeded = false;
+  bool _saveEq = false;
+  bool _saveVolume = false;
+  bool _saving = false;
 
   void _seed(SonosSystem system) {
     if (_seeded) return;
@@ -68,12 +71,12 @@ class _State extends ConsumerState<ProfileCreateScreen> {
     final name = _name.text.trim();
     final taken = isProfileNameTaken(profiles, name);
     final anyIncluded = _included.values.any((v) => v);
-    final canSave = name.isNotEmpty && !taken && anyIncluded;
+    final canSave = name.isNotEmpty && !taken && anyIncluded && !_saving;
 
     return AppScaffold(
       title: 'New profile',
       bottomOverlay: _BottomButtonBar(
-        label: 'Create profile',
+        label: _saving ? 'Reading settings…' : 'Create profile',
         onPressed: canSave ? () => _save(name) : null,
       ),
       body: ListView(
@@ -108,18 +111,73 @@ class _State extends ConsumerState<ProfileCreateScreen> {
             ),
             Gap.s,
           ],
+          Gap.l,
+          Text('Speaker settings', style: theme.textTheme.titleSmall),
+          Text(
+            'Optionally snapshot each speaker’s current settings and restore '
+            'them when this profile is applied.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          Gap.s,
+          Card(
+            margin: EdgeInsets.zero,
+            child: Column(
+              children: [
+                // Split card: each tile rounds only the corners it shares with
+                // the card, so the ink highlight matches (top tile → top corners,
+                // bottom tile → bottom corners; the divider edge stays square).
+                SwitchListTile(
+                  value: _saveEq,
+                  onChanged: (v) => setState(() => _saveEq = v),
+                  shape: const RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.vertical(top: Radius.circular(12))),
+                  secondary: const Icon(Icons.equalizer),
+                  title: const Text('Save EQ settings'),
+                  subtitle: const Text(
+                      'Bass, treble, loudness, night sound, speech, sub & surround level'),
+                ),
+                const Divider(height: 1),
+                SwitchListTile(
+                  value: _saveVolume,
+                  onChanged: (v) => setState(() => _saveVolume = v),
+                  shape: const RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.vertical(bottom: Radius.circular(12))),
+                  secondary: const Icon(Icons.volume_up),
+                  title: const Text('Save volume'),
+                  subtitle: const Text(
+                      'Applying the profile will change how loud each speaker plays'),
+                ),
+              ],
+            ),
+          ),
         ],
       ),
     );
   }
 
   Future<void> _save(String name) async {
-    final chosen = [
+    var chosen = [
       for (final e in _entities)
         if (_included[e.primaryUuid] ?? false) e,
     ];
     final router = GoRouter.of(context);
     final id = DateTime.now().microsecondsSinceEpoch.toString();
+    // Reading EQ/volume is several SOAP calls per speaker — show progress and
+    // enrich the snapshots before saving.
+    if (_saveEq || _saveVolume) {
+      setState(() => _saving = true);
+      try {
+        chosen = await ref
+            .read(sonosControllerProvider.notifier)
+            .captureSettings(chosen, eq: _saveEq, volume: _saveVolume);
+      } finally {
+        if (mounted) setState(() => _saving = false);
+      }
+    }
     await ref
         .read(profilesProvider.notifier)
         .add(Profile(id: id, name: name, entities: chosen));
@@ -144,6 +202,7 @@ class _SelectableEntityCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       margin: EdgeInsets.zero,
+      clipBehavior: Clip.antiAlias,
       child: CheckboxListTile(
         value: included,
         onChanged: (v) => onChanged(v ?? false),

--- a/lib/features/profiles/profile_detail_screen.dart
+++ b/lib/features/profiles/profile_detail_screen.dart
@@ -92,7 +92,11 @@ class _State extends ConsumerState<ProfileDetailScreen> {
                 leading: Icon(entityIcon(e.kind)),
                 titleAlignment: ListTileTitleAlignment.center,
                 title: Text(e.label),
-                subtitle: Text(entitySummary(e, system)),
+                subtitle: Text(
+                  e.settingsSummary.isEmpty
+                      ? entitySummary(e, system)
+                      : '${entitySummary(e, system)}\n${e.settingsSummary}',
+                ),
               ),
             ),
             Gap.s,

--- a/lib/features/profiles/profiles_screen.dart
+++ b/lib/features/profiles/profiles_screen.dart
@@ -133,6 +133,7 @@ class _ProfileTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final summary = profile.entities.map((e) => e.label).join(' · ');
+    final settings = profile.settingsSummary;
     return Card(
       margin: EdgeInsets.zero,
       child: InkWell(
@@ -156,6 +157,19 @@ class _ProfileTile extends StatelessWidget {
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
+                    if (settings.isNotEmpty) ...[
+                      Gap.xs,
+                      Row(
+                        children: [
+                          Icon(Icons.equalizer,
+                              size: 14, color: theme.colorScheme.primary),
+                          Gap.xs,
+                          Text(settings,
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                  color: theme.colorScheme.primary)),
+                        ],
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -9,6 +9,7 @@ import '../data/sonos/front_layout.dart' as front_layout;
 import '../data/sonos/identify_service.dart';
 import '../data/sonos/led_identify.dart';
 import '../data/sonos/sonos_repository.dart';
+import '../data/sonos/speaker_settings.dart';
 import '../features/profiles/profile.dart';
 
 final sonosRepositoryProvider =
@@ -93,6 +94,46 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   Future<SonosSystem?> build() => _discover();
 
   SonosRepository get _repo => ref.read(sonosRepositoryProvider);
+
+  final _settings = SpeakerSettingsClient();
+
+  /// Reads each entity's per-speaker audio settings ([eq] bundle and/or [volume])
+  /// and returns copies enriched with a `settings` map. Called by
+  /// the create flow when the user opts into saving speaker settings; keeps the
+  /// SOAP reads off the widget. Speakers not currently on the network are simply
+  /// skipped (nothing to read).
+  Future<List<EntitySnapshot>> captureSettings(
+      List<EntitySnapshot> entities,
+      {required bool eq, required bool volume}) async {
+    final sys = state.value;
+    if (sys == null || (!eq && !volume)) return entities;
+    final out = <EntitySnapshot>[];
+    for (final e in entities) {
+      final map = <String, SpeakerSettings>{};
+      for (final uuid in e.involvedUuids) {
+        final ip = sys.device(uuid)?.ip;
+        if (ip == null) continue;
+        final s = await _settings.read(ip, eq: eq, volume: volume);
+        if (!s.isEmpty) map[uuid] = s;
+      }
+      out.add(map.isEmpty ? e : e.copyWith(settings: map));
+    }
+    return out;
+  }
+
+  /// Restores each captured per-speaker setting after a bond has settled (bonding
+  /// can reset EQ, so this must run last). Best-effort + a no-op when [e] carries
+  /// no settings (old profiles / toggles off) → zero extra writes.
+  Future<void> _restoreSettings(
+      EntitySnapshot e, SonosSystem sys, void Function(String) note) async {
+    if (e.settings.isEmpty) return;
+    for (final entry in e.settings.entries) {
+      final ip = sys.device(entry.key)?.ip;
+      if (ip == null) continue;
+      note('restoring settings');
+      await _settings.apply(ip, entry.value);
+    }
+  }
 
   /// Discover the system and cache an IP for cheap refreshes. Runs on launch
   /// (from [build]) and on every explicit [scan].
@@ -197,6 +238,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         tracker.start(e.primaryUuid);
         try {
           sys = await _applyEntity(e, sys!, (n) => tracker.note(e.primaryUuid, n));
+          // Restore captured EQ/volume last — bonding can reset EQ.
+          await _restoreSettings(e, sys, (n) => tracker.note(e.primaryUuid, n));
           tracker.done(e.primaryUuid);
         } on OperationCancelled {
           rethrow;

--- a/test/profile_preflight_test.dart
+++ b/test/profile_preflight_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/data/models/sonos_models.dart';
+import 'package:sonority/features/profiles/profile.dart';
+import 'package:sonority/features/profiles/profile_controller.dart';
+
+/// Regression: a speaker bonded to the profile entity's OWN coordinator is not
+/// a conflict — the apply path no-ops for it, so pre-flight must not report
+/// "Will free" (it did, for every satellite / pair half / zone member).
+void main() {
+  const beam = 'RINCON_BEAM01400';
+  const fl = 'RINCON_FL01400';
+  const sub = 'RINCON_SUB01400';
+  const pairL = 'RINCON_PL01400';
+  const pairR = 'RINCON_PR01400';
+
+  SonosDevice dev(String uuid, String name) =>
+      SonosDevice(uuid: uuid, roomName: name, modelName: 'x', ip: '1.2.3.4');
+
+  final devices = {
+    beam: dev(beam, 'Woonkamer'),
+    fl: dev(fl, 'Woonkamer'),
+    sub: dev(sub, 'Sub'),
+    pairL: dev(pairL, 'Zolder'),
+    pairR: dev(pairR, 'Zolder'),
+  };
+
+  Profile profileOf(EntitySnapshot e) =>
+      Profile(id: 'p', name: 'P', entities: [e]);
+
+  test('already-formed HT: satellites are NOT conflicts', () {
+    const map = '$beam:CC;$fl:LF;$sub:SW';
+    final system = SonosSystem(
+      groups: [
+        ZoneGroup(coordinatorUuid: beam, members: [
+          ZoneGroupMember(uuid: beam, zoneName: 'Woonkamer', htSatChanMapSet: map),
+        ]),
+      ],
+      devicesByUuid: devices,
+    );
+    final snap = EntitySnapshot.fromMember(system.groups.first.members.first);
+    final issues = preflightProfile(profileOf(snap), system);
+    expect(issues.single.conflicts, isEmpty);
+    expect(issues.single.blocked, isFalse);
+  });
+
+  test('already-formed pair: hidden half is NOT a conflict', () {
+    const map = '$pairL:LF,LF;$pairR:RF,RF';
+    final system = SonosSystem(
+      groups: [
+        ZoneGroup(coordinatorUuid: pairL, members: [
+          ZoneGroupMember(uuid: pairL, zoneName: 'Zolder', channelMapSet: map),
+          const ZoneGroupMember(uuid: pairR, zoneName: 'Zolder', invisible: true),
+        ]),
+      ],
+      devicesByUuid: devices,
+    );
+    final snap = EntitySnapshot.fromMember(system.groups.first.members.first);
+    final issues = preflightProfile(profileOf(snap), system);
+    expect(issues.single.conflicts, isEmpty);
+  });
+
+  test('speaker bonded to a DIFFERENT entity IS a conflict', () {
+    // Profile wants pairL+pairR, but pairR is currently an HT satellite.
+    const wantedMap = '$pairL:LF,LF;$pairR:RF,RF';
+    final system = SonosSystem(
+      groups: [
+        ZoneGroup(coordinatorUuid: pairL, members: [
+          ZoneGroupMember(uuid: pairL, zoneName: 'Zolder'),
+        ]),
+        ZoneGroup(coordinatorUuid: beam, members: [
+          ZoneGroupMember(
+              uuid: beam,
+              zoneName: 'Woonkamer',
+              htSatChanMapSet: '$beam:CC;$pairR:RF'),
+        ]),
+      ],
+      devicesByUuid: devices,
+    );
+    const snap = EntitySnapshot(
+      kind: EntityKind.stereoPair,
+      primaryUuid: pairL,
+      mapSet: wantedMap,
+      names: {pairL: 'Zolder'},
+    );
+    final issues = preflightProfile(profileOf(snap), system);
+    expect(issues.single.conflicts, [devices[pairR]!.roomName]);
+  });
+}

--- a/test/profile_test.dart
+++ b/test/profile_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonority/data/models/sonos_models.dart';
+import 'package:sonority/data/sonos/speaker_settings.dart';
 import 'package:sonority/features/profiles/profile.dart';
 
 void main() {
@@ -65,5 +66,54 @@ void main() {
     expect(back.entities.first.mapSet, '$beam:CC;$fl:LF;$fr:RF;$sub:SW');
     expect(back.entities[1].kind, EntityKind.single);
     expect(back.entities.first.names[beam], 'Woonkamer');
+  });
+
+  test('captured speaker settings round-trip through JSON', () {
+    final snap = EntitySnapshot.fromMember(ZoneGroupMember(
+      uuid: fl,
+      zoneName: 'Bureau',
+    )).copyWith(settings: {
+      fl: const SpeakerSettings(bass: 3, treble: -2, loudness: true, volume: 25),
+    });
+    final profile = Profile(id: 'p2', name: 'Tuned', entities: [snap]);
+    final back = Profile.fromJson(
+        jsonDecode(jsonEncode(profile.toJson())) as Map<String, dynamic>);
+    final s = back.entities.first.settings[fl]!;
+    expect(s.bass, 3);
+    expect(s.treble, -2);
+    expect(s.loudness, isTrue);
+    expect(s.volume, 25);
+    expect(s.nightMode, isNull); // not captured → stays null
+    expect(back.entities.first.settingsSummary, 'EQ + volume saved');
+    expect(back.settingsSummary, 'EQ + volume saved');
+  });
+
+  test('legacy profile without a settings key deserializes to empty', () {
+    final legacy = {
+      'id': 'p3',
+      'name': 'Old',
+      'entities': [
+        {
+          'kind': 'single',
+          'primaryUuid': fl,
+          'mapSet': null,
+          'names': {fl: 'Bureau'},
+        }
+      ],
+    };
+    final back = Profile.fromJson(legacy);
+    expect(back.entities.first.settings, isEmpty);
+    expect(back.entities.first.settingsSummary, '');
+    // Omitted from JSON when empty.
+    expect(back.entities.first.toJson().containsKey('settings'), isFalse);
+  });
+
+  test('settingsSummary reflects EQ-only vs volume-only', () {
+    final base = EntitySnapshot.fromMember(ZoneGroupMember(uuid: fl, zoneName: 'x'));
+    expect(base.copyWith(settings: {fl: const SpeakerSettings(bass: 1)}).settingsSummary,
+        'EQ saved');
+    expect(
+        base.copyWith(settings: {fl: const SpeakerSettings(volume: 10)}).settingsSummary,
+        'Volume saved');
   });
 }

--- a/test/speaker_settings_test.dart
+++ b/test/speaker_settings_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/data/sonos/soap_client.dart';
+import 'package:sonority/data/sonos/speaker_settings.dart';
+import 'package:xml/xml.dart';
+
+/// Records write calls and answers reads from a per-action table. A read whose
+/// action/EQType isn't in the table throws — simulating a speaker that doesn't
+/// support that setting, which the client must turn into `null` (not a failure).
+class _FakeSoap extends SonosSoapClient {
+  final Map<String, String> reads; // key: action or "GetEQ:EQType" → out element text
+  final List<String> writes = [];
+
+  _FakeSoap(this.reads);
+
+  @override
+  Future<XmlElement> call({
+    required String ip,
+    required String controlPath,
+    required String serviceType,
+    required String action,
+    Map<String, String> args = const {},
+    Duration timeout = const Duration(seconds: 8),
+  }) async {
+    if (action.startsWith('Set')) {
+      writes.add(action == 'SetEQ'
+          ? 'SetEQ:${args['EQType']}=${args['DesiredValue']}'
+          : '$action=${args.values.last}');
+      return XmlDocument.parse('<Body/>').rootElement;
+    }
+    final key = action == 'GetEQ' ? 'GetEQ:${args['EQType']}' : action;
+    final v = reads[key];
+    if (v == null) throw SonosSoapException(action, faultString: 'unsupported');
+    // Every Get* returns its value in a matching Current* element; GetEQ uses
+    // CurrentValue.
+    final el = action == 'GetEQ' ? 'CurrentValue' : action.replaceFirst('Get', 'Current');
+    return XmlDocument.parse('<Body><$el>$v</$el></Body>').rootElement;
+  }
+}
+
+void main() {
+  test('read parses supported fields and nulls unsupported ones', () async {
+    final fake = _FakeSoap({
+      'GetBass': '5',
+      'GetTreble': '-3',
+      'GetLoudness': '1',
+      'GetEQ:NightMode': '1',
+      // No DialogLevel/SubGain/SurroundLevel → those throw → null.
+      'GetVolume': '22',
+      'GetMute': '0',
+    });
+    final s = await SpeakerSettingsClient(fake).read('1.2.3.4', volume: true);
+    expect(s.bass, 5);
+    expect(s.treble, -3);
+    expect(s.loudness, isTrue);
+    expect(s.nightMode, isTrue);
+    expect(s.dialogLevel, isNull);
+    expect(s.subGain, isNull);
+    expect(s.volume, 22);
+    expect(s.mute, isFalse);
+  });
+
+  test('read skips EQ when eq:false, volume when volume:false', () async {
+    final fake = _FakeSoap({'GetBass': '5', 'GetVolume': '22'});
+    final volOnly = await SpeakerSettingsClient(fake).read('1.2.3.4',
+        eq: false, volume: true);
+    expect(volOnly.bass, isNull);
+    expect(volOnly.volume, 22);
+    expect(volOnly.hasEq, isFalse);
+
+    final eqOnly = await SpeakerSettingsClient(fake).read('1.2.3.4');
+    expect(eqOnly.bass, 5);
+    expect(eqOnly.volume, isNull);
+    expect(eqOnly.hasVolume, isFalse);
+  });
+
+  test('apply writes only non-null fields', () async {
+    final fake = _FakeSoap(const {});
+    await SpeakerSettingsClient(fake).apply(
+      '1.2.3.4',
+      const SpeakerSettings(bass: 4, nightMode: true, volume: 30),
+    );
+    expect(fake.writes, containsAll(['SetBass=4', 'SetEQ:NightMode=1', 'SetVolume=30']));
+    expect(fake.writes.any((w) => w.startsWith('SetTreble')), isFalse);
+    expect(fake.writes.any((w) => w.startsWith('SetLoudness')), isFalse);
+    expect(fake.writes.length, 3);
+  });
+
+  test('empty settings write nothing', () async {
+    final fake = _FakeSoap(const {});
+    await SpeakerSettingsClient(fake).apply('1.2.3.4', SpeakerSettings.empty);
+    expect(fake.writes, isEmpty);
+  });
+}

--- a/tool/eq_probe.dart
+++ b/tool/eq_probe.dart
@@ -1,0 +1,225 @@
+// Read-only probe for Sonos per-speaker EQ / audio settings over the local API.
+// Run on the same Wi-Fi as your Sonos system:
+//
+//   dart run tool/eq_probe.dart                    # read-only: dump SCPD + values
+//   dart run tool/eq_probe.dart --test <room|uuid> # round-trip Bass (bump + restore)
+//
+// It (1) fetches the RenderingControl SCPD to confirm the exact action/argument
+// names for Bass/Treble/Loudness/EQ/OutputFixed, then (2) reads the current
+// value of each setting for every discovered speaker, annotated with its HT
+// channel. --test flips Bass by +1 and restores it to confirm writes take.
+//
+// Purpose: nail down the exact action names, EQType tokens and value ranges
+// BEFORE wiring lib/data/sonos/speaker_settings.dart into the app.
+
+// ignore_for_file: avoid_print
+
+import 'package:http/http.dart' as http;
+import 'package:xml/xml.dart';
+
+import 'package:sonority/data/sonos/soap_client.dart';
+import 'package:sonority/data/sonos/zone_topology.dart';
+
+import 'discover_util.dart';
+
+const _rcService = 'urn:schemas-upnp-org:service:RenderingControl:1';
+const _rcControl = '/MediaRenderer/RenderingControl/Control';
+final _soap = SonosSoapClient();
+
+// The EQType tokens we expect Sonos to expose via GetEQ/SetEQ. The probe reads
+// each; ones the speaker doesn't support just fault (shown as ✗) — that tells us
+// which apply to which model.
+const _eqTypes = [
+  'NightMode',
+  'DialogLevel',
+  'SubGain',
+  'SurroundLevel',
+  'MusicSurroundLevel',
+  'HeightChannelLevel',
+  'SubEnabled',
+];
+
+String _short(Object e) {
+  final s = e.toString();
+  return s.length > 90 ? '${s.substring(0, 90)}…' : s;
+}
+
+/// Print every RenderingControl action whose name mentions an audio setting,
+/// with its in/out arguments — so we know the exact envelope + value ranges.
+Future<void> _dumpEqActions(String ip) async {
+  try {
+    final res = await http
+        .get(Uri.parse('http://$ip:1400/xml/RenderingControl1.xml'))
+        .timeout(const Duration(seconds: 8));
+    if (res.statusCode != 200) {
+      print('  SCPD fetch failed: HTTP ${res.statusCode}');
+      return;
+    }
+    final doc = XmlDocument.parse(res.body);
+    bool interesting(String n) =>
+        n.contains('Bass') ||
+        n.contains('Treble') ||
+        n.contains('Loudness') ||
+        n.contains('EQ') ||
+        n.contains('OutputFixed');
+    final actions = doc
+        .findAllElements('action')
+        .where((a) => interesting(a.getElement('name')?.innerText ?? ''));
+    for (final a in actions) {
+      print('  • ${a.getElement('name')?.innerText ?? '?'}');
+      for (final arg in a.findAllElements('argument')) {
+        final an = arg.getElement('name')?.innerText ?? '?';
+        final dir = arg.getElement('direction')?.innerText ?? '?';
+        final rel = arg.getElement('relatedStateVariable')?.innerText ?? '';
+        print('      ${dir.padRight(3)} $an  ($rel)');
+      }
+    }
+    // Value ranges live on the state variables (allowedValueRange / list).
+    for (final sv in doc.findAllElements('stateVariable')) {
+      final n = sv.getElement('name')?.innerText ?? '';
+      if (!(n.contains('Bass') || n.contains('Treble') || n.contains('Loudness'))) {
+        continue;
+      }
+      final min = sv.findAllElements('minimum').map((e) => e.innerText);
+      final max = sv.findAllElements('maximum').map((e) => e.innerText);
+      if (min.isNotEmpty || max.isNotEmpty) {
+        print('  range $n: ${min.firstOrNull ?? '?'} .. ${max.firstOrNull ?? '?'}');
+      }
+    }
+  } catch (e) {
+    print('  SCPD fetch error: ${_short(e)}');
+  }
+}
+
+Future<String?> _read(String ip, String action, String outEl,
+    {Map<String, String> extra = const {}}) async {
+  try {
+    final body = await _soap.call(
+      ip: ip,
+      controlPath: _rcControl,
+      serviceType: _rcService,
+      action: action,
+      args: {'InstanceID': '0', ...extra},
+    );
+    final els = body.findAllElements(outEl);
+    return els.isEmpty ? null : els.first.innerText.trim();
+  } catch (e) {
+    return '✗ ${_short(e)}';
+  }
+}
+
+Future<String> _readAll(String ip) async {
+  final bass = await _read(ip, 'GetBass', 'CurrentBass');
+  final treble = await _read(ip, 'GetTreble', 'CurrentTreble');
+  final loud =
+      await _read(ip, 'GetLoudness', 'CurrentLoudness', extra: {'Channel': 'Master'});
+  final vol =
+      await _read(ip, 'GetVolume', 'CurrentVolume', extra: {'Channel': 'Master'});
+  final parts = [
+    'bass=$bass',
+    'treble=$treble',
+    'loud=$loud',
+    'vol=$vol',
+  ];
+  for (final t in _eqTypes) {
+    final v = await _read(ip, 'GetEQ', 'CurrentValue', extra: {'EQType': t});
+    // Only surface EQ types the speaker actually answers, to keep lines readable.
+    if (v != null && !v.startsWith('✗')) parts.add('$t=$v');
+  }
+  return parts.join('  ');
+}
+
+Future<void> main(List<String> argv) async {
+  print('🔎 Discovery…');
+  final ipByUuid = <String, String>{};
+  final labelByUuid = <String, String>{};
+  String? anyIp;
+  for (final d in await discoverDevices()) {
+    if (d.ip == null) continue;
+    anyIp ??= d.ip;
+    ipByUuid[d.uuid] = d.ip!;
+    labelByUuid[d.uuid] = '${d.roomName} (${d.modelName})';
+  }
+  if (anyIp == null) {
+    print('❌ Could not read any device description.');
+    return;
+  }
+
+  // Map uuid -> channel token(s) from any HT map or stereo-pair/zone map.
+  final channelByUuid = <String, String>{};
+  final groups = await ZoneTopologyClient(SonosSoapClient()).getZoneGroups(anyIp);
+  for (final g in groups) {
+    for (final m in g.members) {
+      for (final raw in [m.htSatChanMapSet, m.channelMapSet]) {
+        if (raw == null || raw.isEmpty) continue;
+        for (final part in raw.split(';')) {
+          final c = part.indexOf(':');
+          if (c < 0) continue;
+          channelByUuid[part.substring(0, c).trim()] = part.substring(c + 1).trim();
+        }
+      }
+    }
+  }
+
+  String? resolve(String roomOrUuid) {
+    if (ipByUuid.containsKey(roomOrUuid)) return roomOrUuid;
+    final hit = labelByUuid.entries.firstWhere(
+      (e) => e.value.toLowerCase().contains(roomOrUuid.toLowerCase()),
+      orElse: () => const MapEntry('', ''),
+    );
+    return hit.key.isEmpty ? null : hit.key;
+  }
+
+  // ---- write round-trip: bump Bass by +1, then restore (confirms writes) ----
+  if (argv.contains('--test')) {
+    final idx = argv.indexOf('--test');
+    final target = (idx + 1 < argv.length) ? argv[idx + 1] : '';
+    final uuid = resolve(target);
+    if (uuid == null) {
+      print('❌ No speaker matching "$target".');
+      return;
+    }
+    final ip = ipByUuid[uuid]!;
+    try {
+      final before = await _read(ip, 'GetBass', 'CurrentBass');
+      final n = int.tryParse(before ?? '') ?? 0;
+      final bumped = n >= 10 ? n - 1 : n + 1;
+      await _soap.call(
+        ip: ip,
+        controlPath: _rcControl,
+        serviceType: _rcService,
+        action: 'SetBass',
+        args: {'InstanceID': '0', 'DesiredBass': '$bumped'},
+      );
+      final mid = await _read(ip, 'GetBass', 'CurrentBass');
+      await _soap.call(
+        ip: ip,
+        controlPath: _rcControl,
+        serviceType: _rcService,
+        action: 'SetBass',
+        args: {'InstanceID': '0', 'DesiredBass': '$n'},
+      );
+      final after = await _read(ip, 'GetBass', 'CurrentBass');
+      print('${labelByUuid[uuid]} @ $ip  bass: $before → $mid → $after (restored)');
+    } catch (e) {
+      print('✗ ${labelByUuid[uuid]} @ $ip: ${_short(e)}');
+    }
+    return;
+  }
+
+  // ---- default: read-only diagnostic ----
+  print('\n📜 RenderingControl SCPD — EQ/audio actions (via $anyIp):');
+  await _dumpEqActions(anyIp);
+
+  print('\n📊 Audio settings per speaker:');
+  for (final entry in ipByUuid.entries) {
+    final uuid = entry.key, ip = entry.value;
+    final ch = channelByUuid[uuid];
+    final tag = ch == null ? '' : ' [$ch]';
+    print('  ${(labelByUuid[uuid] ?? uuid)}$tag');
+    print('      ${await _readAll(ip)}');
+  }
+
+  print('\nLegend: bass/treble typically −10..10, loud/night 0/1, '
+      'sub/surround gain a signed range. ✗ = the speaker rejects that setting.');
+}


### PR DESCRIPTION
## What

Profiles can now snapshot each speaker's audio settings (EQ + optionally volume) and re-apply them on top of the restored layout — so applying a profile brings back the *complete* setup, not just who's bonded to whom.

- **New engine client** `lib/data/sonos/speaker_settings.dart` (RenderingControl): bass/treble/loudness, `GetEQ`/`SetEQ` (NightMode, DialogLevel, SubGain, SurroundLevel), volume/mute. Best-effort per field — unsupported settings read as `null` and are skipped on apply.
- **Two independent create-flow toggles**: "Save EQ settings" and "Save volume" (volume is transient playback state and surprising to restore, so it's a separate opt-in).
- **`EntitySnapshot.settings`** (uuid → settings), omitted from JSON when empty → pre-feature profiles round-trip unchanged and apply with zero extra writes.
- **Restore runs last**, after the bond settles — bonding can reset EQ (same mechanism that invalidates Trueplay).
- Profile tiles/detail show an **"EQ + volume saved"** badge.
- **Fix**: preflight false "Will free" — speakers bonded to the entity's *own* coordinator are no longer reported as conflicts (now mirrors `_applyEntity`'s owner checks).
- **Fix**: split-card ink highlight rounds only the corners each tile shares with the card.
- `tool/eq_probe.dart`: SCPD dump + per-speaker EQ read + `--test` Bass round-trip.

## Hardware validation (real Sonos system, via Android emulator E2E)

| Entity | Capture | Restore | Notes |
|---|---|---|---|
| Single | ✅ | ✅ | drift → apply → exact values back |
| Home theater | ✅ | ✅ | coordinator carries EQ; satellites reject reads (UPnPError 803) → skipped |
| Stereo pair | ✅ | ✅ | **both members** answer EQ while bonded — distinct per-speaker values restored |
| Zone | ✅ | ✅ | both members captured & restored |

Also confirmed on hardware: `GetBass`/`SetBass` (−10..10), `GetLoudness`, `GetEQ` EQType tokens, and that legacy (pre-feature) profiles load and apply with no extra writes.

## Tests

111 tests green, `flutter analyze` clean. New: `speaker_settings_test.dart` (parse/skip/apply-only-non-null), profile serialization round-trip + legacy compat, `profile_preflight_test.dart` (own-bond ≠ conflict regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)