### PR TITLE
feat(profiles): rename EQ capture to "audio settings" + card polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Releasing: before tagging `vX.Y.Z`, rename `[Unreleased]` below to
 ## [Unreleased]
 
 ### Changed
+- Profiles: the EQ capture toggle is now **"Save audio settings"** — the label
+  undersold a bundle that also covers night sound, speech enhancement, sub &
+  surround levels and lip sync. Profile cards now show separate **Audio
+  settings** / **Volume** badges (instead of one combined "EQ" line) and use an
+  icon-only play button with a bit more breathing room.
 - The macOS `.dmg` download now opens a styled drag-to-Applications install
   window — the app icon, an arrow, and an Applications shortcut over a branded
   background — instead of a bare disk image.

--- a/lib/data/sonos/speaker_settings.dart
+++ b/lib/data/sonos/speaker_settings.dart
@@ -66,12 +66,12 @@ class SpeakerSettings {
 
   static const empty = SpeakerSettings();
 
-  bool get hasEq =>
+  bool get hasAudioSettings =>
       bass != null || treble != null || loudness != null || eq.isNotEmpty;
 
   bool get hasVolume => volume != null || mute != null;
 
-  bool get isEmpty => !hasEq && !hasVolume;
+  bool get isEmpty => !hasAudioSettings && !hasVolume;
 
   /// Serializes only the non-null/non-empty fields, so an EQ-only capture
   /// doesn't store bogus volume keys and old profiles round-trip cleanly.
@@ -106,13 +106,14 @@ class SpeakerSettingsClient {
   static const _service = 'urn:schemas-upnp-org:service:RenderingControl:1';
   static const _control = '/MediaRenderer/RenderingControl/Control';
 
-  /// Reads a settings snapshot for the speaker at [ip]. [eq] captures the EQ
-  /// bundle (bass/treble/loudness + every [eqTypes] token the speaker answers);
-  /// [volume] captures volume/mute. The two are independent toggles.
+  /// Reads a settings snapshot for the speaker at [ip]. [audio] captures the
+  /// audio-settings bundle (bass/treble/loudness + every [eqTypes] token the
+  /// speaker answers); [volume] captures volume/mute. The two are independent
+  /// toggles.
   Future<SpeakerSettings> read(String ip,
-      {bool eq = true, bool volume = false}) async {
+      {bool audio = true, bool volume = false}) async {
     final eqValues = <String, int>{};
-    if (eq) {
+    if (audio) {
       for (final t in eqTypes) {
         final v = await _readInt(ip, 'GetEQ', 'CurrentValue',
             extra: {'EQType': t});
@@ -120,9 +121,9 @@ class SpeakerSettingsClient {
       }
     }
     return SpeakerSettings(
-      bass: eq ? await _readInt(ip, 'GetBass', 'CurrentBass') : null,
-      treble: eq ? await _readInt(ip, 'GetTreble', 'CurrentTreble') : null,
-      loudness: eq
+      bass: audio ? await _readInt(ip, 'GetBass', 'CurrentBass') : null,
+      treble: audio ? await _readInt(ip, 'GetTreble', 'CurrentTreble') : null,
+      loudness: audio
           ? await _readBool(ip, 'GetLoudness', 'CurrentLoudness',
               extra: const {'Channel': 'Master'})
           : null,

--- a/lib/features/profiles/profile.dart
+++ b/lib/features/profiles/profile.dart
@@ -101,14 +101,14 @@ class EntitySnapshot {
         settings: settings ?? this.settings,
       );
 
-  /// A short label for the UI describing what audio settings are captured, or
-  /// `''` when none — appended to [entitySummary] on the tiles.
+  /// A short label for the UI describing what settings are captured, or `''`
+  /// when none — appended to [entitySummary] on the tiles.
   String get settingsSummary {
     final vals = settings.values;
-    final eq = vals.any((s) => s.hasEq);
+    final audio = vals.any((s) => s.hasAudioSettings);
     final vol = vals.any((s) => s.hasVolume);
-    if (eq && vol) return 'EQ + volume saved';
-    if (eq) return 'EQ saved';
+    if (audio && vol) return 'Audio settings + volume saved';
+    if (audio) return 'Audio settings saved';
     if (vol) return 'Volume saved';
     return '';
   }
@@ -145,17 +145,12 @@ class Profile {
 
   const Profile({required this.id, required this.name, required this.entities});
 
-  /// Aggregated across entities: what audio settings this profile carries, or
-  /// `''` when none.
-  String get settingsSummary {
-    final all = entities.expand((e) => e.settings.values);
-    final eq = all.any((s) => s.hasEq);
-    final vol = all.any((s) => s.hasVolume);
-    if (eq && vol) return 'EQ + volume saved';
-    if (eq) return 'EQ saved';
-    if (vol) return 'Volume saved';
-    return '';
-  }
+  /// Aggregated across entities — drive the badges on the profile tile.
+  bool get hasAudioSettings =>
+      entities.any((e) => e.settings.values.any((s) => s.hasAudioSettings));
+
+  bool get hasVolume =>
+      entities.any((e) => e.settings.values.any((s) => s.hasVolume));
 
   Profile copyWith({String? name, List<EntitySnapshot>? entities}) => Profile(
         id: id,

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -31,7 +31,7 @@ class _State extends ConsumerState<ProfileCreateScreen> {
   final List<EntitySnapshot> _entities = [];
   final Map<String, bool> _included = {};
   bool _seeded = false;
-  bool _saveEq = false;
+  bool _saveAudio = false;
   bool _saveVolume = false;
   bool _saving = false;
 
@@ -213,15 +213,16 @@ class _State extends ConsumerState<ProfileCreateScreen> {
                 // the card, so the ink highlight matches (top tile → top corners,
                 // bottom tile → bottom corners; the divider edge stays square).
                 SwitchListTile(
-                  value: _saveEq,
-                  onChanged: (v) => setState(() => _saveEq = v),
+                  value: _saveAudio,
+                  onChanged: (v) => setState(() => _saveAudio = v),
                   shape: const RoundedRectangleBorder(
                       borderRadius:
                           BorderRadius.vertical(top: Radius.circular(12))),
-                  secondary: const Icon(Icons.equalizer),
-                  title: const Text('Save EQ settings'),
+                  secondary: const Icon(Icons.tune),
+                  title: const Text('Save audio settings'),
                   subtitle: const Text(
-                      'Bass, treble, loudness, night sound, speech, sub & surround level'),
+                      'EQ, night sound, speech enhancement, sub & surround '
+                      'levels, lip sync & more'),
                 ),
                 const Divider(height: 1),
                 SwitchListTile(
@@ -277,14 +278,14 @@ class _State extends ConsumerState<ProfileCreateScreen> {
       if (ok != true) return;
     }
 
-    // Reading EQ/volume is several SOAP calls per speaker — show progress and
+    // Reading settings is several SOAP calls per speaker — show progress and
     // enrich the snapshots before saving.
-    if (_saveEq || _saveVolume) {
+    if (_saveAudio || _saveVolume) {
       setState(() => _saving = true);
       try {
         chosen = await ref
             .read(sonosControllerProvider.notifier)
-            .captureSettings(chosen, eq: _saveEq, volume: _saveVolume);
+            .captureSettings(chosen, audio: _saveAudio, volume: _saveVolume);
       } finally {
         if (mounted) setState(() => _saving = false);
       }

--- a/lib/features/profiles/profiles_screen.dart
+++ b/lib/features/profiles/profiles_screen.dart
@@ -133,14 +133,13 @@ class _ProfileTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final summary = profile.entities.map((e) => e.label).join(' · ');
-    final settings = profile.settingsSummary;
     return Card(
       margin: EdgeInsets.zero,
       child: InkWell(
         borderRadius: BorderRadius.circular(20),
         onTap: onEdit,
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
+          padding: const EdgeInsets.fromLTRB(16, 16, 8, 16),
           child: Row(
             children: [
               Expanded(
@@ -157,16 +156,18 @@ class _ProfileTile extends StatelessWidget {
                         color: theme.colorScheme.onSurfaceVariant,
                       ),
                     ),
-                    if (settings.isNotEmpty) ...[
-                      Gap.xs,
-                      Row(
+                    if (profile.hasAudioSettings || profile.hasVolume) ...[
+                      Gap.s,
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
                         children: [
-                          Icon(Icons.equalizer,
-                              size: 14, color: theme.colorScheme.primary),
-                          Gap.xs,
-                          Text(settings,
-                              style: theme.textTheme.labelSmall?.copyWith(
-                                  color: theme.colorScheme.primary)),
+                          if (profile.hasAudioSettings)
+                            const _Badge(
+                                icon: Icons.tune, label: 'Audio settings'),
+                          if (profile.hasVolume)
+                            const _Badge(
+                                icon: Icons.volume_up, label: 'Volume'),
                         ],
                       ),
                     ],
@@ -174,14 +175,10 @@ class _ProfileTile extends StatelessWidget {
                 ),
               ),
               Gap.s,
-              FilledButton.icon(
+              IconButton.filled(
                 onPressed: onApply,
-                icon: const Icon(Icons.play_arrow, size: 20),
-                label: const Text('Apply'),
-                style: FilledButton.styleFrom(
-                  minimumSize: const Size(0, 40),
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                ),
+                tooltip: 'Apply',
+                icon: const Icon(Icons.play_arrow),
               ),
               PopupMenuButton<String>(
                 onSelected: (v) => v == 'edit' ? onEdit() : onDelete(),
@@ -193,6 +190,38 @@ class _ProfileTile extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Small pill on the profile tile marking what captured settings it carries.
+class _Badge extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  const _Badge({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: theme.colorScheme.onSecondaryContainer),
+          Gap.xs,
+          Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSecondaryContainer,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -108,23 +108,23 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
 
   final _settings = SpeakerSettingsClient();
 
-  /// Reads each entity's per-speaker audio settings ([eq] bundle and/or [volume])
+  /// Reads each entity's per-speaker settings ([audio] bundle and/or [volume])
   /// and returns copies enriched with a `settings` map. Called by
   /// the create flow when the user opts into saving speaker settings; keeps the
   /// SOAP reads off the widget. Speakers not currently on the network are simply
   /// skipped (nothing to read).
   Future<List<EntitySnapshot>> captureSettings(
       List<EntitySnapshot> entities,
-      {required bool eq, required bool volume}) async {
+      {required bool audio, required bool volume}) async {
     final sys = state.value;
-    if (sys == null || (!eq && !volume)) return entities;
+    if (sys == null || (!audio && !volume)) return entities;
     final out = <EntitySnapshot>[];
     for (final e in entities) {
       final map = <String, SpeakerSettings>{};
       for (final uuid in e.involvedUuids) {
         final ip = sys.device(uuid)?.ip;
         if (ip == null) continue;
-        final s = await _settings.read(ip, eq: eq, volume: volume);
+        final s = await _settings.read(ip, audio: audio, volume: volume);
         if (!s.isEmpty) map[uuid] = s;
       }
       out.add(map.isEmpty ? e : e.copyWith(settings: map));
@@ -148,7 +148,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       }
       final s = entry.value;
       final what = [
-        if (s.hasEq) 'EQ',
+        if (s.hasAudioSettings) 'audio settings',
         if (s.hasVolume) 'volume',
       ].join(' + ');
       ph.note('restoring $what — ${dev!.typeLabel}');

--- a/test/profile_test.dart
+++ b/test/profile_test.dart
@@ -89,8 +89,9 @@ void main() {
     expect(s.loudness, isTrue);
     expect(s.volume, 25);
     expect(s.eq, {'NightMode': 1, 'AudioDelay': 2});
-    expect(back.entities.first.settingsSummary, 'EQ + volume saved');
-    expect(back.settingsSummary, 'EQ + volume saved');
+    expect(back.entities.first.settingsSummary, 'Audio settings + volume saved');
+    expect(back.hasAudioSettings, isTrue);
+    expect(back.hasVolume, isTrue);
   });
 
   test('legacy profile without a settings key deserializes to empty', () {
@@ -113,10 +114,10 @@ void main() {
     expect(back.entities.first.toJson().containsKey('settings'), isFalse);
   });
 
-  test('settingsSummary reflects EQ-only vs volume-only', () {
+  test('settingsSummary reflects audio-only vs volume-only', () {
     final base = EntitySnapshot.fromMember(ZoneGroupMember(uuid: fl, zoneName: 'x'));
     expect(base.copyWith(settings: {fl: const SpeakerSettings(bass: 1)}).settingsSummary,
-        'EQ saved');
+        'Audio settings saved');
     expect(
         base.copyWith(settings: {fl: const SpeakerSettings(volume: 10)}).settingsSummary,
         'Volume saved');

--- a/test/speaker_settings_test.dart
+++ b/test/speaker_settings_test.dart
@@ -61,14 +61,14 @@ void main() {
     expect(s.mute, isFalse);
   });
 
-  test('read skips EQ when eq:false, volume when volume:false', () async {
+  test('read skips audio when audio:false, volume when volume:false', () async {
     final fake = _FakeSoap({'GetBass': '5', 'GetVolume': '22'});
     final volOnly = await SpeakerSettingsClient(fake).read('1.2.3.4',
-        eq: false, volume: true);
+        audio: false, volume: true);
     expect(volOnly.bass, isNull);
     expect(volOnly.eq, isEmpty);
     expect(volOnly.volume, 22);
-    expect(volOnly.hasEq, isFalse);
+    expect(volOnly.hasAudioSettings, isFalse);
 
     final eqOnly = await SpeakerSettingsClient(fake).read('1.2.3.4');
     expect(eqOnly.bass, 5);


### PR DESCRIPTION
## What

The profile capture toggle labelled **"Save EQ settings"** undersold what it captures — the bundle also includes night sound, speech enhancement, sub & surround levels, lip sync delay and height channel, not just EQ. This generalizes the user-facing wording to **"audio settings"** and polishes the profile card.

## Changes

- **Toggle** → "Save audio settings" (icon `tune`), with a subtitle listing "EQ, night sound, speech enhancement, sub & surround levels, lip sync & more". Volume stays a separate toggle.
- **Profile card**: the single combined "EQ + volume saved" line becomes two separate pill badges — **Audio settings** and **Volume**. The text "Apply" button is now an icon-only filled play button, and the card has a bit more breathing room.
- **Internal naming**: renamed at the semantic layer (`SpeakerSettings.hasAudioSettings`, `read(audio:)`, `captureSettings(audio:)`, `_saveAudio`). Wire-level names (`eqTypes`, the `eq` token map) and persisted JSON keys (`'eq'`, `'settings'`) are unchanged, so existing saved profiles keep loading.

## Testing

- `flutter analyze` clean, `flutter test` green (updated `profile_test`, `speaker_settings_test`).
- Verified the card layout on the macOS proxy (build → launch → screenshot Profiles tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)