### PR TITLE
fix(discovery): unicast :1400 subnet sweep when SSDP multicast fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ Releasing: before tagging `vX.Y.Z`, rename `[Unreleased]` below to
   appears only while content scrolls under it — replacing its drop shadow, so
   every screen's chrome reads as flat and line-based.
 
+### Fixed
+- **Discovery on iPhone** — the TestFlight build could hang on "Scanning your
+  network" and fail: real iPhones silently block the multicast discovery
+  packets (a restricted Apple entitlement the app doesn't carry; the simulator
+  doesn't enforce it). When multicast finds nothing, discovery now falls back
+  to directly probing the local network for Sonos players — which only needs
+  the local-network permission the app already asks for. This also helps
+  mesh/guest networks that filter multicast.
+
 ## [0.5.0] - 2026-07-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,20 @@ Run on the same Wi-Fi as the Sonos system:
 ## Platform notes
 - iOS: `Info.plist` has `NSLocalNetworkUsageDescription` + `NSBonjourServices`
   (mandatory on iOS 14+ or all LAN traffic is silently blocked).
+- **iOS device multicast is blocked (cost a real TestFlight bug):** physical
+  iPhones silently drop multicast sends (SSDP M-SEARCH) unless the app carries
+  the *restricted* `com.apple.developer.networking.multicast` entitlement —
+  the iOS target has no entitlements file. Simulator doesn't enforce it (sim
+  worked, device didn't); the local-network permission prompt covers unicast
+  only. Fix: `SsdpDiscovery.discover()` falls back to a unicast TCP :1400
+  sweep of each interface's /24 (assumed /24 — `dart:io` exposes no netmask;
+  ~600ms, one hit suffices since topology recovers the rest). Also helps
+  multicast-filtering mesh/guest networks. **Future improvement:** request the
+  multicast entitlement from Apple (developer.apple.com → "Multicast Networking
+  Entitlement Request", days–weeks), enable the capability on the App ID, add
+  `ios/Runner/Runner.entitlements` + `CODE_SIGN_ENTITLEMENTS` in the pbxproj,
+  regenerate match profiles (`docs/SIGNING.md`) — restores native SSDP on
+  device; keep the sweep as fallback regardless.
 - macOS: entitlements include `network.client` + `network.server`; window is locked
   to a fixed **420×880 portrait** (`MainFlutterWindow.swift`) so the UI only ever
   handles one mobile layout.

--- a/lib/data/sonos/ssdp_discovery.dart
+++ b/lib/data/sonos/ssdp_discovery.dart
@@ -8,6 +8,13 @@ import 'dart:io';
 /// multicast group `239.255.255.250:1900` and collect `LOCATION` headers from
 /// the unicast replies. Each location points at a player's
 /// `http://<ip>:1400/xml/device_description.xml`.
+///
+/// If SSDP yields nothing we fall back to a unicast sweep of the local /24
+/// on TCP port 1400. Multicast sends silently fail on physical iPhones
+/// (they need the restricted `com.apple.developer.networking.multicast`
+/// entitlement; unicast only needs the local-network permission) and are
+/// filtered by some mesh/guest networks. One hit is enough — the repository
+/// recovers the rest of the system from topology.
 class SsdpDiscovery {
   static final InternetAddress _multicast = InternetAddress('239.255.255.250');
   static const int _port = 1900;
@@ -49,6 +56,33 @@ class SsdpDiscovery {
     } finally {
       socket?.close();
     }
+    if (locations.isEmpty) return _scanSubnet();
+    return locations;
+  }
+
+  /// Unicast fallback: probe every /24 neighbour on TCP :1400 and synthesize
+  /// the same description URLs SSDP would have returned.
+  Future<Set<String>> _scanSubnet() async {
+    final locations = <String>{};
+    final interfaces = await NetworkInterface.list(
+      type: InternetAddressType.IPv4,
+      includeLoopback: false,
+    );
+    final candidates = <String>{
+      for (final i in interfaces)
+        for (final a in i.addresses)
+          if (!a.address.startsWith('169.254.')) ...subnetHosts(a.address),
+    };
+    await Future.wait(candidates.map((ip) async {
+      try {
+        final s = await Socket.connect(ip, 1400,
+            timeout: const Duration(milliseconds: 600));
+        s.destroy();
+        locations.add('http://$ip:1400/xml/device_description.xml');
+      } catch (_) {
+        // Not a Sonos player (or not up) — skip.
+      }
+    }));
     return locations;
   }
 
@@ -60,6 +94,19 @@ class SsdpDiscovery {
         'ST: $_searchTarget\r\n'
         '\r\n';
     return msg.codeUnits;
+  }
+
+  /// The other hosts of [ip]'s /24 (`.1`–`.254`, excluding [ip] itself).
+  // ponytail: dart:io exposes no netmask — assume /24. On a wider subnet the
+  // sweep still succeeds if ANY player shares this /24 slice (topology
+  // recovers the rest); only all-players-outside-the-slice fails. If that
+  // bites, add real netmask detection (platform channel / getifaddrs).
+  static List<String> subnetHosts(String ip) {
+    final prefix = ip.substring(0, ip.lastIndexOf('.'));
+    return [
+      for (var h = 1; h <= 254; h++)
+        if ('$prefix.$h' != ip) '$prefix.$h',
+    ];
   }
 
   String? _extractLocation(String response) {

--- a/test/ssdp_discovery_test.dart
+++ b/test/ssdp_discovery_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/data/sonos/ssdp_discovery.dart';
+
+void main() {
+  test('subnetHosts enumerates the /24 minus self and .0/.255', () {
+    final hosts = SsdpDiscovery.subnetHosts('192.168.1.42');
+    expect(hosts, hasLength(253));
+    expect(hosts.first, '192.168.1.1');
+    expect(hosts.last, '192.168.1.254');
+    expect(hosts, isNot(contains('192.168.1.42')));
+    expect(hosts, isNot(contains('192.168.1.0')));
+    expect(hosts, isNot(contains('192.168.1.255')));
+    expect(hosts, isNot(contains('192.168.2.1')));
+  });
+}


### PR DESCRIPTION
## Problem

The TestFlight build on a real iPhone hangs on "Scanning your network" and fails, while the simulator works. Root cause: discovery is SSDP multicast only, and physical iPhones (iOS 14+) silently drop multicast sends unless the app carries the **restricted** `com.apple.developer.networking.multicast` entitlement — the iOS target has no entitlements file at all. The simulator doesn't enforce this, and the local-network permission prompt only covers unicast.

## Fix

When SSDP returns nothing, `SsdpDiscovery.discover()` falls back to a unicast sweep: probe every /24 neighbour of each IPv4 interface on TCP :1400 (600 ms timeout, all concurrent, ~1 s total) and synthesize the same `device_description.xml` URLs SSDP would return. One hit suffices — topology recovers every other member; non-Sonos false positives are dropped by the existing description-fetch handling. The fix lives in the shared class, so the app and all `tool/*.dart` CLIs get it with zero call-site changes. Also helps mesh/guest networks that filter multicast.

/24 is assumed (dart:io exposes no netmask): over-probing on smaller subnets is harmless; wider subnets still work if any player shares the phone's /24 slice. Ceiling documented in a `ponytail:` comment.

Future improvement (documented in CLAUDE.md): request the multicast entitlement from Apple to restore native SSDP on device; the sweep stays as fallback regardless.

## Validation

- `flutter analyze` clean, all 134 tests pass (new unit test for the /24 enumeration).
- Read-only hardware check on the real LAN: the sweep found all 11 Sonos players' :1400 ports in 635 ms.
- Real proof pending: next TestFlight build on a physical iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)