### PR TITLE
Flat hairline separation for the chrome bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Releasing: before tagging `vX.Y.Z`, rename `[Unreleased]` below to
 `[X.Y.Z] - YYYY-MM-DD`. CI copies that section into the GitHub Release notes
 (see `.github/workflows/release.yml`).
 
+## [Unreleased]
+
+### Changed
+- Consistent, flat separation for the top app bar and bottom navigation bar. The
+  nav bar now shows a hairline dividing it from the page and cards (it was
+  meant to but never rendered), and the app bar matches with a hairline that
+  appears only while content scrolls under it — replacing its drop shadow, so
+  every screen's chrome reads as flat and line-based.
+
 ## [0.5.0] - 2026-07-06
 
 ### Added

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -88,6 +88,9 @@ class _HomeShell extends StatelessWidget {
       bottomNavigationBar: DecoratedBox(
         // Hairline divider so the nav bar reads as a separate surface from the
         // page behind it (dynamic-colour tones alone don't separate them).
+        // Foreground: the nav bar's opaque background would paint over a
+        // background-position border, so draw the line on top of its top edge.
+        position: DecorationPosition.foreground,
         decoration: BoxDecoration(
           border: Border(top: BorderSide(color: scheme.outlineVariant)),
         ),

--- a/lib/core/theme.dart
+++ b/lib/core/theme.dart
@@ -113,10 +113,11 @@ class AppTheme {
         backgroundColor: pageBg,
         surfaceTintColor: Colors.transparent,
         centerTitle: false,
-        // Flat at rest; a subtle shadow appears once content scrolls under it
-        // (surfaceTint stays off, so the affordance is the shadow, not a tint).
+        // Fully flat, top and bottom. The scroll-under affordance is a hairline
+        // (AppScaffold's ScrolledUnderDivider), matching the flat nav-bar line —
+        // no shadow, no tint.
         elevation: 0,
-        scrolledUnderElevation: 3,
+        scrolledUnderElevation: 0,
         shadowColor: scheme.shadow,
         titleTextStyle: TextStyle(
           color: scheme.onSurface,

--- a/lib/features/front_surrounds/front_surrounds_flow.dart
+++ b/lib/features/front_surrounds/front_surrounds_flow.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
+import '../widgets/app_scaffold.dart';
 import '../widgets/bonding_progress_screen.dart';
 import '../widgets/bondable_speaker_tile.dart';
 import '../widgets/identify_controls.dart';
@@ -120,7 +121,13 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
     ];
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Set up home theater')),
+      appBar: AppBar(
+        title: const Text('Set up home theater'),
+        bottom: const PreferredSize(
+          preferredSize: Size.fromHeight(1),
+          child: ScrolledUnderDivider(),
+        ),
+      ),
       body: SafeArea(
         child: Stepper(
           currentStep: _step,

--- a/lib/features/widgets/app_scaffold.dart
+++ b/lib/features/widgets/app_scaffold.dart
@@ -47,6 +47,11 @@ class AppScaffold extends StatelessWidget {
     }
     return Scaffold(
       appBar: AppBar(
+        scrolledUnderElevation: 0,
+        bottom: const PreferredSize(
+          preferredSize: Size.fromHeight(1),
+          child: ScrolledUnderDivider(),
+        ),
         title: titleWidget ??
             (subtitle == null
                 ? Text(title)
@@ -84,6 +89,61 @@ class AppScaffold extends StatelessWidget {
                 ],
               ),
       ),
+    );
+  }
+}
+
+/// A 1px hairline for an [AppBar.bottom] that fades in only while content is
+/// scrolled under the app bar — the flat, line-based equivalent of the M3
+/// scroll-under shadow. Mirrors [AppBar]'s own detection
+/// ([ScrollNotificationObserver] + `metrics.extentBefore`), so its timing
+/// matches the shadow it replaces. Constant height ⇒ no layout jump; only the
+/// colour animates.
+class ScrolledUnderDivider extends StatefulWidget {
+  const ScrolledUnderDivider({super.key});
+
+  @override
+  State<ScrolledUnderDivider> createState() => _ScrolledUnderDividerState();
+}
+
+class _ScrolledUnderDividerState extends State<ScrolledUnderDivider> {
+  ScrollNotificationObserverState? _observer;
+  bool _under = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _observer?.removeListener(_onScroll);
+    _observer = ScrollNotificationObserver.maybeOf(context);
+    _observer?.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _observer?.removeListener(_onScroll);
+    _observer = null;
+    super.dispose();
+  }
+
+  void _onScroll(ScrollNotification notification) {
+    if (!defaultScrollNotificationPredicate(notification)) return;
+    if (notification is! ScrollUpdateNotification &&
+        notification is! ScrollMetricsNotification) {
+      return;
+    }
+    if (notification.metrics.axis != Axis.vertical) return;
+    final under = notification.metrics.extentBefore > 0;
+    if (under != _under) setState(() => _under = under);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 150),
+      height: 1,
+      color: _under
+          ? Theme.of(context).colorScheme.outlineVariant
+          : Colors.transparent,
     );
   }
 }

--- a/lib/features/widgets/bonding_progress_screen.dart
+++ b/lib/features/widgets/bonding_progress_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/theme.dart';
 import '../../data/sonos/cancellation.dart';
 import '../../state/sonos_controller.dart';
+import 'app_scaffold.dart';
 import 'apply_progress_view.dart';
 
 /// How a bonding operation ended, returned by [showBondingProgress].
@@ -135,6 +136,10 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
         // Fixed app bar, matching the rest of the app's pages.
         appBar: AppBar(
           automaticallyImplyLeading: false,
+          bottom: const PreferredSize(
+            preferredSize: Size.fromHeight(1),
+            child: ScrolledUnderDivider(),
+          ),
           title: Text(widget.title),
           actions: [
             IconButton(

--- a/test/scrolled_under_divider_test.dart
+++ b/test/scrolled_under_divider_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/core/theme.dart';
+import 'package:sonority/features/widgets/app_scaffold.dart';
+
+void main() {
+  Color dividerColor(WidgetTester tester) {
+    final container = tester.widget<Container>(
+      find.descendant(
+        of: find.byType(ScrolledUnderDivider),
+        matching: find.byType(Container),
+      ),
+    );
+    return container.color ?? (container.decoration as BoxDecoration).color!;
+  }
+
+  testWidgets('app-bar hairline is transparent at rest, outlineVariant on scroll',
+      (tester) async {
+    final theme = AppTheme.light();
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: AppScaffold(
+        title: 'Test',
+        body: ListView(
+          children:
+              List.generate(50, (i) => SizedBox(height: 80, child: Text('$i'))),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(dividerColor(tester), Colors.transparent);
+
+    await tester.drag(find.byType(ListView), const Offset(0, -300));
+    await tester.pumpAndSettle();
+
+    expect(dividerColor(tester), theme.colorScheme.outlineVariant);
+  });
+}


### PR DESCRIPTION
## Why

On the System page the bottom nav bar blended into the page/cards — no visible separation. Turned out the nav bar's top hairline **never rendered**: the `DecoratedBox` painted its border *behind* the opaque `NavigationBar` (`DecorationPosition.background`). Also inconsistent: the app bar had no separator at rest and grew a *shadow* on scroll, while the nav bar was meant to be a static line.

Decision (with the user): keep it **flat and line-based** everywhere, matching the group-screen header divider and the card outlines.

## What

- **`app.dart`** — draw the nav-bar top hairline in the foreground so it actually shows.
- **`app_scaffold.dart`** — new `ScrolledUnderDivider`: a 1px hairline for `AppBar.bottom` that fades in only while content is scrolled under, using the same `ScrollNotificationObserver` mechanism M3's `AppBar` uses (so timing matches the shadow it replaces). Constant height ⇒ no layout jump; only the colour animates.
- **`theme.dart`** — `scrolledUnderElevation: 0` globally: every chrome bar is now flat.
- **`front_surrounds_flow.dart`, `bonding_progress_screen.dart`** — same line on their raw AppBars. `group_flow` left as-is (already has its own header divider).

## Verification

- `flutter analyze` clean, full test suite green.
- New widget test (`test/scrolled_under_divider_test.dart`): divider is transparent at rest, `outlineVariant` after a scroll.
- Visual on the macOS proxy: nav-bar hairline now clearly visible; app bar flat at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)