### PR TITLE
feat(ui): tappable version chip opens version/changelog dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Releasing: before tagging `vX.Y.Z`, rename `[Unreleased]` below to
   on Android, a matching SF Symbol on iOS).
 
 ### Changed
+- The **version chip** in the app bar is now tappable — it opens a dialog with
+  the full version and build number, this changelog, and a link to the GitHub
+  project.
 - The apply progress timeline now marks no-op steps as **skipped** (grey dot +
   reason, e.g. "layout unchanged — nothing to do", "name unchanged — nothing to
   do") instead of showing them as completed work, so a re-apply that changed

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -52,5 +52,12 @@
             <data
                 android:mimeType="text/plain"/>
         </intent>
+        <!-- url_launcher: open https links (GitHub button in the version dialog). -->
+        <intent>
+            <action
+                android:name="android.intent.action.VIEW"/>
+            <data
+                android:scheme="https"/>
+        </intent>
     </queries>
 </manifest>

--- a/lib/features/widgets/version_badge.dart
+++ b/lib/features/widgets/version_badge.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+const _repoUrl = 'https://github.com/CasperVerswijvelt/Sonority';
 
 /// Muted `v<version>` label for an app-bar `actions:` slot. Reads the built
-/// package version at runtime so it tracks pubspec automatically.
+/// package version at runtime so it tracks pubspec automatically. Tapping it
+/// opens a dialog with the full version, the changelog and a GitHub link.
 class VersionBadge extends StatelessWidget {
   const VersionBadge({super.key});
 
@@ -13,31 +18,208 @@ class VersionBadge extends StatelessWidget {
     return FutureBuilder<PackageInfo>(
       future: _info,
       builder: (context, snap) {
-        final v = snap.data?.version;
-        if (v == null) return const SizedBox.shrink();
-        final scheme = Theme.of(context).colorScheme;
+        final info = snap.data;
+        if (info == null) return const SizedBox.shrink();
         return Padding(
           padding: const EdgeInsets.only(right: 12),
           child: Center(
-            child: Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-              decoration: BoxDecoration(
-                color: scheme.onSurface.withValues(alpha: 0.06),
-                borderRadius: BorderRadius.circular(20),
-              ),
-              child: Text(
-                'v$v',
-                style: TextStyle(
-                  color: scheme.onSurfaceVariant,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
+            child: _VersionPill(
+              'v${info.version}',
+              onTap: () => showVersionDialog(context, info),
             ),
           ),
         );
       },
+    );
+  }
+}
+
+/// The muted rounded pill, shared by the app-bar badge and the dialog header.
+class _VersionPill extends StatelessWidget {
+  const _VersionPill(this.text, {this.onTap});
+  final String text;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.onSurface.withValues(alpha: 0.06),
+      borderRadius: BorderRadius.circular(20),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+          child: Text(
+            text,
+            style: TextStyle(
+              color: scheme.onSurfaceVariant,
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Version + changelog dialog opened by tapping the [VersionBadge].
+Future<void> showVersionDialog(BuildContext context, PackageInfo info) {
+  return showDialog<void>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          const Text('Sonority'),
+          _VersionPill(fullVersionLabel(info)),
+        ],
+      ),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Flexible(
+              child: FutureBuilder<String>(
+                future: rootBundle.loadString('CHANGELOG.md'),
+                builder: (ctx, snap) {
+                  final md = snap.data;
+                  if (md == null) return const SizedBox.shrink();
+                  return SingleChildScrollView(
+                    child: _ChangelogView(parseChangelog(md)),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => launchUrl(
+            Uri.parse(_repoUrl),
+            mode: LaunchMode.externalApplication,
+          ),
+          child: const Text('GitHub'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(ctx),
+          child: const Text('Close'),
+        ),
+      ],
+    ),
+  );
+}
+
+/// `v0.5.0-8` — version plus the rebuild counter, decoded from the build
+/// number per docs/PUBLISHING.md (`N = major*1000000 + minor*10000 +
+/// patch*100 + build`). Falls back to the raw build number if N doesn't fit
+/// that scheme.
+String fullVersionLabel(PackageInfo info) {
+  final parts = info.version.split('.').map(int.tryParse).toList();
+  final n = int.tryParse(info.buildNumber);
+  if (parts.length == 3 && !parts.contains(null) && n != null) {
+    final build =
+        n - (parts[0]! * 1000000 + parts[1]! * 10000 + parts[2]! * 100);
+    if (build >= 0 && build < 100) return 'v${info.version}-$build';
+  }
+  return 'v${info.version} (${info.buildNumber})';
+}
+
+enum ChangelogKind { release, section, bullet }
+
+class ChangelogEntry {
+  ChangelogEntry(this.kind, this.text);
+  final ChangelogKind kind;
+  String text;
+}
+
+/// Line-based parser for this repo's Keep-a-Changelog format: `## [x.y.z] - date`
+/// releases, `### Added/Changed/…` sections and `-` bullets (with wrapped
+/// continuation lines joined). The file preamble, `**` emphasis, and headers
+/// with no bullets under them (e.g. an empty `[Unreleased]`) are dropped.
+/// ponytail: covers exactly the shapes CHANGELOG.md uses; grow it (or swap in a
+/// markdown package) only if the file's format grows.
+List<ChangelogEntry> parseChangelog(String markdown) {
+  final entries = <ChangelogEntry>[];
+  for (final raw in markdown.split('\n')) {
+    final line = raw.trimRight();
+    if (line.startsWith('## ')) {
+      final m = RegExp(r'^## \[(.+?)\](?:\s*-\s*(.+))?$').firstMatch(line);
+      final text = m == null
+          ? line.substring(3)
+          : (m[2] == null ? m[1]! : '${m[1]} — ${m[2]}');
+      entries.add(ChangelogEntry(ChangelogKind.release, text));
+    } else if (entries.isEmpty) {
+      // Preamble before the first release header.
+    } else if (line.startsWith('### ')) {
+      entries.add(ChangelogEntry(ChangelogKind.section, line.substring(4)));
+    } else if (line.startsWith('- ')) {
+      entries.add(ChangelogEntry(ChangelogKind.bullet, line.substring(2)));
+    } else if (line.startsWith('  ') &&
+        entries.last.kind == ChangelogKind.bullet) {
+      entries.last.text += ' ${line.trim()}';
+    }
+  }
+  for (final e in entries) {
+    e.text = e.text.replaceAll('**', '');
+  }
+  // Walk bottom-up so each header knows whether any bullets sit under it.
+  final kept = <ChangelogEntry>[];
+  var bulletsInSection = false;
+  var bulletsInRelease = false;
+  for (final e in entries.reversed) {
+    switch (e.kind) {
+      case ChangelogKind.bullet:
+        bulletsInSection = bulletsInRelease = true;
+        kept.add(e);
+      case ChangelogKind.section:
+        if (bulletsInSection) kept.add(e);
+        bulletsInSection = false;
+      case ChangelogKind.release:
+        if (bulletsInRelease) kept.add(e);
+        bulletsInSection = bulletsInRelease = false;
+    }
+  }
+  return kept.reversed.toList();
+}
+
+class _ChangelogView extends StatelessWidget {
+  const _ChangelogView(this.entries);
+  final List<ChangelogEntry> entries;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Theme.of(context).textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final e in entries)
+          switch (e.kind) {
+            ChangelogKind.release => Padding(
+                padding: const EdgeInsets.only(top: 16, bottom: 2),
+                child: Text(e.text, style: text.titleMedium),
+              ),
+            ChangelogKind.section => Padding(
+                padding: const EdgeInsets.only(top: 8, bottom: 4),
+                child: Text(e.text, style: text.labelLarge),
+              ),
+            ChangelogKind.bullet => Padding(
+                padding: const EdgeInsets.only(bottom: 4),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('•  '),
+                    Expanded(child: Text(e.text, style: text.bodySmall)),
+                  ],
+                ),
+              ),
+          },
+      ],
     );
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,9 +8,11 @@ import Foundation
 import dynamic_color
 import package_info_plus
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -7,12 +7,15 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
 
 DEPENDENCIES:
   - dynamic_color (from `Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
 
 EXTERNAL SOURCES:
   dynamic_color:
@@ -23,12 +26,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
   dynamic_color: cb7c2a300ee67ed3bd96c3e852df3af0300bf610
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -756,6 +756,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.6"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   shared_preferences: ^2.5.5
   animations: ^2.2.0
   package_info_plus: ^8.0.0
+  url_launcher: ^6.3.0
   # SF Symbols for the profile glyph on iOS (matches the native quick-action
   # icon). Android keeps Material icons. See profile_ui.dart `profileGlyph`.
   flutter_sficon: ^1.3.0
@@ -104,6 +105,8 @@ flutter:
 
   assets:
     - assets/brand/
+    # Shown in the version dialog (tap the app-bar version chip).
+    - CHANGELOG.md
 
   # To add assets to your application, add an assets section, like this:
   # assets:

--- a/test/changelog_parser_test.dart
+++ b/test/changelog_parser_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:sonority/features/widgets/version_badge.dart';
+
+const _sample = '''
+# Changelog
+
+All notable changes are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+## [0.5.0] - 2026-07-06
+
+### Added
+- **Dual Subs** — a home theater can now bond **two Subs**, with both shown
+  in the layout diagram and re-applied from a profile.
+- Room renaming.
+
+### Changed
+- Discovery auto-scans on launch.
+
+## [0.4.0] - 2026-06-28
+
+### Notes
+- Sonos invalidates Trueplay when the bonded set changes.
+''';
+
+void main() {
+  test('parses releases, sections and wrapped bullets; drops preamble and '
+      'empty sections', () {
+    final entries = parseChangelog(_sample);
+    final rendered =
+        entries.map((e) => '${e.kind.name}: ${e.text}').toList();
+    expect(rendered, [
+      'release: 0.5.0 — 2026-07-06',
+      'section: Added',
+      'bullet: Dual Subs — a home theater can now bond two Subs, with both '
+          'shown in the layout diagram and re-applied from a profile.',
+      'bullet: Room renaming.',
+      'section: Changed',
+      'bullet: Discovery auto-scans on launch.',
+      'release: 0.4.0 — 2026-06-28',
+      'section: Notes',
+      'bullet: Sonos invalidates Trueplay when the bonded set changes.',
+    ]);
+  });
+
+  test('parses the real CHANGELOG format markers', () {
+    final entries = parseChangelog('## [Unreleased]\n\n### Added\n- One.\n');
+    expect(entries.first.text, 'Unreleased');
+    expect(entries.last.text, 'One.');
+  });
+
+  test('fullVersionLabel decodes the rebuild counter, falls back on raw', () {
+    PackageInfo info(String v, String b) => PackageInfo(
+        appName: '', packageName: '', version: v, buildNumber: b);
+    expect(fullVersionLabel(info('0.5.0', '50008')), 'v0.5.0-8');
+    expect(fullVersionLabel(info('1.0.0', '1000000')), 'v1.0.0-0');
+    expect(fullVersionLabel(info('0.5.0', '99999')), 'v0.5.0 (99999)');
+    expect(fullVersionLabel(info('0.5', '50008')), 'v0.5 (50008)');
+  });
+
+  testWidgets('version dialog shows version+build and the bundled changelog',
+      (tester) async {
+    final info = PackageInfo(
+      appName: 'Sonority',
+      packageName: 'be.casperverswijvelt.sonority',
+      version: '0.5.0',
+      buildNumber: '50008',
+    );
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (ctx) => TextButton(
+          onPressed: () => showVersionDialog(ctx, info),
+          child: const Text('open'),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('v0.5.0-8'), findsOneWidget);
+    // Real CHANGELOG.md asset loaded and parsed.
+    expect(find.text('0.5.0 — 2026-07-06'), findsOneWidget);
+    expect(find.text('GitHub'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

The app-bar version chip is now tappable. It opens a dialog with:

- **Full version** as the same chip-styled pill in the dialog header — `v0.5.0-8`, with the rebuild counter decoded from the build number per the scheme in `docs/PUBLISHING.md` (`N = major*1000000 + minor*10000 + patch*100 + build`; falls back to the raw build number if it doesn't fit).
- **Changelog** — `CHANGELOG.md` is bundled as an asset and rendered by a small line-based parser (release headers, Added/Changed sections, bullets with wrapped lines joined, `**` stripped; preamble and empty sections dropped). No markdown package — flutter_markdown is discontinued and the file only uses three line shapes.
- **GitHub** button opening the repo via `url_launcher` (new dependency; Android `<queries>` https intent added for API 30+).

The pill styling is shared (`_VersionPill`) between the app-bar badge and the dialog header.

## Testing

- Unit tests for the changelog parser and version-label decoding, plus a widget test that pumps the real dialog and loads the actual bundled `CHANGELOG.md` (`test/changelog_parser_test.dart`).
- `flutter analyze` clean, all tests pass.
- Verified live on the macOS app (chip → dialog → changelog renders, pill shows `v0.5.0-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)