### PR TITLE
feat(progress): two-level timeline — phase sub-steps under each entity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,8 @@ lib/
                      ssdp_discovery · device_description · soap_client
                      zone_topology  · device_properties (bonding + stereo + zone attrs)
                      channel_map    · front_layout (buildLayoutMap + diffHtLayout — any role)
-                     apply_progress (ApplyStep/ApplyProgress — per-step status)
+                     apply_progress (ApplyStep/ApplyProgress — per-step status;
+                       flat list, `parentId` nests phase sub-steps under entities)
                      identify_service (chime)
                      speaker_settings (RenderingControl EQ/volume read+apply for profiles)
                      sonos_repository (orchestrates; bondAndVerify write+retry;

--- a/lib/data/sonos/apply_progress.dart
+++ b/lib/data/sonos/apply_progress.dart
@@ -9,6 +9,9 @@ library;
 enum ApplyStatus { pending, active, done, failed }
 
 /// One step in a bonding operation, e.g. "Bond surrounds" or "Restore names".
+/// A step with a [parentId] is a phase sub-step rendered nested under its
+/// parent (entity) step; the list stays flat — tree order == list order
+/// because operations run strictly sequentially.
 class ApplyStep {
   final String id;
   final String label;
@@ -18,11 +21,15 @@ class ApplyStep {
   /// success it may carry a short note ("re-asserted after 1 retry").
   final String? detail;
 
+  /// Non-null for a phase sub-step nested under a top-level step.
+  final String? parentId;
+
   const ApplyStep({
     required this.id,
     required this.label,
     this.status = ApplyStatus.pending,
     this.detail,
+    this.parentId,
   });
 
   ApplyStep copyWith({ApplyStatus? status, String? detail}) => ApplyStep(
@@ -30,8 +37,10 @@ class ApplyStep {
         label: label,
         status: status ?? this.status,
         detail: detail ?? this.detail,
+        parentId: parentId,
       );
 
+  bool get isChild => parentId != null;
   bool get isFailed => status == ApplyStatus.failed;
 }
 
@@ -45,6 +54,10 @@ class ApplyProgress {
   final void Function(List<ApplyStep> steps)? onChange;
   final void Function(String line)? onLog;
 
+  /// The most recently begun phase sub-step — [noteActive] routes verbose
+  /// per-attempt text here. Well-defined because operations are sequential.
+  String? _activeChildId;
+
   ApplyProgress(List<ApplyStep> steps, {this.onChange, this.onLog})
       : _steps = List.of(steps) {
     _emit();
@@ -55,18 +68,110 @@ class ApplyProgress {
   int _indexOf(String id) => _steps.indexWhere((s) => s.id == id);
 
   void start(String id) {
+    _activeChildId = null; // each entity starts with a clean phase slate
     _set(id, ApplyStatus.active);
     _log(id, '▸');
   }
 
   void done(String id, {String? detail}) {
+    _closeActiveChildOf(id, ApplyStatus.done);
+    // Drop seeded phases that turned out unnecessary.
+    _steps.removeWhere(
+        (s) => s.parentId == id && s.status == ApplyStatus.pending);
     _set(id, ApplyStatus.done, detail);
     _log(id, '✓');
   }
 
   void fail(String id, String detail) {
+    // The view shows the error on the sub-step when the parent has children,
+    // so the failing phase must carry the reason too.
+    _closeActiveChildOf(id, ApplyStatus.failed, detail);
     _set(id, ApplyStatus.failed, detail);
     _log(id, '✗', detail);
+  }
+
+  /// Seeds pending phase sub-steps under [parentId] (the phases knowable
+  /// upfront); conditional phases are inserted later by [startSub].
+  void seedSubs(String parentId, List<(String id, String label)> subs) {
+    var at = _lastChildIndex(parentId) + 1;
+    for (final (id, label) in subs) {
+      _steps.insert(
+          at++, ApplyStep(id: id, label: label, parentId: parentId));
+    }
+    _emit();
+  }
+
+  /// Begins phase [id] under [parentId]: completes the previously active
+  /// phase (starting phase N+1 means N finished), activates the seeded
+  /// sub-step if it exists (refreshing its label — seeds may be approximate),
+  /// else inserts it before the parent's first pending sub-step (a
+  /// conditional phase like "freeing" runs before the seeded ones).
+  void startSub(String parentId, String id, String label) {
+    if (_activeChildId != id) _closeActiveChildOf(parentId, ApplyStatus.done);
+    final step = ApplyStep(
+        id: id, label: label, status: ApplyStatus.active, parentId: parentId);
+    final i = _indexOf(id);
+    if (i >= 0) {
+      _steps[i] = step;
+    } else {
+      var at = _steps.indexWhere(
+          (s) => s.parentId == parentId && s.status == ApplyStatus.pending);
+      if (at < 0) at = _lastChildIndex(parentId) + 1;
+      _steps.insert(at, step);
+    }
+    _activeChildId = id;
+    _emit();
+    _log(id, '▸');
+  }
+
+  /// Marks the active phase done without starting the next one (used when an
+  /// entity's work short-circuits, e.g. "layout unchanged").
+  void doneSub({String? detail}) {
+    final id = _activeChildId;
+    if (id == null) return;
+    _activeChildId = null;
+    _set(id, ApplyStatus.done, detail);
+    _log(id, '✓', detail);
+  }
+
+  /// Verbose within-phase progress ("attempt 2: re-asserting") → subtitle of
+  /// the active phase sub-step; falls back to the active top-level step so
+  /// paths without phases still surface their notes.
+  void noteActive(String detail) {
+    final id = _activeChildId ??
+        _steps
+            .where((s) => !s.isChild && s.status == ApplyStatus.active)
+            .firstOrNull
+            ?.id;
+    if (id != null) note(id, detail);
+  }
+
+  void _closeActiveChildOf(String parentId, ApplyStatus status,
+      [String? detail]) {
+    final id = _activeChildId;
+    if (id == null) return;
+    final i = _indexOf(id);
+    if (i < 0 || _steps[i].parentId != parentId) return;
+    _activeChildId = null;
+    if (_steps[i].status != ApplyStatus.active) return;
+    // Clear the transient verbose note unless we're recording a failure.
+    _steps[i] = ApplyStep(
+      id: _steps[i].id,
+      label: _steps[i].label,
+      status: status,
+      detail: detail,
+      parentId: parentId,
+    );
+    _emit();
+    _log(id, status == ApplyStatus.failed ? '✗' : '✓', detail);
+  }
+
+  int _lastChildIndex(String parentId) {
+    var last = _indexOf(parentId);
+    for (var i = 0; i < _steps.length; i++) {
+      if (_steps[i].parentId == parentId) last = i;
+    }
+    return last;
   }
 
   /// Updates the live detail of a step without changing its status — used to
@@ -90,8 +195,9 @@ class ApplyProgress {
   void _log(String id, String glyph, [String? detail]) {
     final i = _indexOf(id);
     if (i < 0) return;
+    final indent = _steps[i].isChild ? '  ' : '';
     final suffix = detail == null ? '' : ': $detail';
-    onLog?.call('$glyph ${_steps[i].label}$suffix');
+    onLog?.call('$indent$glyph ${_steps[i].label}$suffix');
   }
 
   void _emit() => onChange?.call(steps);

--- a/lib/features/widgets/apply_progress_view.dart
+++ b/lib/features/widgets/apply_progress_view.dart
@@ -45,7 +45,15 @@ class ApplyProgressView extends StatelessWidget {
             child: Column(
               children: [
                 for (var i = 0; i < steps.length; i++)
-                  _TimelineRow(step: steps[i], isLast: i == steps.length - 1),
+                  _TimelineRow(
+                    step: steps[i],
+                    isLast: i == steps.length - 1,
+                    // Extra gap before the next entity groups its section.
+                    nextIsParent:
+                        i + 1 < steps.length && !steps[i + 1].isChild,
+                    hasChildren: !steps[i].isChild &&
+                        steps.any((s) => s.parentId == steps[i].id),
+                  ),
               ],
             ),
           ),
@@ -55,17 +63,28 @@ class ApplyProgressView extends StatelessWidget {
   }
 }
 
-/// One node + its connector + label/detail.
+/// One node + its connector + label/detail on a single shared spine: big
+/// nodes (checkmark when done) for top-level entity steps, small plain dots
+/// for phase sub-steps (blue while busy, green when done, red on failure).
+/// A parent that has children shows label + node only (the verbose/error
+/// text lives on its sub-steps).
 class _TimelineRow extends StatelessWidget {
   final ApplyStep step;
   final bool isLast;
-  const _TimelineRow({required this.step, required this.isLast});
+  final bool nextIsParent;
+  final bool hasChildren;
+  const _TimelineRow(
+      {required this.step,
+      required this.isLast,
+      required this.nextIsParent,
+      required this.hasChildren});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
     final active = step.status == ApplyStatus.active;
+    final child = step.isChild;
 
     final labelColor = switch (step.status) {
       ApplyStatus.failed => scheme.error,
@@ -73,16 +92,22 @@ class _TimelineRow extends StatelessWidget {
       _ => scheme.onSurface,
     };
 
+    // The connector stretches through the bottom padding, so a bigger gap
+    // before the next entity visually groups each section.
+    final gapAfter = isLast ? 0.0 : (nextIsParent ? 22.0 : 10.0);
+
     return IntrinsicHeight(
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // Node + connector line column.
+          // Node + connector line column — one spine shared by all rows.
           SizedBox(
             width: 24,
             child: Column(
               children: [
-                SizedBox(height: 24, child: Center(child: _Node(step: step))),
+                SizedBox(
+                    height: 24,
+                    child: Center(child: _Node(step: step, small: child))),
                 if (!isLast)
                   Expanded(
                     child: Center(
@@ -95,7 +120,7 @@ class _TimelineRow extends StatelessWidget {
           Gap.m,
           Expanded(
             child: Padding(
-              padding: EdgeInsets.only(bottom: isLast ? 0 : 16),
+              padding: EdgeInsets.only(bottom: gapAfter),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
@@ -105,22 +130,28 @@ class _TimelineRow extends StatelessWidget {
                       alignment: Alignment.centerLeft,
                       child: Text(
                         step.label,
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          color: labelColor,
-                          fontWeight:
-                              active ? FontWeight.w600 : FontWeight.w400,
-                        ),
+                        style: (child
+                                ? theme.textTheme.bodyMedium?.copyWith(
+                                    color: labelColor,
+                                    fontWeight: active
+                                        ? FontWeight.w600
+                                        : FontWeight.w400,
+                                  )
+                                : theme.textTheme.titleMedium?.copyWith(
+                                    color: labelColor,
+                                    fontWeight: FontWeight.w600,
+                                  )),
                       ),
                     ),
                   ),
-                  if (step.isFailed)
+                  if (step.isFailed && !hasChildren)
                     Padding(
                       padding: const EdgeInsets.only(top: 2),
                       child: Text(step.detail ?? 'Failed.',
                           style: theme.textTheme.bodyMedium
                               ?.copyWith(color: scheme.error)),
                     )
-                  else if (active)
+                  else if (active && !hasChildren)
                     Padding(
                       padding: const EdgeInsets.only(top: 4),
                       child: Row(
@@ -138,6 +169,15 @@ class _TimelineRow extends StatelessWidget {
                           ),
                         ],
                       ),
+                    )
+                  else if (step.status == ApplyStatus.done &&
+                      child &&
+                      step.detail != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 2),
+                      child: Text(step.detail!,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                              color: scheme.onSurfaceVariant)),
                     ),
                 ],
               ),
@@ -149,33 +189,69 @@ class _TimelineRow extends StatelessWidget {
   }
 }
 
-/// The timeline node: bare checkmark (done), pulsing dot (active), grey dot
-/// (to-do), or a red dot (failed).
+/// The timeline node. A main (entity) step is always the SAME fixed-size
+/// circle — filled green + check when done, filled red + X when failed, an
+/// outlined ring with a pulsing dot while busy, a grey ring when to-do — so
+/// milestones read consistently across states. Phase sub-steps ([small]) are
+/// plain 6px dots in every state, only the color changes: green done, blue
+/// pulsing busy, red failed, grey to-do.
 class _Node extends StatelessWidget {
   final ApplyStep step;
-  const _Node({required this.step});
+  final bool small;
+  const _Node({required this.step, this.small = false});
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final pendingColor = scheme.onSurfaceVariant.withValues(alpha: 0.5);
+    final green = theme.brightness == Brightness.dark
+        ? Colors.green.shade400
+        : Colors.green.shade600;
+    if (small) {
+      return switch (step.status) {
+        ApplyStatus.done => _dot(green, 6),
+        ApplyStatus.active => const _PulsingDot(size: 6),
+        ApplyStatus.failed => _dot(scheme.error, 6),
+        ApplyStatus.pending => _dot(pendingColor, 6),
+      };
+    }
     return switch (step.status) {
-      ApplyStatus.done => Icon(Icons.check, size: 18, color: scheme.primary),
-      ApplyStatus.active => const _PulsingDot(),
-      ApplyStatus.failed => Icon(Icons.close, size: 16, color: scheme.error),
-      ApplyStatus.pending => _dot(scheme.onSurfaceVariant.withValues(alpha: 0.5)),
+      ApplyStatus.done => _circle(
+          fill: green,
+          child: const Icon(Icons.check, size: 14, color: Colors.white)),
+      ApplyStatus.failed => _circle(
+          fill: scheme.error,
+          child: const Icon(Icons.close, size: 14, color: Colors.white)),
+      ApplyStatus.active => _circle(
+          border: scheme.primary, child: const _PulsingDot(size: 10)),
+      ApplyStatus.pending => _circle(border: pendingColor),
     };
   }
 
-  static Widget _dot(Color color) => Container(
-        width: 10,
-        height: 10,
+  static Widget _dot(Color color, double size) => Container(
+        width: size,
+        height: size,
         decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+      );
+
+  static Widget _circle({Color? fill, Color? border, Widget? child}) =>
+      Container(
+        width: 22,
+        height: 22,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: fill,
+          border: border == null ? null : Border.all(color: border, width: 2),
+        ),
+        child: child == null ? null : Center(child: child),
       );
 }
 
 /// A softly pulsating dot marking the active step.
 class _PulsingDot extends StatefulWidget {
-  const _PulsingDot();
+  final double size;
+  const _PulsingDot({this.size = 12});
 
   @override
   State<_PulsingDot> createState() => _PulsingDotState();
@@ -202,8 +278,8 @@ class _PulsingDotState extends State<_PulsingDot>
       opacity: Tween(begin: 0.3, end: 1.0)
           .animate(CurvedAnimation(parent: _c, curve: Curves.easeInOut)),
       child: Container(
-        width: 12,
-        height: 12,
+        width: widget.size,
+        height: widget.size,
         decoration: BoxDecoration(shape: BoxShape.circle, color: color),
       ),
     );

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -15,6 +15,17 @@ import '../features/profiles/profile.dart';
 final sonosRepositoryProvider =
     Provider<SonosRepository>((ref) => SonosRepository());
 
+/// Phase emitters for one parent (entity) step — built by
+/// `SonosController._phases`, consumed by the apply helpers so each phase
+/// becomes a persistent sub-step in the progress timeline instead of an
+/// overwriting note.
+typedef Phases = ({
+  void Function(List<(String, String)>) seed,
+  void Function(String id, String label) phase,
+  void Function(String) note,
+  void Function({String? detail}) endPhase,
+});
+
 /// Live per-step progress of the in-flight bonding operation (full HT setup /
 /// profile-apply). The flow/profile UI watches this to show a stepper with the
 /// active step and exactly where a failure happened. Empty when idle.
@@ -125,12 +136,12 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   /// can reset EQ, so this must run last). Best-effort + a no-op when [e] carries
   /// no settings (old profiles / toggles off) → zero extra writes.
   Future<void> _restoreSettings(
-      EntitySnapshot e, SonosSystem sys, void Function(String) note) async {
+      EntitySnapshot e, SonosSystem sys, Phases ph) async {
     if (e.settings.isEmpty) return;
+    ph.phase('settings', 'Restore settings');
     for (final entry in e.settings.entries) {
       final ip = sys.device(entry.key)?.ip;
       if (ip == null) continue;
-      note('restoring settings');
       await _settings.apply(ip, entry.value);
     }
   }
@@ -193,13 +204,15 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     state = const AsyncValue.loading();
     final result = await AsyncValue.guard(() async {
       tracker.start('bond');
+      final ph = _phases(tracker, 'bond');
+      ph.seed([('bond', 'Bond ${target.entries.length - 1} speakers')]);
       try {
         final sys = await _applyHtTarget(
           bar: soundbarDevice,
           current: soundbar,
           target: target,
           sys: previous ?? await _repo.discover(),
-          note: (n) => tracker.note('bond', n),
+          ph: ph,
         );
         tracker.done('bond');
         return sys;
@@ -238,10 +251,21 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       SonosSystem? sys = previous;
       for (final e in entities) {
         tracker.start(e.primaryUuid);
+        final ph = _phases(tracker, e.primaryUuid);
+        // Pre-list the phases knowable from the snapshot; conditional ones
+        // (freeing conflicts, removing changed satellites) pop in when needed.
+        ph.seed([
+          if (e.kind == EntityKind.homeTheater)
+            ('bond', 'Bond ${e.involvedUuids.length - 1} speakers')
+          else if (e.kind != EntityKind.single)
+            ('bond', 'Bond ${e.involvedUuids.length} speakers'),
+          ('names', 'Restore room name'),
+          if (e.settings.isNotEmpty) ('settings', 'Restore settings'),
+        ]);
         try {
-          sys = await _applyEntity(e, sys!, (n) => tracker.note(e.primaryUuid, n));
+          sys = await _applyEntity(e, sys!, ph);
           // Restore captured EQ/volume last — bonding can reset EQ.
-          await _restoreSettings(e, sys, (n) => tracker.note(e.primaryUuid, n));
+          await _restoreSettings(e, sys, ph);
           tracker.done(e.primaryUuid);
         } on OperationCancelled {
           rethrow;
@@ -256,7 +280,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   }
 
   Future<SonosSystem> _applyEntity(
-      EntitySnapshot e, SonosSystem sys, void Function(String) note) async {
+      EntitySnapshot e, SonosSystem sys, Phases ph) async {
     switch (e.kind) {
       case EntityKind.single:
         final dev = sys.device(e.primaryUuid);
@@ -264,10 +288,12 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           throw Exception('“${e.label}” isn’t on the network.');
         }
         if (sys.ownerOf(e.primaryUuid) != null) {
-          note('freeing from its current bond');
+          ph.phase('free', 'Free from its current bond');
           await _repo.freeSpeaker(sys, e.primaryUuid);
+          ph.note('waiting for Sonos to settle');
           sys = await _settleRead(sys, dev!.ip!);
         }
+        ph.phase('names', 'Restore room name');
         await _repo.setRoomName(ip: dev!.ip!, name: e.names[e.primaryUuid] ?? dev.roomName);
         return sys;
 
@@ -282,6 +308,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         final involved = e.involvedUuids.toList();
         // Already exactly this group? Just re-assert the name (no disruptive write).
         if (_isGroupFormed(sys, e.primaryUuid, involved)) {
+          ph.phase('bond', 'Bond ${involved.length} speakers');
+          ph.endPhase(detail: 'already formed — nothing to do');
+          ph.phase('names', 'Restore room name');
           await _repo.setRoomName(
               ip: coord!.ip!, name: e.names[coord.uuid] ?? coord.roomName);
           return sys;
@@ -290,7 +319,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         for (final u in involved) {
           final owner = sys.ownerOf(u);
           if (owner != null && !involved.contains(owner)) {
-            note('freeing $u');
+            ph.phase('free', 'Free conflicting speakers');
+            ph.note('freeing ${sys.device(u)?.roomName ?? u}');
             await _repo.freeSpeaker(sys, u);
             sys = await _settleRead(sys, coord!.ip!);
           }
@@ -314,8 +344,10 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         if (memberEntries.length < 2) {
           throw Exception('“${e.label}” is missing speakers.');
         }
-        note('bonding ${memberEntries.length} speakers${sub != null ? ' + sub' : ''}');
+        ph.phase('bond',
+            'Bond ${memberEntries.length} speakers${sub != null ? ' + sub' : ''}');
         await _repo.createGroup(members: memberEntries, sub: sub);
+        ph.note('waiting for Sonos to confirm');
         sys = await _pollUntil(
           previous: sys,
           ip: coord!.ip,
@@ -325,6 +357,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         if (!_isGroupFormed(sys, e.primaryUuid, involved)) {
           throw Exception('Sonos did not form “${e.label}”.');
         }
+        ph.phase('names', 'Restore room name');
         await _repo.setRoomName(
             ip: coord.ip!, name: e.names[coord.uuid] ?? coord.roomName);
         return sys;
@@ -345,7 +378,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         for (final u in satUuids) {
           final owner = sys.ownerOf(u);
           if (owner != null && owner != bar!.uuid) {
-            note('freeing $u');
+            ph.phase('free', 'Free conflicting speakers');
+            ph.note('freeing ${sys.device(u)?.roomName ?? u}');
             await _repo.freeSpeaker(sys, u);
             sys = await _settleRead(sys, bar.ip!);
           }
@@ -365,8 +399,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           current: cur ?? ZoneGroupMember(uuid: bar.uuid, zoneName: e.label),
           target: fullTarget,
           sys: sys,
-          note: note,
+          ph: ph,
         );
+        ph.phase('names', 'Restore room name');
         await _repo.setRoomName(ip: bar.ip!, name: e.names[bar.uuid] ?? bar.roomName);
         return sys;
     }
@@ -382,25 +417,28 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     required ZoneGroupMember current,
     required ChannelMap target,
     required SonosSystem sys,
-    required void Function(String) note,
+    required Phases ph,
   }) async {
     final diff = front_layout.diffHtLayout(current: current, target: target);
+    final bondLabel = 'Bond ${target.entries.length - 1} speakers';
     if (diff.isNoOp) {
-      note('layout unchanged — nothing to do');
+      ph.phase('bond', bondLabel);
+      ph.endPhase(detail: 'layout unchanged — nothing to do');
       return sys;
     }
     if (diff.toRemove.isNotEmpty) {
-      note('removing ${diff.toRemove.length} changed speakers');
+      ph.phase('remove', 'Remove ${diff.toRemove.length} changed speakers');
       await _repo.removeHtSatellites(
           soundbarIp: bar.ip!, uuids: diff.toRemove, cancel: _activeOp);
+      ph.note('waiting for Sonos to settle');
       sys = await _settleRead(sys, bar.ip!);
     }
-    note('bonding ${target.entries.length - 1} speakers');
+    ph.phase('bond', bondLabel);
     return _repo.bondAndVerify(
         coordinator: bar,
         target: target,
         previous: sys,
-        onNote: note,
+        onNote: ph.note,
         cancel: _activeOp);
   }
 
@@ -468,11 +506,16 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     state = const AsyncValue.loading();
     final result = await AsyncValue.guard(() async {
       tracker.start('remove');
+      final ph = _phases(tracker, 'remove');
+      ph.seed([
+        ('unbond', 'Unbond ${uuids.length} speaker(s)'),
+        ('settle', 'Wait for Sonos to settle'),
+      ]);
       try {
-        tracker.note('remove', 'unbonding ${uuids.length} speaker(s)');
+        ph.phase('unbond', 'Unbond ${uuids.length} speaker(s)');
         await _repo.removeHtSatellites(
             soundbarIp: ip, uuids: uuids, cancel: _activeOp);
-        tracker.note('remove', 'waiting for Sonos to settle');
+        ph.phase('settle', 'Wait for Sonos to settle');
         final sys = await _pollUntil(
           previous: previous,
           ip: ip,
@@ -525,10 +568,18 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     state = const AsyncValue.loading();
     final result = await AsyncValue.guard(() async {
       tracker.start('group');
+      final ph = _phases(tracker, 'group');
+      final wanted = name?.trim();
+      ph.seed([
+        ('bond', 'Bond speakers'),
+        ('confirm', 'Wait for Sonos to confirm'),
+        if (wanted != null && wanted.isNotEmpty && coord.ip != null)
+          ('name', 'Name the group'),
+      ]);
       try {
-        tracker.note('group', 'bonding speakers');
+        ph.phase('bond', 'Bond speakers');
         await _repo.createGroup(members: members, sub: sub);
-        tracker.note('group', 'waiting for Sonos to confirm');
+        ph.phase('confirm', 'Wait for Sonos to confirm');
         var system = await _pollUntil(
           previous: previous,
           ip: coord.ip ?? _lastIp,
@@ -545,9 +596,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           throw Exception(
               'Sonos did not create the group — a speaker may be incompatible.');
         }
-        final wanted = name?.trim();
         if (wanted != null && wanted.isNotEmpty && coord.ip != null) {
-          tracker.note('group', 'naming the group');
+          ph.phase('name', 'Name the group');
           await _repo.setRoomName(ip: coord.ip!, name: wanted);
           system = await _pollUntil(
             previous: system,
@@ -599,11 +649,16 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     state = const AsyncValue.loading();
     final result = await AsyncValue.guard(() async {
       tracker.start('ungroup');
+      final ph = _phases(tracker, 'ungroup');
+      ph.seed([
+        ('separate', 'Separate + restore room names'),
+        ('settle', 'Wait for Sonos to settle'),
+      ]);
       try {
         // 1. A bond can't be dissolved while the coordinator is a non-coordinator
         //    member of a larger playback group — detach into its own group first.
         if (coord.ip != null && !_isStandalone(previous, coord.uuid)) {
-          tracker.note('ungroup', 'detaching from playback group');
+          ph.phase('detach', 'Detach from playback group');
           await _repo.detachFromGroup(coord.ip!);
           await _pollUntil(
             previous: previous,
@@ -613,9 +668,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           );
         }
         // 2. Dissolve (SeparateStereoPair on the live map) + restore names.
-        tracker.note('ungroup', 'separating + restoring room names');
+        ph.phase('separate', 'Separate + restore room names');
         await _repo.separateGroup(members: members, channelMapSet: cms);
-        tracker.note('ungroup', 'waiting for Sonos to settle');
+        ph.phase('settle', 'Wait for Sonos to settle');
         final system = await _pollUntil(
           previous: previous,
           ip: coord.ip ?? _lastIp,
@@ -703,6 +758,21 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         steps,
         onChange: ref.read(applyProgressProvider.notifier).set,
         onLog: ref.read(operationLogProvider.notifier).add,
+      );
+
+  /// Phase emitters bound to one parent (entity) step, so call sites don't
+  /// thread the parent id: [seed] pre-lists the phases knowable upfront as
+  /// pending sub-steps, [phase] begins one (seeded or conditional), [note]
+  /// streams verbose progress to the active phase's subtitle, and [endPhase]
+  /// completes the active phase early (short-circuits like "layout
+  /// unchanged"). Child ids are prefixed with the parent id to stay unique in
+  /// the flat step list.
+  Phases _phases(ApplyProgress t, String parentId) => (
+        seed: (subs) => t.seedSubs(parentId,
+            [for (final (id, label) in subs) ('$parentId/$id', label)]),
+        phase: (id, label) => t.startSub(parentId, '$parentId/$id', label),
+        note: t.noteActive,
+        endPhase: t.doneSub,
       );
 
   /// Finalizes a bonding op's [result] against the pre-op [previous] state.

--- a/test/apply_progress_test.dart
+++ b/test/apply_progress_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:sonority/data/sonos/apply_progress.dart';
+
+void main() {
+  ApplyProgress tracker(List<String> log) => ApplyProgress(
+        const [
+          ApplyStep(id: 'e1', label: 'Home Theater: Living Room'),
+          ApplyStep(id: 'e2', label: 'Single: Kitchen'),
+        ],
+        onLog: log.add,
+      );
+
+  test('seedSubs inserts pending children right after the parent', () {
+    final p = tracker([]);
+    p.seedSubs('e1', [('e1/bond', 'Bond 3 speakers'), ('e1/names', 'Restore room name')]);
+    expect(p.steps.map((s) => s.id), ['e1', 'e1/bond', 'e1/names', 'e2']);
+    expect(p.steps[1].parentId, 'e1');
+    expect(p.steps[1].status, ApplyStatus.pending);
+  });
+
+  test('startSub activates a seeded child and refreshes its label', () {
+    final p = tracker([]);
+    p.seedSubs('e1', [('e1/bond', 'Bond speakers')]);
+    p.start('e1');
+    p.startSub('e1', 'e1/bond', 'Bond 2 speakers + sub');
+    final bond = p.steps.firstWhere((s) => s.id == 'e1/bond');
+    expect(bond.status, ApplyStatus.active);
+    expect(bond.label, 'Bond 2 speakers + sub');
+  });
+
+  test('a conditional phase inserts before pending seeded siblings', () {
+    final p = tracker([]);
+    p.seedSubs('e1', [('e1/bond', 'Bond 3 speakers'), ('e1/names', 'Restore room name')]);
+    p.start('e1');
+    p.startSub('e1', 'e1/free', 'Free conflicting speakers');
+    expect(p.steps.map((s) => s.id), ['e1', 'e1/free', 'e1/bond', 'e1/names', 'e2']);
+  });
+
+  test('starting the next phase completes the previous one', () {
+    final p = tracker([]);
+    p.start('e1');
+    p.startSub('e1', 'e1/free', 'Free conflicting speakers');
+    p.noteActive('freeing Kitchen');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    final free = p.steps.firstWhere((s) => s.id == 'e1/free');
+    expect(free.status, ApplyStatus.done);
+    expect(free.detail, isNull); // transient verbose note cleared
+    expect(p.steps.firstWhere((s) => s.id == 'e1/bond').status,
+        ApplyStatus.active);
+  });
+
+  test('noteActive updates the active child, falls back to active parent', () {
+    final p = tracker([]);
+    p.start('e1');
+    p.noteActive('working'); // no child yet → parent
+    expect(p.steps.first.detail, 'working');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    p.noteActive('attempt 2: re-asserting');
+    expect(p.steps.firstWhere((s) => s.id == 'e1/bond').detail,
+        'attempt 2: re-asserting');
+  });
+
+  test('doneSub short-circuits the active phase with a detail', () {
+    final p = tracker([]);
+    p.start('e1');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    p.doneSub(detail: 'layout unchanged — nothing to do');
+    final bond = p.steps.firstWhere((s) => s.id == 'e1/bond');
+    expect(bond.status, ApplyStatus.done);
+    expect(bond.detail, 'layout unchanged — nothing to do');
+  });
+
+  test('parent done completes the active child and drops leftover pending ones',
+      () {
+    final p = tracker([]);
+    p.seedSubs('e1', [('e1/bond', 'Bond'), ('e1/settings', 'Restore settings')]);
+    p.start('e1');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    p.done('e1');
+    expect(p.steps.firstWhere((s) => s.id == 'e1/bond').status,
+        ApplyStatus.done);
+    expect(p.steps.any((s) => s.id == 'e1/settings'), isFalse);
+  });
+
+  test('parent fail propagates the reason to the active child', () {
+    final p = tracker([]);
+    p.start('e1');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    p.fail('e1', 'satellite never joined');
+    final bond = p.steps.firstWhere((s) => s.id == 'e1/bond');
+    expect(bond.status, ApplyStatus.failed);
+    expect(bond.detail, 'satellite never joined');
+    expect(p.steps.first.status, ApplyStatus.failed);
+  });
+
+  test('the next entity starts with a clean phase slate', () {
+    final p = tracker([]);
+    p.start('e1');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    p.done('e1');
+    p.start('e2');
+    p.noteActive('freeing'); // must land on e2, not a stale e1 child
+    expect(p.steps.firstWhere((s) => s.id == 'e2').detail, 'freeing');
+  });
+
+  test('raw log indents child lines', () {
+    final log = <String>[];
+    final p = tracker(log);
+    p.start('e1');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    expect(log.last, '  ▸ Bond 3 speakers');
+  });
+}


### PR DESCRIPTION
## What

The apply/bonding progress screen rendered one bullet per entity whose single subtitle was **overwritten** by every progress note — a one-entity apply showed one bullet + one mutating line, and multi-entity applies hid the phase sequence entirely.

Now each entity is a main milestone on a single timeline spine, with its phases as persistent sub-steps and the verbose per-attempt info as the active phase's subtitle:

- **Main step** (entity): fixed-size circle in every state — filled green + check (done), filled red + X (failed), ring + pulsing dot (busy), grey ring (pending) — with a bold label.
- **Sub-steps** (phases): uniform small dots, color-only state (green done / blue busy / red failed / grey to-do). Phases knowable from the snapshot ("Bond 5 speakers", "Restore room name", "Restore settings") are **pre-listed as pending** when the entity starts; conditional ones ("Free conflicting speakers", "Remove N changed speakers") slot in before the pending seeds when they actually fire.
- **Subtitle** on the active sub-step: the verbose progress ("attempt 2: re-asserting", "waiting for Sonos to settle"); short-circuit notes ("layout unchanged — nothing to do") stay visible on done sub-steps.

## How

- `apply_progress.dart` (pure Dart): flat list + `parentId` — tree order == list order since ops are strictly sequential. New: `seedSubs`, `startSub`, `noteActive`, `doneSub`; parent `done`/`fail` auto-closes the active child (fail propagates the reason) and drops unused pending seeds; raw log indents child lines.
- `sonos_controller.dart`: a `Phases` record (`seed`/`phase`/`note`/`endPhase`) bound per entity; wired through `_applyEntity`, `_applyHtTarget`, `_restoreSettings` and the single-op flows (HT setup, create/separate group, remove roles). `bondAndVerify`'s `onNote` contract is untouched — the engine/repository has no changes.
- `apply_progress_view.dart`: single shared spine, no indent; wider gap before each next entity groups sections; parent rows with children show label + node only.

## Testing

- `flutter analyze` clean, all 124 tests pass (10 new in `test/apply_progress_test.dart`: seeding, insertion order, auto-complete on phase transition, note routing, fail propagation, pending cleanup, log indentation).
- Verified live on real hardware (macOS app): single-entity no-op profile apply and a multi-entity apply incl. a failed entity (error carried on the failing phase sub-step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)