### PR TITLE
fix(discovery): top-align overview so it doesn't center mid-transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Releasing: before tagging `vX.Y.Z`, rename `[Unreleased]` below to
   every screen's chrome reads as flat and line-based.
 
 ### Fixed
+- The system overview no longer drifts to the vertical centre during the
+  scan/rescan transition — short (non-scrolling) content now stays pinned to
+  the top throughout the animation instead of floating to the middle and
+  snapping back.
 - **Discovery on iPhone** — the TestFlight build could hang on "Scanning your
   network" and fail: real iPhones silently block the multicast discovery
   packets (a restricted Apple entitlement the app doesn't carry; the simulator

--- a/lib/features/discovery/discovery_screen.dart
+++ b/lib/features/discovery/discovery_screen.dart
@@ -58,13 +58,16 @@ class DiscoveryScreen extends ConsumerWidget {
             icon: const Icon(Icons.refresh),
           ),
       ],
-      // The Scaffold body is a tight viewport-height box, so each child fills
-      // the screen: the scanning/error placeholders center, _SystemView scrolls
-      // internally. The switcher never inflates to the tall outgoing list
-      // mid-transition, so the spinner stays screen-centered (no jump).
+      // The scanning/error placeholders center themselves (their Center
+      // expands to the body height); _SystemView shrink-wraps when short. The
+      // switcher's default layout is a center-aligned Stack, which floats that
+      // shrink-wrapped content to the vertical middle mid-transition (when the
+      // expanding placeholder inflates the Stack) — top-align it instead.
       body: PageTransitionSwitcher(
         duration: const Duration(milliseconds: 250),
         reverse: state.isLoading,
+        layoutBuilder: (entries) =>
+            Stack(alignment: Alignment.topCenter, children: entries),
         transitionBuilder: (child, anim, secondaryAnim) => SharedAxisTransition(
           animation: anim,
           secondaryAnimation: secondaryAnim,

--- a/test/discovery_transition_layout_test.dart
+++ b/test/discovery_transition_layout_test.dart
@@ -1,0 +1,57 @@
+import 'package:animations/animations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The discovery screen's PageTransitionSwitcher must top-align its entries:
+/// with the default center-aligned Stack, short (shrink-wrapped) system
+/// content floats to the vertical middle mid-transition while the expanding
+/// scanning placeholder inflates the Stack. Mirrors the switcher config in
+/// discovery_screen.dart.
+Widget _switcher(Widget child) {
+  return MaterialApp(
+    home: Scaffold(
+      body: PageTransitionSwitcher(
+        duration: const Duration(milliseconds: 250),
+        layoutBuilder: (entries) =>
+            Stack(alignment: Alignment.topCenter, children: entries),
+        transitionBuilder: (child, anim, secondaryAnim) => SharedAxisTransition(
+          animation: anim,
+          secondaryAnimation: secondaryAnim,
+          transitionType: SharedAxisTransitionType.scaled,
+          fillColor: Colors.transparent,
+          child: child,
+        ),
+        child: child,
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('short content stays top-aligned mid-transition', (
+    tester,
+  ) async {
+    const shortContent = Key('short');
+    final short = SingleChildScrollView(
+      key: const ValueKey('system'),
+      child: Column(
+        children: [SizedBox(key: shortContent, height: 100, width: 100)],
+      ),
+    );
+    const spinner = Center(
+      key: ValueKey('scanning'),
+      child: CircularProgressIndicator(),
+    );
+
+    await tester.pumpWidget(_switcher(short));
+    expect(tester.getTopLeft(find.byKey(shortContent)).dy, 0);
+
+    // Swap to the expanding placeholder and freeze mid-transition: the
+    // outgoing short content must not sink toward the center (the default
+    // center-aligned Stack would put it ~250px down). A few px of slack
+    // absorbs the exit transition's zoom-out transform.
+    await tester.pumpWidget(_switcher(spinner));
+    await tester.pump(const Duration(milliseconds: 125));
+    expect(tester.getTopLeft(find.byKey(shortContent)).dy, closeTo(0, 10));
+  });
+}


### PR DESCRIPTION
## What

The system overview page visibly slid its content to the vertical centre during the scan/rescan transition, then snapped back to the top once settled — but only when content was short enough not to scroll.

## Why

`PageTransitionSwitcher`'s default `layoutBuilder` stacks entries with `Alignment.center`. Settled, the stack shrinks to the short (shrink-wrapped) `SingleChildScrollView`, so nothing moves. Mid-transition the expanding "Scanning your network…" placeholder inflates the stack to full body height, and `Alignment.center` then parks the shrink-wrapped system list in the vertical middle until the animation ends.

## Fix

Give the switcher a top-aligned `layoutBuilder` (`Stack(alignment: Alignment.topCenter, ...)`). The scanning/error placeholders center themselves via their own `Center`, so the spinner is unaffected.

## Testing

- New widget test `test/discovery_transition_layout_test.dart` freezes the switcher mid-transition and asserts the short content stays at the top (y≈0). Against the old default layout it sits at y≈246 (centered).
- Full suite green (140 tests), `flutter analyze` clean.
- Verified on the macOS app against a live Sonos system — both the non-scrollable and (via temporary filler) scrollable cases stay top-aligned through the rescan animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)