### PR TITLE
feat(nav): animate bottom-tab switches with M3 shared-axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Releasing: before tagging `vX.Y.Z`, rename `[Unreleased]` below to
 `[X.Y.Z] - YYYY-MM-DD`. CI copies that section into the GitHub Release notes
 (see `.github/workflows/release.yml`).
 
+## [Unreleased]
+
+### Changed
+- Switching bottom-nav tabs (System ↔ Profiles) now animates with a Material 3
+  shared-axis transition (fade + slide), sliding the way the tab bar moves.
+
 ## [0.5.0] - 2026-07-06
 
 ### Added

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Platform;
 
+import 'package:animations/animations.dart';
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -18,8 +19,13 @@ import 'features/group/group_detail_screen.dart';
 final _router = GoRouter(
   initialLocation: '/',
   routes: [
-    StatefulShellRoute.indexedStack(
+    StatefulShellRoute(
       builder: (context, state, shell) => _HomeShell(shell: shell),
+      navigatorContainerBuilder: (context, shell, children) =>
+          _AnimatedBranchContainer(
+        currentIndex: shell.currentIndex,
+        children: children,
+      ),
       branches: [
         // System: discovery + the per-device detail/flow screens.
         StatefulShellBranch(
@@ -107,6 +113,100 @@ class _HomeShell extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Renders the shell's branch navigators, cross-animating the active branch
+/// with an M3 shared-axis transition on tab switch. All branches stay mounted
+/// (Offstage) so each tab keeps its state, exactly like the old IndexedStack.
+class _AnimatedBranchContainer extends StatefulWidget {
+  final int currentIndex;
+  final List<Widget> children;
+  const _AnimatedBranchContainer({
+    required this.currentIndex,
+    required this.children,
+  });
+
+  @override
+  State<_AnimatedBranchContainer> createState() =>
+      _AnimatedBranchContainerState();
+}
+
+class _AnimatedBranchContainerState extends State<_AnimatedBranchContainer>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 300),
+    value: 1, // start settled; only tab changes drive it
+  );
+  int _previousIndex = 0;
+  bool _reverse = false;
+
+  @override
+  void didUpdateWidget(_AnimatedBranchContainer old) {
+    super.didUpdateWidget(old);
+    if (old.currentIndex != widget.currentIndex) {
+      _previousIndex = old.currentIndex;
+      // Slide the way the tab bar moves: forward to a higher index, back to a lower.
+      _reverse = widget.currentIndex < old.currentIndex;
+      _controller.forward(from: 0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final animating = _controller.isAnimating;
+        // Draw non-active branches first, active branch last so it paints on top.
+        final ordered = <Widget>[];
+        for (var i = 0; i < widget.children.length; i++) {
+          if (i == widget.currentIndex) continue;
+          ordered.add(_branch(
+            widget.children[i],
+            visible: animating && i == _previousIndex,
+            outgoing: true,
+          ));
+        }
+        ordered.add(_branch(
+          widget.children[widget.currentIndex],
+          visible: true,
+          outgoing: false,
+        ));
+        return Stack(children: ordered);
+      },
+    );
+  }
+
+  Widget _branch(Widget child, {required bool visible, required bool outgoing}) {
+    if (!visible) {
+      return Offstage(
+        offstage: true,
+        child: TickerMode(enabled: false, child: child),
+      );
+    }
+    // Forward: new slides in from the right, old exits left. Reverse mirrors it
+    // by driving the transitions backwards (ReverseAnimation), so back-navigation
+    // slides the opposite way.
+    final rev = ReverseAnimation(_controller);
+    return SharedAxisTransition(
+      animation: outgoing
+          ? (_reverse ? rev : kAlwaysCompleteAnimation)
+          : (_reverse ? kAlwaysCompleteAnimation : _controller),
+      secondaryAnimation: outgoing
+          ? (_reverse ? kAlwaysDismissedAnimation : _controller)
+          : (_reverse ? rev : kAlwaysDismissedAnimation),
+      transitionType: SharedAxisTransitionType.horizontal,
+      fillColor: Colors.transparent,
+      child: child,
     );
   }
 }


### PR DESCRIPTION
## What

Bottom-nav tab switches (System ↔ Profiles) now animate with a Material 3 **shared-axis** transition (fade + horizontal slide) instead of the instant IndexedStack swap. The slide follows the tab-bar direction — forward to a higher index, mirrored (reversed) to a lower one.

## How

- `lib/app.dart`: swap `StatefulShellRoute.indexedStack` → `StatefulShellRoute` with a `navigatorContainerBuilder`.
- New `_AnimatedBranchContainer`: keeps **all** branches mounted (`Offstage` + `TickerMode(false)`) so each tab keeps its state exactly like the old IndexedStack, and cross-animates the active branch with `SharedAxisTransition` (300ms). A `_reverse` flag (set when the new index is lower) drives the transitions backwards via `ReverseAnimation` so back-navigation mirrors the forward slide.

`animations` was already a dependency — no pubspec change. Push/back nav is untouched (already animated).

## Verify

`flutter analyze` clean, `flutter test` green (125 passing). Ran on the macOS app and confirmed both directions slide+fade correctly and tab state is preserved across switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)