### PR TITLE
feat(profiles): capture the full GetEQ family + clearer restore logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,15 @@ duplicate the app because we only **read the live values at snapshot and write
 them back on apply** — there are **no EQ/volume editing sliders** in Sonority
 (that WOULD duplicate the app). Keep it that way: capture+restore only, never
 standalone editing. (`speaker_settings.dart`, two per-profile toggles — EQ, and
-volume separately since restoring volume is surprising.)
+volume separately since restoring volume is surprising.) The EQ bundle =
+bass/treble/loudness + every `GetEQ`/`SetEQ` token (the shared `eqTypes` list;
+all Beam-confirmed): NightMode, DialogLevel, SubGain/SubEnable/SubPolarity/
+SubCrossover, SurroundLevel/SurroundEnable/SurroundMode/MusicSurroundLevel,
+AudioDelay (lip sync), AudioDelayLeftRear/RightRear (surround distance),
+HeightChannelLevel. **Gotcha:** the enable tokens are `SubEnable`/
+`SurroundEnable` — WITHOUT the trailing "d" of the SCPD state vars
+(`SubEnabled` faults 402). NOT exposed locally (so not capturable): volume
+limit, spatial music, TV autoplay/disband-on-autoplay, group audio delay, IR.
 
 The app does **no audio processing** — it only issues the bonding/config SOAP
 calls the official app blocks. Audio quality comes from the real speakers.

--- a/lib/data/sonos/speaker_settings.dart
+++ b/lib/data/sonos/speaker_settings.dart
@@ -2,27 +2,56 @@ import 'package:xml/xml.dart';
 
 import 'soap_client.dart';
 
+/// The `GetEQ`/`SetEQ` types captured in the EQ bundle — every stable sound
+/// setting the local API exposes (all hardware-confirmed on a Beam Gen 2 via
+/// `tool/eq_probe.dart`). Values are ints; booleans are 0/1. Note the enable
+/// tokens are `SubEnable`/`SurroundEnable` — WITHOUT the trailing "d" the SCPD
+/// state variables carry (`SubEnabled` faults with 402).
+///
+/// Covers, in Sonos-app terms: night sound (NightMode), speech enhancement
+/// (DialogLevel), sub level/on-off/phase/crossover (SubGain/SubEnable/
+/// SubPolarity/SubCrossover), surround on-off + TV & music levels + full-vs-
+/// ambient music mode (SurroundEnable/SurroundLevel/MusicSurroundLevel/
+/// SurroundMode), lip sync (AudioDelay), surround distance (AudioDelayLeftRear/
+/// RightRear), height channel level. NOT exposed by the local API (so not
+/// captured): volume limit, spatial music, TV autoplay/disband, group audio
+/// delay, IR.
+const eqTypes = [
+  'NightMode',
+  'DialogLevel',
+  'SubGain',
+  'SubEnable',
+  'SubPolarity',
+  'SubCrossover',
+  'SurroundLevel',
+  'SurroundEnable',
+  'SurroundMode',
+  'MusicSurroundLevel',
+  'AudioDelay',
+  'AudioDelayLeftRear',
+  'AudioDelayRightRear',
+  'HeightChannelLevel',
+];
+
 /// A snapshot of one speaker's audio settings, read from the `RenderingControl`
-/// service. Every field is nullable: `null` means "not captured" (the profile
-/// toggle was off) OR "this speaker doesn't support it" (e.g. a plain Play:1 has
-/// no `SubGain`). Reading and applying are both best-effort per field — one
-/// setting faulting never sinks the rest.
+/// service. Every field is nullable / possibly absent: it means "not captured"
+/// (the profile toggle was off) OR "this speaker doesn't support it" (e.g. a
+/// plain Play:1 answers no surround/sub tokens; HT satellites reject EQ reads
+/// entirely with UPnPError 803). Reading and applying are both best-effort per
+/// field — one setting faulting never sinks the rest.
 ///
-/// EQ fields (`bass`…`surroundLevel`) are stable configuration and pair well
-/// with a saved layout. `volume`/`mute` are transient playback state, captured
-/// only when the user opts in via the separate volume toggle.
-///
-/// Action/arg shapes follow the RenderingControl SCPD (confirm with
-/// `tool/eq_probe.dart`): Get/SetBass, Get/SetTreble, Get/SetLoudness(Channel),
-/// Get/SetEQ(EQType), Get/SetVolume(Channel), Get/SetMute(Channel).
+/// [bass]/[treble]/[loudness] have dedicated SOAP actions; every other sound
+/// setting rides the generic `GetEQ`/`SetEQ` pair and lives in [eq] keyed by
+/// EQType (see [eqTypes]). [volume]/[mute] are transient playback state,
+/// captured only when the user opts in via the separate volume toggle.
 class SpeakerSettings {
   final int? bass;
   final int? treble;
   final bool? loudness;
-  final bool? nightMode; // EQType NightMode
-  final int? dialogLevel; // EQType DialogLevel (speech enhancement)
-  final int? subGain; // EQType SubGain
-  final int? surroundLevel; // EQType SurroundLevel
+
+  /// EQType → value for every token the speaker answered (see [eqTypes]).
+  final Map<String, int> eq;
+
   final int? volume;
   final bool? mute;
 
@@ -30,10 +59,7 @@ class SpeakerSettings {
     this.bass,
     this.treble,
     this.loudness,
-    this.nightMode,
-    this.dialogLevel,
-    this.subGain,
-    this.surroundLevel,
+    this.eq = const {},
     this.volume,
     this.mute,
   });
@@ -41,28 +67,19 @@ class SpeakerSettings {
   static const empty = SpeakerSettings();
 
   bool get hasEq =>
-      bass != null ||
-      treble != null ||
-      loudness != null ||
-      nightMode != null ||
-      dialogLevel != null ||
-      subGain != null ||
-      surroundLevel != null;
+      bass != null || treble != null || loudness != null || eq.isNotEmpty;
 
   bool get hasVolume => volume != null || mute != null;
 
   bool get isEmpty => !hasEq && !hasVolume;
 
-  /// Serializes only the non-null fields, so an EQ-only capture doesn't store
-  /// bogus volume keys and old profiles round-trip cleanly.
+  /// Serializes only the non-null/non-empty fields, so an EQ-only capture
+  /// doesn't store bogus volume keys and old profiles round-trip cleanly.
   Map<String, dynamic> toJson() => {
         if (bass != null) 'bass': bass,
         if (treble != null) 'treble': treble,
         if (loudness != null) 'loudness': loudness,
-        if (nightMode != null) 'nightMode': nightMode,
-        if (dialogLevel != null) 'dialogLevel': dialogLevel,
-        if (subGain != null) 'subGain': subGain,
-        if (surroundLevel != null) 'surroundLevel': surroundLevel,
+        if (eq.isNotEmpty) 'eq': eq,
         if (volume != null) 'volume': volume,
         if (mute != null) 'mute': mute,
       };
@@ -71,10 +88,7 @@ class SpeakerSettings {
         bass: j['bass'] as int?,
         treble: j['treble'] as int?,
         loudness: j['loudness'] as bool?,
-        nightMode: j['nightMode'] as bool?,
-        dialogLevel: j['dialogLevel'] as int?,
-        subGain: j['subGain'] as int?,
-        surroundLevel: j['surroundLevel'] as int?,
+        eq: Map<String, int>.from((j['eq'] as Map?) ?? const {}),
         volume: j['volume'] as int?,
         mute: j['mute'] as bool?,
       );
@@ -93,10 +107,18 @@ class SpeakerSettingsClient {
   static const _control = '/MediaRenderer/RenderingControl/Control';
 
   /// Reads a settings snapshot for the speaker at [ip]. [eq] captures the EQ
-  /// bundle (bass/treble/loudness/night/speech/sub/surround); [volume] captures
-  /// volume/mute. The two are independent toggles.
+  /// bundle (bass/treble/loudness + every [eqTypes] token the speaker answers);
+  /// [volume] captures volume/mute. The two are independent toggles.
   Future<SpeakerSettings> read(String ip,
       {bool eq = true, bool volume = false}) async {
+    final eqValues = <String, int>{};
+    if (eq) {
+      for (final t in eqTypes) {
+        final v = await _readInt(ip, 'GetEQ', 'CurrentValue',
+            extra: {'EQType': t});
+        if (v != null) eqValues[t] = v;
+      }
+    }
     return SpeakerSettings(
       bass: eq ? await _readInt(ip, 'GetBass', 'CurrentBass') : null,
       treble: eq ? await _readInt(ip, 'GetTreble', 'CurrentTreble') : null,
@@ -104,10 +126,7 @@ class SpeakerSettingsClient {
           ? await _readBool(ip, 'GetLoudness', 'CurrentLoudness',
               extra: const {'Channel': 'Master'})
           : null,
-      nightMode: eq ? await _readEqBool(ip, 'NightMode') : null,
-      dialogLevel: eq ? await _readEqInt(ip, 'DialogLevel') : null,
-      subGain: eq ? await _readEqInt(ip, 'SubGain') : null,
-      surroundLevel: eq ? await _readEqInt(ip, 'SurroundLevel') : null,
+      eq: eqValues,
       volume: volume
           ? await _readInt(ip, 'GetVolume', 'CurrentVolume',
               extra: const {'Channel': 'Master'})
@@ -132,13 +151,8 @@ class SpeakerSettingsClient {
       await _set(ip, 'SetLoudness',
           {'Channel': 'Master', 'DesiredLoudness': s.loudness! ? '1' : '0'});
     }
-    if (s.nightMode != null) {
-      await _setEq(ip, 'NightMode', s.nightMode! ? '1' : '0');
-    }
-    if (s.dialogLevel != null) await _setEq(ip, 'DialogLevel', '${s.dialogLevel}');
-    if (s.subGain != null) await _setEq(ip, 'SubGain', '${s.subGain}');
-    if (s.surroundLevel != null) {
-      await _setEq(ip, 'SurroundLevel', '${s.surroundLevel}');
+    for (final e in s.eq.entries) {
+      await _set(ip, 'SetEQ', {'EQType': e.key, 'DesiredValue': '${e.value}'});
     }
     if (s.volume != null) {
       await _set(ip, 'SetVolume',
@@ -179,13 +193,7 @@ class SpeakerSettingsClient {
     return v == null ? null : v == '1';
   }
 
-  Future<int?> _readEqInt(String ip, String type) =>
-      _readInt(ip, 'GetEQ', 'CurrentValue', extra: {'EQType': type});
-
-  Future<bool?> _readEqBool(String ip, String type) =>
-      _readBool(ip, 'GetEQ', 'CurrentValue', extra: {'EQType': type});
-
-  // ---- write helpers (swallow faults; one setting must not block the rest) ----
+  // ---- write helper (swallows faults; one setting must not block the rest) ----
 
   Future<void> _set(String ip, String action, Map<String, String> extra) async {
     try {
@@ -198,7 +206,4 @@ class SpeakerSettingsClient {
       );
     } catch (_) {/* best-effort */}
   }
-
-  Future<void> _setEq(String ip, String type, String value) =>
-      _set(ip, 'SetEQ', {'EQType': type, 'DesiredValue': value});
 }

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -128,10 +128,19 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       EntitySnapshot e, SonosSystem sys, void Function(String) note) async {
     if (e.settings.isEmpty) return;
     for (final entry in e.settings.entries) {
-      final ip = sys.device(entry.key)?.ip;
-      if (ip == null) continue;
-      note('restoring settings');
-      await _settings.apply(ip, entry.value);
+      final dev = sys.device(entry.key);
+      final ip = dev?.ip;
+      if (ip == null) {
+        note('skipping settings for ${entry.key} — not on the network');
+        continue;
+      }
+      final s = entry.value;
+      final what = [
+        if (s.hasEq) 'EQ',
+        if (s.hasVolume) 'volume',
+      ].join(' + ');
+      note('restoring $what — ${dev!.typeLabel}');
+      await _settings.apply(ip, s);
     }
   }
 

--- a/test/profile_test.dart
+++ b/test/profile_test.dart
@@ -73,7 +73,12 @@ void main() {
       uuid: fl,
       zoneName: 'Bureau',
     )).copyWith(settings: {
-      fl: const SpeakerSettings(bass: 3, treble: -2, loudness: true, volume: 25),
+      fl: const SpeakerSettings(
+          bass: 3,
+          treble: -2,
+          loudness: true,
+          eq: {'NightMode': 1, 'AudioDelay': 2},
+          volume: 25),
     });
     final profile = Profile(id: 'p2', name: 'Tuned', entities: [snap]);
     final back = Profile.fromJson(
@@ -83,7 +88,7 @@ void main() {
     expect(s.treble, -2);
     expect(s.loudness, isTrue);
     expect(s.volume, 25);
-    expect(s.nightMode, isNull); // not captured → stays null
+    expect(s.eq, {'NightMode': 1, 'AudioDelay': 2});
     expect(back.entities.first.settingsSummary, 'EQ + volume saved');
     expect(back.settingsSummary, 'EQ + volume saved');
   });

--- a/test/speaker_settings_test.dart
+++ b/test/speaker_settings_test.dart
@@ -5,7 +5,8 @@ import 'package:xml/xml.dart';
 
 /// Records write calls and answers reads from a per-action table. A read whose
 /// action/EQType isn't in the table throws — simulating a speaker that doesn't
-/// support that setting, which the client must turn into `null` (not a failure).
+/// support that setting, which the client must turn into an absent field (not
+/// a failure).
 class _FakeSoap extends SonosSoapClient {
   final Map<String, String> reads; // key: action or "GetEQ:EQType" → out element text
   final List<String> writes = [];
@@ -38,13 +39,15 @@ class _FakeSoap extends SonosSoapClient {
 }
 
 void main() {
-  test('read parses supported fields and nulls unsupported ones', () async {
+  test('read parses supported fields and skips unsupported EQ types', () async {
     final fake = _FakeSoap({
       'GetBass': '5',
       'GetTreble': '-3',
       'GetLoudness': '1',
       'GetEQ:NightMode': '1',
-      // No DialogLevel/SubGain/SurroundLevel → those throw → null.
+      'GetEQ:SurroundMode': '1',
+      'GetEQ:AudioDelayLeftRear': '2',
+      // No DialogLevel/SubGain/… → those throw → absent from the map.
       'GetVolume': '22',
       'GetMute': '0',
     });
@@ -52,9 +55,8 @@ void main() {
     expect(s.bass, 5);
     expect(s.treble, -3);
     expect(s.loudness, isTrue);
-    expect(s.nightMode, isTrue);
-    expect(s.dialogLevel, isNull);
-    expect(s.subGain, isNull);
+    expect(s.eq,
+        {'NightMode': 1, 'SurroundMode': 1, 'AudioDelayLeftRear': 2});
     expect(s.volume, 22);
     expect(s.mute, isFalse);
   });
@@ -64,6 +66,7 @@ void main() {
     final volOnly = await SpeakerSettingsClient(fake).read('1.2.3.4',
         eq: false, volume: true);
     expect(volOnly.bass, isNull);
+    expect(volOnly.eq, isEmpty);
     expect(volOnly.volume, 22);
     expect(volOnly.hasEq, isFalse);
 
@@ -73,21 +76,32 @@ void main() {
     expect(eqOnly.hasVolume, isFalse);
   });
 
-  test('apply writes only non-null fields', () async {
+  test('apply writes only captured fields', () async {
     final fake = _FakeSoap(const {});
     await SpeakerSettingsClient(fake).apply(
       '1.2.3.4',
-      const SpeakerSettings(bass: 4, nightMode: true, volume: 30),
+      const SpeakerSettings(
+          bass: 4, eq: {'NightMode': 1, 'SubPolarity': 2}, volume: 30),
     );
-    expect(fake.writes, containsAll(['SetBass=4', 'SetEQ:NightMode=1', 'SetVolume=30']));
+    expect(
+        fake.writes,
+        containsAll(
+            ['SetBass=4', 'SetEQ:NightMode=1', 'SetEQ:SubPolarity=2', 'SetVolume=30']));
     expect(fake.writes.any((w) => w.startsWith('SetTreble')), isFalse);
     expect(fake.writes.any((w) => w.startsWith('SetLoudness')), isFalse);
-    expect(fake.writes.length, 3);
+    expect(fake.writes.length, 4);
   });
 
   test('empty settings write nothing', () async {
     final fake = _FakeSoap(const {});
     await SpeakerSettingsClient(fake).apply('1.2.3.4', SpeakerSettings.empty);
     expect(fake.writes, isEmpty);
+  });
+
+  test('JSON round-trip keeps the eq map; empty eq omitted', () {
+    const s = SpeakerSettings(bass: 1, eq: {'AudioDelay': 3, 'SubEnable': 1});
+    final back = SpeakerSettings.fromJson(s.toJson());
+    expect(back.eq, {'AudioDelay': 3, 'SubEnable': 1});
+    expect(const SpeakerSettings(bass: 1).toJson().containsKey('eq'), isFalse);
   });
 }

--- a/tool/eq_probe.dart
+++ b/tool/eq_probe.dart
@@ -18,6 +18,7 @@ import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart';
 
 import 'package:sonority/data/sonos/soap_client.dart';
+import 'package:sonority/data/sonos/speaker_settings.dart' show eqTypes;
 import 'package:sonority/data/sonos/zone_topology.dart';
 
 import 'discover_util.dart';
@@ -26,18 +27,10 @@ const _rcService = 'urn:schemas-upnp-org:service:RenderingControl:1';
 const _rcControl = '/MediaRenderer/RenderingControl/Control';
 final _soap = SonosSoapClient();
 
-// The EQType tokens we expect Sonos to expose via GetEQ/SetEQ. The probe reads
-// each; ones the speaker doesn't support just fault (shown as ✗) — that tells us
-// which apply to which model.
-const _eqTypes = [
-  'NightMode',
-  'DialogLevel',
-  'SubGain',
-  'SurroundLevel',
-  'MusicSurroundLevel',
-  'HeightChannelLevel',
-  'SubEnabled',
-];
+// The EQType tokens the app captures — shared list so probe and client can't
+// drift. The probe reads each; ones the speaker doesn't support just fault,
+// which tells us which apply to which model.
+const _eqTypes = eqTypes;
 
 String _short(Object e) {
   final s = e.toString();


### PR DESCRIPTION
Follow-up to #8, answering "are sub phase/enabled, surround music level, full-vs-ambient, surround distance, lip sync… captured too?" — they are now.

## What

- **EQ bundle extended from 5 tokens to the full `GetEQ` family**, stored as one `Map<String,int>` (`SpeakerSettings.eq`) instead of per-field boilerplate: NightMode, DialogLevel, SubGain/**SubEnable/SubPolarity/SubCrossover**, SurroundLevel/**SurroundEnable/SurroundMode/MusicSurroundLevel**, **AudioDelay** (lip sync), **AudioDelayLeftRear/RightRear** (surround distance), **HeightChannelLevel**.
- **Gotcha (hardware-confirmed):** the enable tokens are `SubEnable`/`SurroundEnable` — *without* the trailing "d" of the SCPD state vars (`SubEnabled` faults 402).
- **Not exposed by the local API** (so deliberately not captured): volume limit, spatial music, TV autoplay / disband-on-autoplay, group audio delay, IR.
- **Clearer restore logs**: `restoring EQ — Beam (Gen 2)` / `restoring EQ + volume — Play:1` instead of a bare "restoring settings"; off-network speakers are logged as skipped.
- `tool/eq_probe.dart` reuses the shared `eqTypes` list so probe and client can't drift.

## Hardware validation (real Beam Gen 2, app E2E)

All 14 tokens captured into the profile JSON; drifted `SurroundMode`/`AudioDelay`/`SubGain`/`NightMode` → applied → **all restored exactly**, with the layout no-op path ("layout unchanged — nothing to do") intact.

Schema note: replaces the (unreleased) per-field EQ JSON keys with the `eq` map — safe, no released profiles carry settings; the `settings`-absent legacy path is unchanged and still tested.

115 tests green, `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)