### PR TITLE
docs: codify feature/release/review workflows for agents & contributors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 # Builds installable artifacts and publishes a GitHub Release when a version
-# tag is pushed, e.g.:
-#   git tag v0.1.0 && git push origin v0.1.0
+# tag is pushed. Tags are vX.Y.Z-<rebuild> (unique per build, never moved or
+# reused; see CLAUDE.md "Release flow"), e.g.:
+#   git tag v0.5.0-12 && git push origin v0.5.0-12
 #
 # One job per platform × destination, all running in parallel:
 #   android           release-signed APK + AAB → GitHub Release + Google Play
@@ -278,6 +279,8 @@ jobs:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
+      # Tags are never reused across builds, so this only cleans up a failed
+      # re-run of the SAME tag — it never removes a previous release.
       - name: Delete existing release for this tag (clean re-runs)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -285,6 +288,7 @@ jobs:
       - name: Compose release notes (changelog section + install notes)
         run: |
           version="${GITHUB_REF_NAME#v}"
+          version="${version%%-*}"   # v0.5.0-12 → 0.5.0 (notes ignore the build)
           # Extract the "## [<version>] ..." section from CHANGELOG.md, stopping
           # at the next "## [" heading.
           section=$(awk -v ver="$version" '
@@ -309,4 +313,7 @@ jobs:
           # NOTE: do not enable generate_release_notes — it overrides body_path.
           # body = the matching CHANGELOG.md section + the install instructions.
           body_path: release-body.md
+          # Every release starts as a pre-release; the user flips it to a full
+          # release manually when it actually ships.
+          prerelease: true
           fail_on_unmatched_files: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,160 +12,76 @@ section into the GitHub Release notes regardless of the build suffix
 ## [0.5.0] - 2026-07-11
 
 ### Added
-- **Dual Subs** — a home theater can now bond **two Subs**, with both shown in the
-  layout diagram and re-applied from a profile.
-- **Profiles capture & restore per-speaker EQ** — a profile can snapshot each
-  speaker's EQ (bass/treble/loudness, night sound, speech enhancement, sub,
-  surround levels, lip-sync delay) and, as a separate opt-in, its **volume**,
-  then re-apply them after the layout settles. Save/restore only — there are no
-  EQ/volume sliders (that would duplicate the Sonos app).
-- **Re-snapshot a profile** — update an existing profile in place from the
-  current setup, without recreating it.
-- **Speaker groups** — one "Group speakers" page (Stereo / Zone / Custom) to bond
-  2–16 speakers as a **stereo pair**, a full-range **zone**, or a **custom**
-  per-speaker Left/Right/Both layout, each with an **optional Sub**. Mismatched
-  models welcome; not restricted to Sonos' official model list (Play:1 and a
-  Sub-in-group both confirmed working on hardware, audio routing verified).
-  Separate restores original room names; groups are captured in config profiles.
-  (Distinct from temporary playback groups, which the Sonos app already does.)
-- **Config profiles** — snapshot your current layout (home theaters, speaker
-  groups, rooms, with their names) and re-apply it in one tap, e.g. to rebuild a
-  fronts/surrounds setup after moving speakers. A dedicated bottom tab.
-- **Apply a profile from an app shortcut** — long-press the app icon to apply a
-  saved profile in one tap. The shortcut opens the app and runs the apply,
-  scanning your system first and asking for confirmation only when some speakers
-  are missing or in use by another setup.
-- **Per-profile icon & colour** — pick an icon and colour for each profile,
-  shown on its tile, in the editor, and on its app shortcut (a full-colour glyph
-  on Android, a matching SF Symbol on iOS).
-- **Home-screen widgets** — place a widget showing a hand-picked set of profiles
-  (small/medium/large) and apply any of them in one tap. Tiles use a muted tonal
-  look that adapts to light/dark; reorder profiles in the Profiles tab by
-  long-pressing a card.
-- **Full in-app home-theater setup** — the guided flow now bonds dedicated
-  fronts plus **rear surrounds and a sub** (each optional), with a live
-  per-step progress timeline showing the active step and exactly where it
-  failed. Applied with staged bonding (re-asserted until Sonos converges).
+- **Dual Subs** — a home theater can now bond **two Subs**, with both shown in the layout diagram and re-applied from a profile.
+- **Profiles capture & restore per-speaker EQ** — a profile can snapshot each speaker's EQ (bass/treble/loudness, night sound, speech enhancement, sub, surround levels, lip-sync delay) and, as a separate opt-in, its **volume**, then re-apply them after the layout settles. Save/restore only — there are no EQ/volume sliders (that would duplicate the Sonos app).
+- **Re-snapshot a profile** — update an existing profile in place from the current setup, without recreating it.
+- **Speaker groups** — one "Group speakers" page (Stereo / Zone / Custom) to bond 2–16 speakers as a **stereo pair**, a full-range **zone**, or a **custom** per-speaker Left/Right/Both layout, each with an **optional Sub**. Mismatched models welcome; not restricted to Sonos' official model list (Play:1 and a Sub-in-group both confirmed working on hardware, audio routing verified). Separate restores original room names; groups are captured in config profiles. (Distinct from temporary playback groups, which the Sonos app already does.)
+- **Config profiles** — snapshot your current layout (home theaters, speaker groups, rooms, with their names) and re-apply it in one tap, e.g. to rebuild a fronts/surrounds setup after moving speakers. A dedicated bottom tab.
+- **Apply a profile from an app shortcut** — long-press the app icon to apply a saved profile in one tap. The shortcut opens the app and runs the apply, scanning your system first and asking for confirmation only when some speakers are missing or in use by another setup.
+- **Per-profile icon & colour** — pick an icon and colour for each profile, shown on its tile, in the editor, and on its app shortcut (a full-colour glyph on Android, a matching SF Symbol on iOS).
+- **Home-screen widgets** — place a widget showing a hand-picked set of profiles (small/medium/large) and apply any of them in one tap. Tiles use a muted tonal look that adapts to light/dark; reorder profiles in the Profiles tab by long-pressing a card.
+- **Full in-app home-theater setup** — the guided flow now bonds dedicated fronts plus **rear surrounds and a sub** (each optional), with a live per-step progress timeline showing the active step and exactly where it failed. Applied with staged bonding (re-asserted until Sonos converges).
 - **Room renaming** from the room and home-theater detail pages.
-- **Identify a speaker by blinking its status LED** — works on every platform,
-  including macOS (the audio chime stays as a mobile-only extra).
-- Standalone **Subs are now shown in the overview** so a free Sub is easy to spot
-  and add to a home theater or group.
+- **Identify a speaker by blinking its status LED** — works on every platform, including macOS (the audio chime stays as a mobile-only extra).
+- Standalone **Subs are now shown in the overview** so a free Sub is easy to spot and add to a home theater or group.
 
 ### Changed
-- UI overhaul: collapsing large-title app bars, a stepped stereo-pair creation
-  flow, distinct card/nav-bar surfaces on a darker page background, and speaker
-  **types** (e.g. "Beam (Gen 2)", "Play:1") shown wherever a model appears —
-  in diagrams, bonded-speaker cards, and profile summaries.
-- System overview re-sectioned: home theaters → speaker groups → single speaker
-  rooms → other devices, with a compact "+" in the Speaker groups header.
-- Speaker groups now have a **tappable detail view**, and the configure-bond flow
-  **pre-selects the current layout** so it opens on what's actually bonded.
-- The **app version** is shown as a tappable chip in the discovery app bar — it
-  opens a dialog with the full version and build number, this changelog, and a
-  link to the GitHub project.
+- UI overhaul: collapsing large-title app bars, a stepped stereo-pair creation flow, distinct card/nav-bar surfaces on a darker page background, and speaker **types** (e.g. "Beam (Gen 2)", "Play:1") shown wherever a model appears — in diagrams, bonded-speaker cards, and profile summaries.
+- System overview re-sectioned: home theaters → speaker groups → single speaker rooms → other devices, with a compact "+" in the Speaker groups header.
+- Speaker groups now have a **tappable detail view**, and the configure-bond flow **pre-selects the current layout** so it opens on what's actually bonded.
+- The **app version** is shown as a tappable chip in the discovery app bar — it opens a dialog with the full version and build number, this changelog, and a link to the GitHub project.
 - Discovery **auto-scans on launch** — the separate landing page is gone.
-- Applying a home theater or profile now diffs against the live layout and only
-  changes what moved — faster, and an unchanged layout re-applies with no writes.
-- Trueplay: the "x/y active" counter is hidden for single speakers (shown only
-  for home theaters and stereo pairs).
-- The apply/profile progress timeline is now **two-level** — each phase's
-  sub-steps are nested under the entity they act on, so it's clear what's
-  happening and exactly where it failed.
-- The apply progress timeline now marks no-op steps as **skipped** (grey dot +
-  reason, e.g. "layout unchanged — nothing to do", "name unchanged — nothing to
-  do") instead of showing them as completed work, so a re-apply that changed
-  nothing is honest about it. The entity itself keeps its green checkmark — it's
-  still in the desired state.
-- Detail pages show the **entity type as an app-bar subtitle** (speaker model
-  for a room, "Home theater", or the speaker-group kind).
-- Profile creation warns before overwriting, and applying a profile is guarded
-  against re-entrant taps.
-- Profiles: the EQ capture toggle is now **"Save audio settings"** — the label
-  undersold a bundle that also covers night sound, speech enhancement, sub &
-  surround levels and lip sync. Profile cards now show separate **Audio
-  settings** / **Volume** badges (instead of one combined "EQ" line) and use an
-  icon-only play button with a bit more breathing room.
-- Profiles and widgets now share one visual language: SF Symbol glyphs on every
-  platform and soft colour-tinted (tonal) cards instead of bold full-colour
-  fills.
+- Applying a home theater or profile now diffs against the live layout and only changes what moved — faster, and an unchanged layout re-applies with no writes.
+- Trueplay: the "x/y active" counter is hidden for single speakers (shown only for home theaters and stereo pairs).
+- The apply/profile progress timeline is now **two-level** — each phase's sub-steps are nested under the entity they act on, so it's clear what's happening and exactly where it failed.
+- The apply progress timeline now marks no-op steps as **skipped** (grey dot + reason, e.g. "layout unchanged — nothing to do", "name unchanged — nothing to do") instead of showing them as completed work, so a re-apply that changed nothing is honest about it. The entity itself keeps its green checkmark — it's still in the desired state.
+- Detail pages show the **entity type as an app-bar subtitle** (speaker model for a room, "Home theater", or the speaker-group kind).
+- Profile creation warns before overwriting, and applying a profile is guarded against re-entrant taps.
+- Profiles: the EQ capture toggle is now **"Save audio settings"** — the label undersold a bundle that also covers night sound, speech enhancement, sub & surround levels and lip sync. Profile cards now show separate **Audio settings** / **Volume** badges (instead of one combined "EQ" line) and use an icon-only play button with a bit more breathing room.
+- Profiles and widgets now share one visual language: SF Symbol glyphs on every platform and soft colour-tinted (tonal) cards instead of bold full-colour fills.
 - Re-snapshot moved to an app-bar action on the profile detail page.
-- Switching bottom-nav tabs (System ↔ Profiles) now animates with a Material 3
-  shared-axis transition (fade + slide), sliding the way the tab bar moves.
-- Consistent, flat separation for the top app bar and bottom navigation bar. The
-  nav bar now shows a hairline dividing it from the page and cards (it was
-  meant to but never rendered), and the app bar matches with a hairline that
-  appears only while content scrolls under it — replacing its drop shadow, so
-  every screen's chrome reads as flat and line-based.
-- The macOS `.dmg` download now opens a styled drag-to-Applications install
-  window — the app icon, an arrow, and an Applications shortcut over a branded
-  background — instead of a bare disk image.
+- Switching bottom-nav tabs (System ↔ Profiles) now animates with a Material 3 shared-axis transition (fade + slide), sliding the way the tab bar moves.
+- Consistent, flat separation for the top app bar and bottom navigation bar. The nav bar now shows a hairline dividing it from the page and cards (it was meant to but never rendered), and the app bar matches with a hairline that appears only while content scrolls under it — replacing its drop shadow, so every screen's chrome reads as flat and line-based.
+- The macOS `.dmg` download now opens a styled drag-to-Applications install window — the app icon, an arrow, and an Applications shortcut over a branded background — instead of a bare disk image.
 
 ### Fixed
-- **Discovery on iPhone** — the TestFlight build could hang on "Scanning your
-  network" and fail: real iPhones silently block the multicast discovery
-  packets (a restricted Apple entitlement the app doesn't carry; the simulator
-  doesn't enforce it). When multicast finds nothing, discovery now falls back
-  to directly probing the local network for Sonos players — which only needs
-  the local-network permission the app already asks for. This also helps
-  mesh/guest networks that filter multicast.
-- The "couldn't find your system" screen no longer shows a raw `Exception:`
-  prefix on its message, and its title now centres correctly when it wraps to
-  two lines — so an empty network reads as a normal state, not a crash.
-- The system overview no longer drifts to the vertical centre during the
-  scan/rescan transition — short (non-scrolling) content now stays pinned to
-  the top throughout the animation instead of floating to the middle and
-  snapping back.
-- macOS: the window is kept within the visible frame so the Dock can no longer
-  clip it.
-- Tap highlights on list rows now follow the card's rounded corners instead of
-  rendering as a rectangle.
+- **Discovery on iPhone** — the TestFlight build could hang on "Scanning your network" and fail: real iPhones silently block the multicast discovery packets (a restricted Apple entitlement the app doesn't carry; the simulator doesn't enforce it). When multicast finds nothing, discovery now falls back to directly probing the local network for Sonos players — which only needs the local-network permission the app already asks for. This also helps mesh/guest networks that filter multicast.
+- The "couldn't find your system" screen no longer shows a raw `Exception:` prefix on its message, and its title now centres correctly when it wraps to two lines — so an empty network reads as a normal state, not a crash.
+- The system overview no longer drifts to the vertical centre during the scan/rescan transition — short (non-scrolling) content now stays pinned to the top throughout the animation instead of floating to the middle and snapping back.
+- macOS: the window is kept within the visible frame so the Dock can no longer clip it.
+- Tap highlights on list rows now follow the card's rounded corners instead of rendering as a rectangle.
 
 ### Packaging
-- iOS and macOS are now available via **TestFlight**; the macOS direct download
-  is a **Developer ID-signed, notarized `.dmg`** (no Gatekeeper workaround) and
-  the Android APK is **release-signed**.
-- Release CI restructured into clear, per-platform jobs (Android, iOS sideload,
-  iOS TestFlight, macOS `.dmg`, macOS TestFlight, GitHub Release).
+- iOS and macOS are now available via **TestFlight**; the macOS direct download is a **Developer ID-signed, notarized `.dmg`** (no Gatekeeper workaround) and the Android APK is **release-signed**.
+- Release CI restructured into clear, per-platform jobs (Android, iOS sideload, iOS TestFlight, macOS `.dmg`, macOS TestFlight, GitHub Release).
 
 ## [0.4.0] - 2026-06-28
 
 ### Added
-- **Trueplay (room calibration) read + toggle** on home theaters, stereo pairs
-  and standalone rooms. Tuning is still measured in the Sonos app on iOS;
-  Sonority reads the stored result and switches it on/off — including for the
-  unofficial dedicated-fronts setups the Sonos app won't expose.
+- **Trueplay (room calibration) read + toggle** on home theaters, stereo pairs and standalone rooms. Tuning is still measured in the Sonos app on iOS; Sonority reads the stored result and switches it on/off — including for the unofficial dedicated-fronts setups the Sonos app won't expose.
 - Detail screen for stereo pairs and standalone rooms.
 
 ### Changed
 - "Create stereo pair" is now a filled call-to-action button.
-- Home-theater and room detail pages show a spinner on refresh and reload
-  Trueplay status, not just the topology.
+- Home-theater and room detail pages show a spinner on refresh and reload Trueplay status, not just the topology.
 - GitHub Release notes are now generated from this changelog.
 
 ### Notes
-- Sonos invalidates a speaker's Trueplay when its bonded set changes (adding or
-  removing fronts), so a tuning may need to be redone after a layout change —
-  a firmware limitation, not a Sonority bug.
+- Sonos invalidates a speaker's Trueplay when its bonded set changes (adding or removing fronts), so a tuning may need to be redone after a layout change — a firmware limitation, not a Sonority bug.
 
 ## [0.3.0] - 2026-06-27
 
 ### Added
 - App icon and splash screen (parametric Sonos 5.1 surround mark).
-- Support a single **Sonos Amp** as the dedicated fronts (drives both front
-  channels).
-- Google Play Store listing graphics (icon, feature graphic, phone + tablet
-  screenshots).
-- CI now signs the release **App Bundle** and publishes it to the Google Play
-  internal testing track on version tags.
+- Support a single **Sonos Amp** as the dedicated fronts (drives both front channels).
+- Google Play Store listing graphics (icon, feature graphic, phone + tablet screenshots).
+- CI now signs the release **App Bundle** and publishes it to the Google Play internal testing track on version tags.
 
 ## [0.2.0] - 2026-06-19
 
 ### Added
-- **Stereo pairs**, including mismatched / app-blocked models (e.g. One + Play:1),
-  with original room names restored on separation.
-- Release CI: APK plus unsigned iOS and macOS artifacts on `v*` tags, with
-  per-platform install instructions in the release.
+- **Stereo pairs**, including mismatched / app-blocked models (e.g. One + Play:1), with original room names restored on separation.
+- Release CI: APK plus unsigned iOS and macOS artifacts on `v*` tags, with per-platform install instructions in the release.
 
 ### Changed
 - Renamed the app from SoYes to **Sonority**.
@@ -173,6 +89,4 @@ section into the GitHub Release notes regardless of the build suffix
 ## [0.1.0] - 2026-06-18
 
 ### Added
-- Initial release: discover the Sonos system and add/remove dedicated front
-  left/right speakers on a home theater via the local UPnP API, with
-  identify-by-chime to tell speakers apart.
+- Initial release: discover the Sonos system and add/remove dedicated front left/right speakers on a home theater via the local UPnP API, with identify-by-chime to tell speakers apart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,7 @@ section into the GitHub Release notes regardless of the build suffix
 - **Home-screen widgets** — place a widget showing a hand-picked set of profiles
   (small/medium/large) and apply any of them in one tap. Tiles use a muted tonal
   look that adapts to light/dark; reorder profiles in the Profiles tab by
-  long-pressing a card. Built in on Android and iOS (only signing for a physical
-  iOS device needs a one-time Xcode step — see `docs/WIDGETS-SETUP.md`).
+  long-pressing a card.
 - **Full in-app home-theater setup** — the guided flow now bonds dedicated
   fronts plus **rear surrounds and a sub** (each optional), with a live
   per-step progress timeline showing the active step and exactly where it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to Sonority are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Releasing: before tagging `vX.Y.Z`, rename `[Unreleased]` below to
-`[X.Y.Z] - YYYY-MM-DD`. CI copies that section into the GitHub Release notes
+Releasing: before tagging `vX.Y.Z-<rebuild>` (e.g. `v0.5.0-12` for build
+50012), rename `[Unreleased]` below to `[X.Y.Z] - YYYY-MM-DD`. CI copies that
+section into the GitHub Release notes regardless of the build suffix
 (see `.github/workflows/release.yml`).
 
 ## [0.5.0] - 2026-07-11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,7 +446,9 @@ pkill -x Sonority                          # quit (AppleScript quit gets cancell
 1. Implement on a **feature branch** off `main`. Never bump `version:` on the
    branch (see Toolchain — bumps happen only on `main`).
 2. Add a `CHANGELOG.md` entry under `## [Unreleased]` (create the section if
-   absent), unless the user names another version.
+   absent), unless the user names another version. Keep it **concise** — one
+   line/sentence unless the change genuinely needs more to explain it. Write
+   each entry as a **single unwrapped line** (no hard newlines mid-entry).
 3. `flutter analyze` + `flutter test` green.
 4. **Pre-merge review** before opening the PR: spawn a fresh review subagent
    prompted with the Review guidelines below, plus run `/code-review` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -440,6 +440,52 @@ pkill -x Sonority                          # quit (AppleScript quit gets cancell
 - Candidate next: channel-level/height trim (overlaps the app — weak). Discovery
   now recovers topology-only speakers when a description fetch fails (done upstream).
 
+## Recurring workflows
+
+### Feature flow
+1. Implement on a **feature branch** off `main`. Never bump `version:` on the
+   branch (see Toolchain — bumps happen only on `main`).
+2. Add a `CHANGELOG.md` entry under `## [Unreleased]` (create the section if
+   absent), unless the user names another version.
+3. `flutter analyze` + `flutter test` green.
+4. **Pre-merge review** before opening the PR: spawn a fresh review subagent
+   prompted with the Review guidelines below, plus run `/code-review` and
+   `/ponytail-review`; address the findings.
+5. Integrate the latest `origin/main` into the branch, then open a PR to `main`
+   (gh CLI).
+6. The **user merges the PR manually** unless they say otherwise.
+
+### Release flow (on `main`, after merges)
+1. Everything under `[Unreleased]` becomes the new version. Version = semver
+   over what's included (pre-1.0: any feature → minor bump, fixes-only → patch),
+   unless the user specifies a version (existing or new).
+2. Rename `## [Unreleased]` → `## [X.Y.Z] - YYYY-MM-DD`; start a fresh empty
+   `[Unreleased]` above it.
+3. Set pubspec `version: X.Y.Z+<versionCode>` per the formula in
+   `docs/PUBLISHING.md` (the `+N` build counter); commit on `main`.
+4. Tag **`vX.Y.Z-<rebuild>`** (e.g. `v0.5.0-12` = 0.5.0 build 50012) and push.
+   **Never move, delete, or reuse a tag; never delete a GitHub Release** — full
+   history is kept. A re-cut of the same version = rebuild+1 → new tag → new
+   release.
+5. CI publishes the GitHub Release **as pre-release**, with the version's full
+   changelog section (the build suffix is stripped for the notes lookup). The
+   user removes the pre-release mark when it's actually released.
+
+### Review guidelines (the checklist for the review subagent)
+- Correctness and overall code quality; architecture fits the engine/UI split
+  (wire-format details stay in `lib/data/sonos/`).
+- Ponytail principles: simplest thing that works, reuse existing shared
+  helpers/widgets (see Conventions), no speculative abstraction.
+- No dead code.
+- Product principle honored: nothing duplicates the official Sonos app beyond
+  the documented exceptions (see "What this app is").
+- Live-Sonos-write safety patterns respected: snapshot first, explicit confirm,
+  poll-verify (see CRITICAL gotchas).
+- Tests added for new parsing/recipe logic; `flutter analyze` + `flutter test`
+  green.
+- Documentation in sync with the actual featureset (CLAUDE.md feature status,
+  CHANGELOG entry present) — no contradictory or duplicate information.
+
 ## Conventions
 - Keep `flutter analyze` clean and unit tests passing; add tests for new parsing/
   recipe logic (see `test/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,13 +449,18 @@ pkill -x Sonority                          # quit (AppleScript quit gets cancell
    absent), unless the user names another version. Keep it **concise** — one
    line/sentence unless the change genuinely needs more to explain it. Write
    each entry as a **single unwrapped line** (no hard newlines mid-entry).
-3. `flutter analyze` + `flutter test` green.
-4. **Pre-merge review** before opening the PR: spawn a fresh review subagent
+3. **Keep textual marketing copy in sync** with the feature set — when a feature
+   adds/changes user-facing capability, update the copy per §1 of
+   `docs/MARKETING-ASSETS.md` (`docs/app-store/listing.md`, `pubspec.yaml`
+   `description:`, `design/store.html` captions, `README.md` alt text). This is
+   text only; visual assets are a release-time step (see Release flow).
+4. `flutter analyze` + `flutter test` green.
+5. **Pre-merge review** before opening the PR: spawn a fresh review subagent
    prompted with the Review guidelines below, plus run `/code-review` and
    `/ponytail-review`; address the findings.
-5. Integrate the latest `origin/main` into the branch, then open a PR to `main`
+6. Integrate the latest `origin/main` into the branch, then open a PR to `main`
    (gh CLI).
-6. The **user merges the PR manually** unless they say otherwise.
+7. The **user merges the PR manually** unless they say otherwise.
 
 ### Release flow (on `main`, after merges)
 1. Everything under `[Unreleased]` becomes the new version. Version = semver
@@ -469,7 +474,13 @@ pkill -x Sonority                          # quit (AppleScript quit gets cancell
    **Never move, delete, or reuse a tag; never delete a GitHub Release** — full
    history is kept. A re-cut of the same version = rebuild+1 → new tag → new
    release.
-5. CI publishes the GitHub Release **as pre-release**, with the version's full
+5. **Check visual marketing assets.** Review the version's features/changes and
+   decide whether the store screenshots or framed graphics (`design/shots/*`,
+   `design/play/*`, `design/appstore/*`, `docs/screenshots/*`) no longer reflect
+   the app. If they do, **notify the user and get approval before regenerating**
+   — capturing screenshots stages the live Sonos system (see §2–3 of
+   `docs/MARKETING-ASSETS.md`), so never do it unprompted.
+6. CI publishes the GitHub Release **as pre-release**, with the version's full
    changelog section (the build suffix is stripped for the notes lookup). The
    user removes the pre-release mark when it's actually released.
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,7 +1,7 @@
 # Publishing to Google Play
 
 CI (`.github/workflows/release.yml`) builds a **signed release AAB** and uploads
-it to the **internal testing** track whenever a `vX.Y.Z` tag is pushed — *once*
+it to the **open testing** track (Play "beta") whenever a `vX.Y.Z-<rebuild>` tag is pushed — *once*
 the one-time setup below is done. Without the secrets it just builds a
 debug-signed APK and skips Play (so the workflow never breaks for forks).
 
@@ -72,10 +72,14 @@ Before tagging:
 2. In `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (and
    start a fresh empty `[Unreleased]` above it). CI slices that section into the
    GitHub Release notes, followed by the install instructions.
-3. Commit, then:
+3. Commit, then tag `vX.Y.Z-<rebuild>` — the rebuild counter from the
+   versionCode formula above (e.g. `0.5.0+50012` → `v0.5.0-12`). Tags are
+   unique per build and never moved, reused, or deleted; a re-cut gets
+   rebuild+1 and a fresh tag:
 ```sh
-git tag vX.Y.Z && git push origin vX.Y.Z
+git tag v0.5.0-12 && git push origin v0.5.0-12
 ```
-CI signs the AAB, pushes it to Play internal testing, and publishes the GitHub
-Release (changelog section + install notes). Promote to production in the Console
-when ready.
+CI signs the AAB, pushes it to Play open testing (the "beta" track), and
+publishes the GitHub Release (changelog section + install notes) marked as **pre-release** — remove
+that mark when it actually ships. Previous releases are never deleted. Promote
+to production in the Console when ready.


### PR DESCRIPTION
## What

Adds standing instructions for the three recurring flows agents & contributors keep re-deriving, plus the two CI/doc changes needed to make them true.

**CLAUDE.md — new "Recurring workflows" section:**
- **Feature flow** — branch off `main` → CHANGELOG `[Unreleased]` entry → `analyze`/`test` green → pre-merge review (review subagent + `/code-review` + `/ponytail-review`) → integrate `origin/main` → PR; user merges manually.
- **Release flow** — `[Unreleased]` → semver'd version, unique `vX.Y.Z-<rebuild>` tag (never moved/deleted/reused), GitHub Release published **as pre-release** (user flips it live).
- **Review guidelines** — the checklist the review subagent runs against.

**CI/behaviour changes to match the new tag scheme:**
- `release.yml` strips the `-<rebuild>` suffix before the changelog lookup (`v0.5.0-12` → `0.5.0`; plain `v0.5.0` still works) and publishes with `prerelease: true`.
- `CHANGELOG.md` header + `docs/PUBLISHING.md` updated to the `vX.Y.Z-<rebuild>` tag format.

## Why

Tags previously carried no build number and were *moved* on re-cuts (v0.5.0 re-tagged 3×), and CI deleted the prior release each run. The new scheme keeps full release history: one unique tag per build, nothing moved or deleted.

## Verification

- Simulated the CI notes composition locally with `GITHUB_REF_NAME=v0.5.0-12` → extracts the full `[0.5.0]` changelog section.
- YAML validated; no Dart touched (analyze/test unaffected).

## Pre-merge review

Ran the documented review (fresh subagent + `/code-review`): shell logic and `prerelease` placement confirmed correct. Fixed one finding — a duplicated versionCode formula in CLAUDE.md (now a cross-reference to `docs/PUBLISHING.md`). Two pre-existing, out-of-scope items noted to the author (Play track wording; absolute "never delete" phrasing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)