### PR TITLE
fix: engine reliability hardening + review cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Fixed
+- Applying a profile that reuses a speaker from another named stereo pair/zone now restores those speakers' room names instead of leaving them under the group's name.
+- Removing home-theater speakers now reports a clear error if Sonos silently no-ops the change, rather than falsely showing success.
+- Renaming a room no longer displays the new name until Sonos actually confirms it.
+- Discovery now falls back to another player when the first one can't answer the topology read.
+- A permanent bonding fault (e.g. a malformed map) now surfaces immediately instead of retrying for ~2½ minutes, and a failed EQ/volume restore is now reported instead of silently swallowed.
+
 ## [0.5.0] - 2026-07-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,12 @@ It's a cleaner, focused alternative to *SonoSequencr*.
 
 ### Product principle (important)
 **Default: do NOT duplicate features the official Sonos app already has** (EQ/bass/
-treble, volume, grouping, surround level sliders, night sound, Trueplay, …). Every
-feature should be something the Sonos app **won't** let users do. Examples:
+treble editing, volume, grouping, surround-level editing, night sound, Trueplay
+*measurement*, …). Every feature should be something the Sonos app **won't** let
+users do. (Two things below look like exceptions but aren't duplication: we
+*capture+restore* EQ/surround/volume in profiles — never edit them with sliders —
+and we *toggle* an already-measured Trueplay calibration the app hides for
+unofficial fronts — never measure it. Both are called out again below.) Examples:
 - **Dedicated front L/R speakers** on a soundbar (the bar becomes center). ✅ built
 - **Mismatched / app-blocked stereo pairs**. ✅ built
 - **Zones** — bond 2–16 speakers into one room (full-range L+R, no L/R split),

--- a/lib/data/sonos/channel_map.dart
+++ b/lib/data/sonos/channel_map.dart
@@ -74,9 +74,6 @@ class ChannelMap {
                 e.hasChannel(SonosChannel.rightFront)),
       );
 
-  ChannelMap withEntries(Iterable<ChannelMapEntry> add) =>
-      ChannelMap([...entries, ...add]);
-
   ChannelMap withoutUuid(String uuid) =>
       ChannelMap(entries.where((e) => e.uuid != uuid).toList());
 

--- a/lib/data/sonos/soap_client.dart
+++ b/lib/data/sonos/soap_client.dart
@@ -40,18 +40,23 @@ class SonosSoapClient {
       body: body,
     ).timeout(timeout);
 
-    final doc = XmlDocument.parse(res.body);
     if (res.statusCode != 200) {
-      final fault = doc.findAllElements('faultstring');
-      final code = doc.findAllElements('errorCode');
+      // A fault body is usually XML, but a truncated/empty/non-XML error body
+      // must still surface as a SonosSoapException — not an XmlParserException.
+      final doc = _tryParse(res.body);
+      final fault = doc?.findAllElements('faultstring');
+      final code = doc?.findAllElements('errorCode');
       throw SonosSoapException(
         action,
         statusCode: res.statusCode,
-        faultCode: code.isEmpty ? null : code.first.innerText,
-        faultString: fault.isEmpty ? res.reasonPhrase : fault.first.innerText,
+        faultCode: (code == null || code.isEmpty) ? null : code.first.innerText,
+        faultString: (fault == null || fault.isEmpty)
+            ? res.reasonPhrase
+            : fault.first.innerText,
       );
     }
 
+    final doc = XmlDocument.parse(res.body);
     final bodies = doc.findAllElements('Body', namespace: '*');
     if (bodies.isEmpty) {
       throw SonosSoapException(action, faultString: 'Missing SOAP Body in response');
@@ -79,6 +84,14 @@ class SonosSoapClient {
       ..write('</s:Body>')
       ..write('</s:Envelope>');
     return buf.toString();
+  }
+
+  static XmlDocument? _tryParse(String body) {
+    try {
+      return XmlDocument.parse(body);
+    } on XmlException {
+      return null;
+    }
   }
 
   static String _escape(String input) => input

--- a/lib/data/sonos/sonos_repository.dart
+++ b/lib/data/sonos/sonos_repository.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 
-import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/sonos_models.dart';
@@ -16,8 +16,10 @@ import 'ssdp_discovery.dart';
 import 'zone_layout.dart';
 import 'zone_topology.dart';
 
-/// Orchestrates discovery, topology reads, and the bonding actions, and keeps
-/// a per-soundbar restore point so the user can always undo.
+/// Orchestrates discovery, topology reads, and the bonding actions. Persists
+/// only the pre-group room *names* (so they can be restored when a stereo pair /
+/// zone is separated); HT bonding keeps no persisted snapshot, so undoing an HT
+/// change relies on the in-memory previous [SonosSystem].
 class SonosRepository {
   final SsdpDiscovery _ssdp;
   final DeviceDescriptionClient _descriptions;
@@ -55,7 +57,8 @@ class SonosRepository {
         } catch (e) {
           // Non-fatal: a device that fails its description fetch is dropped here
           // and recovered topology-only later. Log so it's diagnosable.
-          debugPrint('Sonority: device_description fetch failed for $loc: $e');
+          developer.log('device_description fetch failed for $loc: $e',
+              name: 'sonority.discover');
           return null;
         }
       }),
@@ -66,7 +69,23 @@ class SonosRepository {
     }
 
     final devicesByUuid = {for (final d in found) d.uuid: d};
-    final groups = await _topology.getZoneGroups(found.first.ip!);
+    // Topology is a system-wide query any player can answer; try each until one
+    // responds so a single unreachable device doesn't fail the whole discovery.
+    List<ZoneGroup>? groups;
+    Object? lastErr;
+    for (final d in found) {
+      final ip = d.ip;
+      if (ip == null) continue;
+      try {
+        groups = await _topology.getZoneGroups(ip);
+        break;
+      } catch (e) {
+        lastErr = e;
+      }
+    }
+    if (groups == null) {
+      throw Exception('Could not read the Sonos topology from any player: $lastErr');
+    }
 
     // Topology is authoritative; SSDP and the per-device description fetch are
     // both lossy. Re-fetch any visible member we don't yet have a description
@@ -165,6 +184,13 @@ class SonosRepository {
       } on TimeoutException {
         // Big bonding calls time out at 8s but the write still takes effect.
         onNote?.call('attempt $attempt: write timed out, verifying');
+      } on SonosSoapException catch (e) {
+        // Only UPnPError 800 ("satellite still mid-reshuffle") is the documented
+        // transient fault. A malformed map (402) or an invalid action for this
+        // coordinator (401) will never converge — surface it immediately instead
+        // of retrying for ~160s and masking it as "channels never joined".
+        if (e.faultCode != '800') rethrow;
+        onNote?.call('attempt $attempt: write error 800, re-asserting');
       } catch (e) {
         // Bonding is eventually-consistent (confirmed on hardware): a write can
         // partially apply then settle, or return a transient UPnPError (e.g. 800
@@ -265,16 +291,23 @@ class SonosRepository {
     if (coordIp == null) throw Exception('Speaker IP unknown; rescan and retry.');
     await _deviceProps.separateBondedZones(
         ip: coordIp, channelMapSet: channelMapSet);
+    await _restoreZoneNames(members);
+  }
+
+  /// Restores each member's saved room name after a group is dissolved (Sonos
+  /// absorbs member names into the coordinator's on separate, and doesn't put
+  /// them back). No-op when no snapshot was persisted — e.g. the group was
+  /// created outside the app or prefs were cleared.
+  Future<void> _restoreZoneNames(List<SonosDevice> members) async {
     final snap = await _loadZoneSnapshot([for (final m in members) m.uuid]);
-    if (snap != null) {
-      await Future<void>.delayed(const Duration(seconds: 2));
-      for (final m in members) {
-        final want = snap[m.uuid];
-        final ip = m.ip;
-        if (want == null || ip == null) continue;
-        if ((await _deviceProps.getZoneAttributes(ip)).zoneName != want.zoneName) {
-          await _deviceProps.setZoneAttributes(ip, want);
-        }
+    if (snap == null) return;
+    await Future<void>.delayed(const Duration(seconds: 2));
+    for (final m in members) {
+      final want = snap[m.uuid];
+      final ip = m.ip;
+      if (want == null || ip == null) continue;
+      if ((await _deviceProps.getZoneAttributes(ip)).zoneName != want.zoneName) {
+        await _deviceProps.setZoneAttributes(ip, want);
       }
     }
   }
@@ -306,6 +339,13 @@ class SonosRepository {
             await _avTransport.becomeCoordinatorOfStandaloneGroup(ip);
             await Future<void>.delayed(const Duration(seconds: 4));
             await _deviceProps.separateBondedZones(ip: ip, channelMapSet: cms);
+            // Same as separateGroup: Sonos leaves members under the coordinator's
+            // absorbed name — restore them from the snapshot if we have one.
+            final members = [
+              m.uuid,
+              ...m.channelMapUuids.where((u) => u != m.uuid),
+            ].map(system.device).whereType<SonosDevice>().toList();
+            await _restoreZoneNames(members);
           }
           return;
         }

--- a/lib/data/sonos/speaker_settings.dart
+++ b/lib/data/sonos/speaker_settings.dart
@@ -140,29 +140,35 @@ class SpeakerSettingsClient {
   }
 
   /// Writes every non-null field of [s]. Each write is independent; a failure is
-  /// swallowed so the remaining settings still apply.
-  Future<void> apply(String ip, SpeakerSettings s) async {
+  /// swallowed so the remaining settings still apply. Returns the number of
+  /// writes that failed — a non-zero count (e.g. a firmware change renaming an
+  /// EQ token so every SetEQ faults) is otherwise invisible to the caller.
+  Future<int> apply(String ip, SpeakerSettings s) async {
+    var failed = 0;
+    Future<void> set(String action, Map<String, String> extra) async {
+      if (!await _set(ip, action, extra)) failed++;
+    }
+
     if (s.bass != null) {
-      await _set(ip, 'SetBass', {'DesiredBass': '${s.bass}'});
+      await set('SetBass', {'DesiredBass': '${s.bass}'});
     }
     if (s.treble != null) {
-      await _set(ip, 'SetTreble', {'DesiredTreble': '${s.treble}'});
+      await set('SetTreble', {'DesiredTreble': '${s.treble}'});
     }
     if (s.loudness != null) {
-      await _set(ip, 'SetLoudness',
+      await set('SetLoudness',
           {'Channel': 'Master', 'DesiredLoudness': s.loudness! ? '1' : '0'});
     }
     for (final e in s.eq.entries) {
-      await _set(ip, 'SetEQ', {'EQType': e.key, 'DesiredValue': '${e.value}'});
+      await set('SetEQ', {'EQType': e.key, 'DesiredValue': '${e.value}'});
     }
     if (s.volume != null) {
-      await _set(ip, 'SetVolume',
-          {'Channel': 'Master', 'DesiredVolume': '${s.volume}'});
+      await set('SetVolume', {'Channel': 'Master', 'DesiredVolume': '${s.volume}'});
     }
     if (s.mute != null) {
-      await _set(
-          ip, 'SetMute', {'Channel': 'Master', 'DesiredMute': s.mute! ? '1' : '0'});
+      await set('SetMute', {'Channel': 'Master', 'DesiredMute': s.mute! ? '1' : '0'});
     }
+    return failed;
   }
 
   // ---- read helpers (null on any fault so unsupported settings are skipped) ----
@@ -196,7 +202,9 @@ class SpeakerSettingsClient {
 
   // ---- write helper (swallows faults; one setting must not block the rest) ----
 
-  Future<void> _set(String ip, String action, Map<String, String> extra) async {
+  /// Returns true if the write succeeded, false if it faulted (best-effort — a
+  /// single failed setting must not block the rest).
+  Future<bool> _set(String ip, String action, Map<String, String> extra) async {
     try {
       await _soap.call(
         ip: ip,
@@ -205,6 +213,9 @@ class SpeakerSettingsClient {
         action: action,
         args: {'InstanceID': '0', ...extra},
       );
-    } catch (_) {/* best-effort */}
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 }

--- a/lib/features/front_surrounds/front_surrounds_flow.dart
+++ b/lib/features/front_surrounds/front_surrounds_flow.dart
@@ -9,6 +9,7 @@ import '../../state/sonos_controller.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/bonding_progress_screen.dart';
 import '../widgets/bondable_speaker_tile.dart';
+import '../widgets/confirm_dialog.dart';
 import '../widgets/identify_controls.dart';
 import '../widgets/speaker_diagram.dart';
 import '../widgets/speaker_side_card.dart';
@@ -160,9 +161,7 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
                     Gap.m,
                     _AmpWiringNote(
                       amp: system.device(_fronts.first),
-                      onIdentify: identify,
-                      onChime: onChime,
-                      identifying: identifyingUuid,
+                      identifyControls: identifyButtons,
                     ),
                   ] else if (_fronts.length == 2) ...[
                     Gap.m,
@@ -404,33 +403,17 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
   /// Confirms unbonding the speakers the user deselected (they become standalone
   /// rooms again). Shows their type since a bonded speaker's name is absorbed.
   Future<bool> _confirmRemoval(SonosSystem system, Set<String> removed) async {
-    final scheme = Theme.of(context).colorScheme;
     final types = [
       for (final u in removed) system.device(u)?.typeLabel ?? 'Speaker',
     ].join(', ');
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        icon: const Icon(Icons.link_off),
-        title: Text('Unbond ${removed.length} speaker'
-            '${removed.length == 1 ? '' : 's'}?'),
-        content: Text(
-          '$types will be removed from this home theater and become standalone '
-          'rooms again. The rest of your layout stays as it is.',
-        ),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(foregroundColor: scheme.error),
-            child: const Text('Unbond'),
-          ),
-        ],
-      ),
+    return confirmDialog(
+      context,
+      icon: Icons.link_off,
+      title: 'Unbond ${removed.length} speaker${removed.length == 1 ? '' : 's'}?',
+      message: '$types will be removed from this home theater and become '
+          'standalone rooms again. The rest of your layout stays as it is.',
+      confirmLabel: 'Unbond',
     );
-    return ok == true;
   }
 }
 
@@ -531,16 +514,9 @@ class _ChooseSub extends StatelessWidget {
 /// Amp mode: the Amp drives both fronts itself — nothing to assign in-app.
 class _AmpWiringNote extends StatelessWidget {
   final SonosDevice? amp;
-  final void Function(SonosDevice device) onIdentify;
-  final Future<void> Function(SonosDevice device)? onChime;
-  final String? identifying;
+  final Widget Function(SonosDevice device) identifyControls;
 
-  const _AmpWiringNote({
-    required this.amp,
-    required this.onIdentify,
-    required this.onChime,
-    required this.identifying,
-  });
+  const _AmpWiringNote({required this.amp, required this.identifyControls});
 
   @override
   Widget build(BuildContext context) {
@@ -556,28 +532,7 @@ class _AmpWiringNote extends StatelessWidget {
         ),
         if (amp != null) ...[
           Gap.s,
-          Wrap(
-            spacing: 8,
-            children: [
-              TextButton.icon(
-                onPressed: identifying == amp.uuid ? null : () => onIdentify(amp),
-                icon: identifying == amp.uuid
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2))
-                    : const Icon(Icons.lightbulb_outline, size: 18),
-                label: Text('Blink ${amp.roomName}'),
-              ),
-              if (onChime != null)
-                TextButton.icon(
-                  onPressed:
-                      identifying == amp.uuid ? null : () => onChime!(amp),
-                  icon: const Icon(Icons.volume_up_outlined, size: 18),
-                  label: const Text('Chime'),
-                ),
-            ],
-          ),
+          identifyControls(amp),
         ],
       ],
     );

--- a/lib/features/group/group_detail_screen.dart
+++ b/lib/features/group/group_detail_screen.dart
@@ -7,6 +7,7 @@ import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/bonding_progress_screen.dart';
+import '../widgets/confirm_dialog.dart';
 import '../widgets/busy_view.dart';
 import '../widgets/destructive_button.dart';
 import '../widgets/pill_chip.dart';
@@ -97,28 +98,15 @@ class GroupDetailScreen extends ConsumerWidget {
 
   Future<void> _confirmSeparate(
       BuildContext context, WidgetRef ref, ZoneGroupMember group) async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        icon: const Icon(Icons.link_off),
-        title: const Text('Separate group?'),
-        content: const Text(
-            'The speakers become standalone rooms again. Their original room '
-            'names will be restored.'),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(
-                foregroundColor: Theme.of(ctx).colorScheme.error),
-            child: const Text('Separate'),
-          ),
-        ],
-      ),
+    final ok = await confirmDialog(
+      context,
+      icon: Icons.link_off,
+      title: 'Separate group?',
+      message: 'The speakers become standalone rooms again. Their original room '
+          'names will be restored.',
+      confirmLabel: 'Separate',
     );
-    if (ok != true || !context.mounted) return;
+    if (!ok || !context.mounted) return;
     final controller = ref.read(sonosControllerProvider.notifier);
     final outcome = await showBondingProgress(
       context,

--- a/lib/features/home_theater/home_theater_screen.dart
+++ b/lib/features/home_theater/home_theater_screen.dart
@@ -8,6 +8,7 @@ import '../../state/sonos_controller.dart';
 import '../../state/trueplay_controller.dart';
 import '../widgets/bonding_progress_screen.dart';
 import '../widgets/busy_view.dart';
+import '../widgets/confirm_dialog.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/destructive_button.dart';
 import '../widgets/diagram_labels.dart';
@@ -116,30 +117,15 @@ class HomeTheaterScreen extends ConsumerWidget {
     Set<SonosChannel> channels,
     String label,
   ) async {
-    final scheme = Theme.of(context).colorScheme;
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        icon: const Icon(Icons.link_off),
-        title: Text('Remove $label?'),
-        content: Text(
-          'These speakers will be un-bonded and become standalone rooms again. '
-          'The rest of your home theater stays as it is.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(foregroundColor: scheme.error),
-            child: const Text('Remove'),
-          ),
-        ],
-      ),
+    final ok = await confirmDialog(
+      context,
+      icon: Icons.link_off,
+      title: 'Remove $label?',
+      message: 'These speakers will be un-bonded and become standalone rooms '
+          'again. The rest of your home theater stays as it is.',
+      confirmLabel: 'Remove',
     );
-    if (ok != true || !context.mounted) return;
+    if (!ok || !context.mounted) return;
 
     final controller = ref.read(sonosControllerProvider.notifier);
     // No success toast — the progress screen already showed the outcome.

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -6,6 +6,7 @@ import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/app_scaffold.dart';
+import '../widgets/confirm_dialog.dart';
 import 'profile.dart';
 import 'profile_controller.dart';
 import 'profile_ui.dart';
@@ -282,30 +283,17 @@ class _State extends ConsumerState<ProfileCreateScreen> {
 
     if (existing != null) {
       // Re-snapshot: gate the overwrite behind an explicit confirm before we
-      // do the (potentially slow) settings read.
-      final ok = await showDialog<bool>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: Text('Replace “${existing.name}”?'),
-          content: const Text(
-            'The previously captured layout will be permanently replaced '
+      // do the (potentially slow) settings read. Not destructive-tinted — it
+      // replaces saved data, not the live speakers.
+      final ok = await confirmDialog(
+        context,
+        title: 'Replace “${existing.name}”?',
+        message: 'The previously captured layout will be permanently replaced '
             'with your current setup.',
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel'),
-            ),
-            // TextButton (not FilledButton) so the actions stay horizontal — the
-            // theme stretches FilledButton to full width, which forces a stack.
-            TextButton(
-              onPressed: () => Navigator.pop(ctx, true),
-              child: const Text('Replace'),
-            ),
-          ],
-        ),
+        confirmLabel: 'Replace',
+        destructive: false,
       );
-      if (ok != true) return;
+      if (!ok) return;
     }
 
     // Reading settings is several SOAP calls per speaker — show progress and

--- a/lib/features/profiles/profiles_screen.dart
+++ b/lib/features/profiles/profiles_screen.dart
@@ -6,6 +6,7 @@ import '../../core/theme.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/bonding_progress_screen.dart';
 import '../widgets/app_scaffold.dart';
+import '../widgets/confirm_dialog.dart';
 import 'profile.dart';
 import 'profile_controller.dart';
 import 'profile_ui.dart';
@@ -91,30 +92,13 @@ class ProfilesScreen extends ConsumerWidget {
     WidgetRef ref,
     Profile p,
   ) async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text('Delete “${p.name}”?'),
-        content: const Text(
-          'This removes the saved profile. Your speakers are '
-          'not changed.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(
-              foregroundColor: Theme.of(ctx).colorScheme.error,
-            ),
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+    final ok = await confirmDialog(
+      context,
+      title: 'Delete “${p.name}”?',
+      message: 'This removes the saved profile. Your speakers are not changed.',
+      confirmLabel: 'Delete',
     );
-    if (ok == true) await ref.read(profilesProvider.notifier).remove(p.id);
+    if (ok) await ref.read(profilesProvider.notifier).remove(p.id);
   }
 }
 

--- a/lib/features/widgets/bonding_progress_screen.dart
+++ b/lib/features/widgets/bonding_progress_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/theme.dart';
 import '../../data/sonos/cancellation.dart';
 import '../../state/sonos_controller.dart';
+import 'confirm_dialog.dart';
 import 'app_scaffold.dart';
 import 'apply_progress_view.dart';
 
@@ -85,28 +86,16 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
   }
 
   Future<void> _confirmAbort() async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        icon: const Icon(Icons.warning_amber),
-        title: const Text('Abort?'),
-        content: const Text(
-            'Stopping now can leave your speakers in an in-between state — some '
-            'changes may be half-applied. You can re-apply afterwards to fix it.'),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Keep going')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(
-                foregroundColor: Theme.of(ctx).colorScheme.error),
-            child: const Text('Abort'),
-          ),
-        ],
-      ),
+    final ok = await confirmDialog(
+      context,
+      icon: Icons.warning_amber,
+      title: 'Abort?',
+      message: 'Stopping now can leave your speakers in an in-between state — '
+          'some changes may be half-applied. You can re-apply afterwards to fix it.',
+      confirmLabel: 'Abort',
+      cancelLabel: 'Keep going',
     );
-    if (ok == true && mounted) {
+    if (ok && mounted) {
       setState(() => _aborting = true);
       ref.read(sonosControllerProvider.notifier).cancelActiveOperation();
     }

--- a/lib/features/widgets/confirm_dialog.dart
+++ b/lib/features/widgets/confirm_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+/// Shared yes/no confirmation dialog. Returns true only if the user taps the
+/// confirm action (false on cancel or dismiss). [destructive] tints the confirm
+/// label with the error color; both actions are `TextButton`s so they stay
+/// horizontal (the theme stretches `FilledButton` to full width, forcing a
+/// stack). Replaces the six hand-rolled confirm dialogs across the features.
+Future<bool> confirmDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  required String confirmLabel,
+  String cancelLabel = 'Cancel',
+  IconData? icon,
+  bool destructive = true,
+}) async {
+  final ok = await showDialog<bool>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      icon: icon == null ? null : Icon(icon),
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(cancelLabel)),
+        TextButton(
+          onPressed: () => Navigator.pop(ctx, true),
+          style: destructive
+              ? TextButton.styleFrom(
+                  foregroundColor: Theme.of(ctx).colorScheme.error)
+              : null,
+          child: Text(confirmLabel),
+        ),
+      ],
+    ),
+  );
+  return ok == true;
+}

--- a/lib/features/widgets/diagram_labels.dart
+++ b/lib/features/widgets/diagram_labels.dart
@@ -1,19 +1,5 @@
 import '../../data/models/sonos_models.dart';
 
-/// Best-effort speaker label for a bonded channel, derived from the
-/// authoritative `HTSatChanMapSet`: discovered device name → satellite zone
-/// name → generic. Returns null when no speaker is assigned to [channel].
-String? labelForChannel(
-    SonosSystem system, ZoneGroupMember member, SonosChannel channel) {
-  final uuid = member.channelAssignments[channel];
-  if (uuid == null) return null;
-  final dev = system.device(uuid);
-  if (dev != null) return dev.roomName;
-  final sat = member.satellites.where((s) => s.uuid == uuid);
-  if (sat.isNotEmpty && sat.first.zoneName.isNotEmpty) return sat.first.zoneName;
-  return 'Speaker';
-}
-
 /// Speaker TYPE for a bonded channel (e.g. "Play:1", "Sub (Gen 1/2)"), or null
 /// when no speaker is assigned — the room name just echoes the HT name, so the
 /// type is the useful label on the diagram.

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -155,7 +155,10 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         if (s.hasVolume) 'volume',
       ].join(' + ');
       ph.note('restoring $what — ${dev!.typeLabel}');
-      await _settings.apply(ip, s);
+      final failed = await _settings.apply(ip, s);
+      if (failed > 0) {
+        ph.note('$failed setting(s) for ${dev.typeLabel} could not be applied');
+      }
     }
   }
 
@@ -596,19 +599,25 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     state = const AsyncValue.loading();
     final result = await AsyncValue.guard(() async {
       await _repo.setRoomName(ip: ip, name: name);
+      bool propagated(SonosSystem s) =>
+          s.allMembers.any((m) => m.uuid == device.uuid && m.zoneName == name);
       var system = await _pollUntil(
         previous: previous,
         ip: ip,
         attempts: 8,
-        until: (s) => s.allMembers.any((m) => m.uuid == device.uuid && m.zoneName == name),
+        until: propagated,
       );
-      // refresh() reuses the prior device index, so patch the renamed device so
-      // its roomName isn't stale until the next full scan.
-      final patched = {
-        for (final e in system.devicesByUuid.entries)
-          e.key: e.key == device.uuid ? e.value.copyWith(roomName: name) : e.value
-      };
-      system = SonosSystem(groups: system.groups, devicesByUuid: patched);
+      // Only assert the new name once the topology actually confirms it —
+      // otherwise return the real read rather than an optimistic name Sonos
+      // never took. refresh() reuses the prior device index, so patch the
+      // renamed device so its roomName isn't stale until the next full scan.
+      if (propagated(system)) {
+        final patched = {
+          for (final e in system.devicesByUuid.entries)
+            e.key: e.key == device.uuid ? e.value.copyWith(roomName: name) : e.value
+        };
+        system = SonosSystem(groups: system.groups, devicesByUuid: patched);
+      }
       return system;
     });
     state = result;
@@ -648,18 +657,22 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         await _repo.removeHtSatellites(
             soundbarIp: ip, uuids: uuids, cancel: _activeOp);
         ph.phase('settle', 'Wait for Sonos to settle');
-        final sys = await _pollUntil(
-          previous: previous,
-          ip: ip,
-          until: (s) {
-            final m = s.allMembers
-                .where((x) => x.uuid == soundbar.uuid)
-                .cast<ZoneGroupMember?>()
-                .firstOrNull;
-            if (m == null) return true;
-            return channels.every((c) => !m.channelAssignments.containsKey(c));
-          },
-        );
+        // The soundbar itself always survives an unbond; a null member here is
+        // the transient mid-reshuffle drop-out, NOT confirmation — keep polling.
+        bool rolesGone(SonosSystem s) {
+          final m = s.allMembers
+              .where((x) => x.uuid == soundbar.uuid)
+              .cast<ZoneGroupMember?>()
+              .firstOrNull;
+          if (m == null) return false;
+          return channels.every((c) => !m.channelAssignments.containsKey(c));
+        }
+
+        final sys = await _pollUntil(previous: previous, ip: ip, until: rolesGone);
+        // Sonos can 200-OK an unbond yet silently no-op — re-assert before done.
+        if (!rolesGone(sys)) {
+          throw Exception('Sonos did not remove the $label — try again.');
+        }
         tracker.done('remove');
         return sys;
       } on OperationCancelled {

--- a/test/device_properties_test.dart
+++ b/test/device_properties_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/data/sonos/device_properties.dart';
+import 'package:sonority/data/sonos/soap_client.dart';
+import 'package:xml/xml.dart';
+
+/// Returns a canned SOAP Body so we can exercise parsing without a network.
+class _FakeSoap extends SonosSoapClient {
+  final String bodyXml;
+  _FakeSoap(this.bodyXml);
+
+  @override
+  Future<XmlElement> call({
+    required String ip,
+    required String controlPath,
+    required String serviceType,
+    required String action,
+    Map<String, String> args = const {},
+    Duration timeout = const Duration(seconds: 8),
+  }) async =>
+      XmlDocument.parse(bodyXml).rootElement;
+}
+
+void main() {
+  group('DevicePropertiesClient.getZoneAttributes parsing', () {
+    Future<ZoneAttributes> parse(String innerBody) =>
+        DevicePropertiesClient(_FakeSoap('<Body>$innerBody</Body>'))
+            .getZoneAttributes('1.2.3.4');
+
+    test('maps all three fields', () async {
+      final a = await parse('<CurrentZoneName>Living Room</CurrentZoneName>'
+          '<CurrentIcon>x-rincon-roomicon:living</CurrentIcon>'
+          '<CurrentConfiguration>1</CurrentConfiguration>');
+      expect(a.zoneName, 'Living Room');
+      expect(a.icon, 'x-rincon-roomicon:living');
+      expect(a.configuration, '1');
+    });
+
+    test('missing elements default to empty string, never null-crash', () async {
+      final a = await parse('<CurrentZoneName>Kitchen</CurrentZoneName>');
+      expect(a.zoneName, 'Kitchen');
+      expect(a.icon, '');
+      expect(a.configuration, '');
+    });
+  });
+}

--- a/test/soap_envelope_test.dart
+++ b/test/soap_envelope_test.dart
@@ -1,3 +1,5 @@
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonority/data/sonos/soap_client.dart';
 import 'package:xml/xml.dart';
@@ -49,5 +51,38 @@ void main() {
     );
     expect(xml, contains('Living &amp; &lt;Room&gt;'));
     expect(xml, isNot(contains('Living & <Room>')));
+  });
+
+  group('SonosSoapClient.call error handling', () {
+    Future<XmlElement> callWith(int status, String body) {
+      final client = MockClient((_) async => http.Response(body, status));
+      return SonosSoapClient(client).call(
+        ip: '1.2.3.4',
+        controlPath: '/x/Control',
+        serviceType: 'svc',
+        action: 'DoThing',
+      );
+    }
+
+    test('non-200 with a non-XML body throws SonosSoapException, not XmlException',
+        () async {
+      // Regression: the body used to be parsed before the status check, so a
+      // truncated/empty error body threw XmlParserException and callers keyed on
+      // SonosSoapException never ran.
+      await expectLater(
+        callWith(500, 'gateway timeout - not xml'),
+        throwsA(isA<SonosSoapException>()
+            .having((e) => e.statusCode, 'statusCode', 500)),
+      );
+    });
+
+    test('non-200 with a SOAP fault body extracts the fault code', () async {
+      await expectLater(
+        callWith(500,
+            '<Body><faultstring>UPnPError</faultstring><errorCode>402</errorCode></Body>'),
+        throwsA(isA<SonosSoapException>()
+            .having((e) => e.faultCode, 'faultCode', '402')),
+      );
+    });
   });
 }

--- a/test/zone_topology_test.dart
+++ b/test/zone_topology_test.dart
@@ -36,6 +36,10 @@ void main() {
     final ls = ht.satellites.firstWhere((s) => s.uuid == 'RINCON_S101400');
     expect(ls.channels, [SonosChannel.leftRear]);
     expect(ls.isRear, isTrue);
+    // A satellite resolves its own IP + name from its Location, independent of
+    // the primary (drives the name-restore-after-unbond path).
+    expect(ls.ip, '192.168.1.11');
+    expect(ls.zoneName, 'Living Room (LS)');
     expect(ht.hasDedicatedFronts, isFalse);
     expect(ht.ip, '192.168.1.10');
 

--- a/tool/discover_util.dart
+++ b/tool/discover_util.dart
@@ -7,7 +7,9 @@ import 'dart:io';
 
 import 'package:sonority/data/models/sonos_models.dart';
 import 'package:sonority/data/sonos/device_description.dart';
+import 'package:sonority/data/sonos/soap_client.dart';
 import 'package:sonority/data/sonos/ssdp_discovery.dart';
+import 'package:sonority/data/sonos/zone_topology.dart';
 
 /// Discovers all players and fetches each one's device description, silently
 /// skipping any whose description fetch fails. The shared read path for tools.
@@ -106,3 +108,57 @@ Map<String, String> parseArgs(List<String> argv,
 
 /// Fixed wait for Sonos topology to begin settling after a write.
 Future<void> settle() => Future<void>.delayed(const Duration(seconds: 4));
+
+/// A uuid-indexed view of the discovered system for the per-speaker probe tools:
+/// IP and "Room (Model)" label per uuid, one reachable IP ([anyIp], null if
+/// nothing answered), and each bonded uuid's channel token(s) from the live
+/// HT / stereo-pair / zone maps.
+class DiscoveryIndex {
+  final Map<String, String> ipByUuid;
+  final Map<String, String> labelByUuid;
+  final String? anyIp;
+  final Map<String, String> channelByUuid;
+  DiscoveryIndex(this.ipByUuid, this.labelByUuid, this.anyIp, this.channelByUuid);
+
+  /// Resolves a room-name substring or a uuid to a uuid we have an IP for.
+  String? resolve(String roomOrUuid) {
+    if (ipByUuid.containsKey(roomOrUuid)) return roomOrUuid;
+    final hit = labelByUuid.entries.firstWhere(
+      (e) => e.value.toLowerCase().contains(roomOrUuid.toLowerCase()),
+      orElse: () => const MapEntry('', ''),
+    );
+    return hit.key.isEmpty ? null : hit.key;
+  }
+}
+
+/// Discovers the system and builds a [DiscoveryIndex] (shared by eq_probe /
+/// trueplay_probe). Reads topology from the first reachable player.
+Future<DiscoveryIndex> discoverIndexed() async {
+  final ipByUuid = <String, String>{};
+  final labelByUuid = <String, String>{};
+  String? anyIp;
+  for (final d in await discoverDevices()) {
+    if (d.ip == null) continue;
+    anyIp ??= d.ip;
+    ipByUuid[d.uuid] = d.ip!;
+    labelByUuid[d.uuid] = '${d.roomName} (${d.modelName})';
+  }
+  final channelByUuid = <String, String>{};
+  if (anyIp != null) {
+    final groups = await ZoneTopologyClient(SonosSoapClient()).getZoneGroups(anyIp);
+    for (final g in groups) {
+      for (final m in g.members) {
+        for (final raw in [m.htSatChanMapSet, m.channelMapSet]) {
+          if (raw == null || raw.isEmpty) continue;
+          for (final part in raw.split(';')) {
+            final c = part.indexOf(':');
+            if (c < 0) continue;
+            channelByUuid[part.substring(0, c).trim()] =
+                part.substring(c + 1).trim();
+          }
+        }
+      }
+    }
+  }
+  return DiscoveryIndex(ipByUuid, labelByUuid, anyIp, channelByUuid);
+}

--- a/tool/discover_util.dart
+++ b/tool/discover_util.dart
@@ -6,6 +6,7 @@
 import 'dart:io';
 
 import 'package:sonority/data/models/sonos_models.dart';
+import 'package:sonority/data/sonos/channel_map.dart';
 import 'package:sonority/data/sonos/device_description.dart';
 import 'package:sonority/data/sonos/soap_client.dart';
 import 'package:sonority/data/sonos/ssdp_discovery.dart';
@@ -144,20 +145,25 @@ Future<DiscoveryIndex> discoverIndexed() async {
     labelByUuid[d.uuid] = '${d.roomName} (${d.modelName})';
   }
   final channelByUuid = <String, String>{};
-  if (anyIp != null) {
-    final groups = await ZoneTopologyClient(SonosSoapClient()).getZoneGroups(anyIp);
-    for (final g in groups) {
-      for (final m in g.members) {
-        for (final raw in [m.htSatChanMapSet, m.channelMapSet]) {
-          if (raw == null || raw.isEmpty) continue;
-          for (final part in raw.split(';')) {
-            final c = part.indexOf(':');
-            if (c < 0) continue;
-            channelByUuid[part.substring(0, c).trim()] =
-                part.substring(c + 1).trim();
+  // Topology is a system-wide query any player can answer; try each until one
+  // responds so a single unreachable device doesn't fail the probe (mirrors
+  // SonosRepository.discover).
+  for (final ip in ipByUuid.values) {
+    try {
+      final groups = await ZoneTopologyClient(SonosSoapClient()).getZoneGroups(ip);
+      for (final g in groups) {
+        for (final m in g.members) {
+          for (final raw in [m.htSatChanMapSet, m.channelMapSet]) {
+            if (raw == null || raw.isEmpty) continue;
+            for (final e in ChannelMap.parse(raw).entries) {
+              channelByUuid[e.uuid] = e.tokens.join(',');
+            }
           }
         }
       }
+      break;
+    } catch (_) {
+      // Try the next player.
     }
   }
   return DiscoveryIndex(ipByUuid, labelByUuid, anyIp, channelByUuid);

--- a/tool/eq_probe.dart
+++ b/tool/eq_probe.dart
@@ -19,7 +19,6 @@ import 'package:xml/xml.dart';
 
 import 'package:sonority/data/sonos/soap_client.dart';
 import 'package:sonority/data/sonos/speaker_settings.dart' show eqTypes;
-import 'package:sonority/data/sonos/zone_topology.dart';
 
 import 'discover_util.dart';
 
@@ -124,50 +123,21 @@ Future<String> _readAll(String ip) async {
 
 Future<void> main(List<String> argv) async {
   print('🔎 Discovery…');
-  final ipByUuid = <String, String>{};
-  final labelByUuid = <String, String>{};
-  String? anyIp;
-  for (final d in await discoverDevices()) {
-    if (d.ip == null) continue;
-    anyIp ??= d.ip;
-    ipByUuid[d.uuid] = d.ip!;
-    labelByUuid[d.uuid] = '${d.roomName} (${d.modelName})';
-  }
-  if (anyIp == null) {
+  final index = await discoverIndexed();
+  if (index.anyIp == null) {
     print('❌ Could not read any device description.');
     return;
   }
-
-  // Map uuid -> channel token(s) from any HT map or stereo-pair/zone map.
-  final channelByUuid = <String, String>{};
-  final groups = await ZoneTopologyClient(SonosSoapClient()).getZoneGroups(anyIp);
-  for (final g in groups) {
-    for (final m in g.members) {
-      for (final raw in [m.htSatChanMapSet, m.channelMapSet]) {
-        if (raw == null || raw.isEmpty) continue;
-        for (final part in raw.split(';')) {
-          final c = part.indexOf(':');
-          if (c < 0) continue;
-          channelByUuid[part.substring(0, c).trim()] = part.substring(c + 1).trim();
-        }
-      }
-    }
-  }
-
-  String? resolve(String roomOrUuid) {
-    if (ipByUuid.containsKey(roomOrUuid)) return roomOrUuid;
-    final hit = labelByUuid.entries.firstWhere(
-      (e) => e.value.toLowerCase().contains(roomOrUuid.toLowerCase()),
-      orElse: () => const MapEntry('', ''),
-    );
-    return hit.key.isEmpty ? null : hit.key;
-  }
+  final ipByUuid = index.ipByUuid;
+  final labelByUuid = index.labelByUuid;
+  final channelByUuid = index.channelByUuid;
+  final anyIp = index.anyIp!;
 
   // ---- write round-trip: bump Bass by +1, then restore (confirms writes) ----
   if (argv.contains('--test')) {
     final idx = argv.indexOf('--test');
     final target = (idx + 1 < argv.length) ? argv[idx + 1] : '';
-    final uuid = resolve(target);
+    final uuid = index.resolve(target);
     if (uuid == null) {
       print('❌ No speaker matching "$target".');
       return;

--- a/tool/full_layout.dart
+++ b/tool/full_layout.dart
@@ -30,14 +30,14 @@ import 'dart:io';
 
 import 'package:sonority/data/models/sonos_models.dart';
 import 'package:sonority/data/sonos/channel_map.dart';
-import 'package:sonority/data/sonos/device_description.dart';
 import 'package:sonority/data/sonos/device_properties.dart';
 import 'package:sonority/data/sonos/soap_client.dart';
-import 'package:sonority/data/sonos/ssdp_discovery.dart';
 import 'package:sonority/data/sonos/zone_topology.dart';
 
+import 'discover_util.dart';
+
 Future<void> main(List<String> argv) async {
-  final args = _parseArgs(argv);
+  final args = parseArgs(argv, flags: {'confirm'});
   final barSel = args['bar'];
   final confirm = args.containsKey('confirm');
   if (barSel == null) {
@@ -47,14 +47,7 @@ Future<void> main(List<String> argv) async {
   }
 
   print('🔎 Discovering system…');
-  final locations = await SsdpDiscovery().discover();
-  final descriptions = DeviceDescriptionClient();
-  final devices = <SonosDevice>[];
-  for (final loc in locations) {
-    try {
-      devices.add(await descriptions.fetch(loc));
-    } catch (_) {}
-  }
+  final devices = await discoverDevices();
   if (devices.isEmpty) {
     print('❌ No devices found.');
     exit(1);
@@ -63,7 +56,7 @@ Future<void> main(List<String> argv) async {
   final topology = ZoneTopologyClient(SonosSoapClient());
   var groups = await topology.getZoneGroups(anyIp);
 
-  final barDevice = _resolveDevice(devices, barSel, mustBeSoundbar: true);
+  final barDevice = resolveDevice(devices, barSel, mustBeSoundbar: true);
   final bar = _findMember(groups, barDevice.uuid);
   final barIp = bar?.ip;
   if (bar == null || barIp == null) {
@@ -76,11 +69,11 @@ Future<void> main(List<String> argv) async {
   // Explicit roles → build a different layout from bare; otherwise rebuild the
   // current one (the realistic profile-apply test).
   final roles = <(SonosChannel, SonosDevice)>[
-    if (args['left'] != null) (SonosChannel.leftFront, _resolveDevice(devices, args['left']!)),
-    if (args['right'] != null) (SonosChannel.rightFront, _resolveDevice(devices, args['right']!)),
-    if (args['rear-left'] != null) (SonosChannel.leftRear, _resolveDevice(devices, args['rear-left']!)),
-    if (args['rear-right'] != null) (SonosChannel.rightRear, _resolveDevice(devices, args['rear-right']!)),
-    if (args['sub'] != null) (SonosChannel.sub, _resolveDevice(devices, args['sub']!)),
+    if (args['left'] != null) (SonosChannel.leftFront, resolveDevice(devices, args['left']!)),
+    if (args['right'] != null) (SonosChannel.rightFront, resolveDevice(devices, args['right']!)),
+    if (args['rear-left'] != null) (SonosChannel.leftRear, resolveDevice(devices, args['rear-left']!)),
+    if (args['rear-right'] != null) (SonosChannel.rightRear, resolveDevice(devices, args['rear-right']!)),
+    if (args['sub'] != null) (SonosChannel.sub, resolveDevice(devices, args['sub']!)),
   ];
   final rebuild = roles.isEmpty;
   final target = rebuild
@@ -203,46 +196,4 @@ ZoneGroupMember? _findMember(List<ZoneGroup> groups, String uuid) {
     }
   }
   return null;
-}
-
-SonosDevice _resolveDevice(List<SonosDevice> devices, String selector,
-    {bool mustBeSoundbar = false}) {
-  if (selector.startsWith('RINCON_')) {
-    final match = devices.where((d) => d.uuid == selector);
-    if (match.isEmpty) {
-      print('❌ No device with uuid $selector');
-      exit(1);
-    }
-    return match.first;
-  }
-  final byName = devices
-      .where((d) => d.roomName.toLowerCase() == selector.toLowerCase())
-      .where((d) => !mustBeSoundbar || d.isSoundbar)
-      .toList();
-  if (byName.isEmpty) {
-    print('❌ No ${mustBeSoundbar ? "soundbar" : "device"} in room "$selector". '
-        'Use a RINCON_ uuid instead.');
-    exit(1);
-  }
-  if (byName.length > 1) {
-    print('❌ Room "$selector" matches ${byName.length} devices — use a RINCON_ uuid.');
-    exit(1);
-  }
-  return byName.first;
-}
-
-Map<String, String> _parseArgs(List<String> argv) {
-  final out = <String, String>{};
-  const flags = {'confirm'};
-  for (var i = 0; i < argv.length; i++) {
-    final a = argv[i];
-    if (!a.startsWith('--')) continue;
-    final key = a.substring(2);
-    if (flags.contains(key)) {
-      out[key] = 'true';
-    } else if (i + 1 < argv.length) {
-      out[key] = argv[++i];
-    }
-  }
-  return out;
 }

--- a/tool/trueplay_probe.dart
+++ b/tool/trueplay_probe.dart
@@ -17,7 +17,6 @@ import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart';
 
 import 'package:sonority/data/sonos/soap_client.dart';
-import 'package:sonority/data/sonos/zone_topology.dart';
 
 import 'discover_util.dart';
 
@@ -89,45 +88,15 @@ Future<void> _setEnabled(String ip, bool on) => _soap.call(
 
 Future<void> main(List<String> argv) async {
   print('🔎 Discovery…');
-  final ipByUuid = <String, String>{};
-  final labelByUuid = <String, String>{};
-  String? anyIp;
-  for (final d in await discoverDevices()) {
-    if (d.ip == null) continue;
-    anyIp ??= d.ip;
-    ipByUuid[d.uuid] = d.ip!;
-    labelByUuid[d.uuid] = '${d.roomName} (${d.modelName})';
-  }
-  if (anyIp == null) {
+  final index = await discoverIndexed();
+  if (index.anyIp == null) {
     print('❌ Could not read any device description.');
     return;
   }
-
-  // Map uuid -> channel token(s) from any HT map or stereo-pair map.
-  final channelByUuid = <String, String>{};
-  final groups =
-      await ZoneTopologyClient(SonosSoapClient()).getZoneGroups(anyIp);
-  for (final g in groups) {
-    for (final m in g.members) {
-      for (final raw in [m.htSatChanMapSet, m.channelMapSet]) {
-        if (raw == null || raw.isEmpty) continue;
-        for (final part in raw.split(';')) {
-          final c = part.indexOf(':');
-          if (c < 0) continue;
-          channelByUuid[part.substring(0, c).trim()] = part.substring(c + 1).trim();
-        }
-      }
-    }
-  }
-
-  String? resolve(String roomOrUuid) {
-    if (ipByUuid.containsKey(roomOrUuid)) return roomOrUuid;
-    final hit = labelByUuid.entries.firstWhere(
-      (e) => e.value.toLowerCase().contains(roomOrUuid.toLowerCase()),
-      orElse: () => const MapEntry('', ''),
-    );
-    return hit.key.isEmpty ? null : hit.key;
-  }
+  final ipByUuid = index.ipByUuid;
+  final labelByUuid = index.labelByUuid;
+  final channelByUuid = index.channelByUuid;
+  final anyIp = index.anyIp!;
 
   // ---- write modes (reversible: enable flag only) ----
   final wantEnable = argv.contains('--enable');
@@ -135,7 +104,7 @@ Future<void> main(List<String> argv) async {
   if (wantEnable || wantDisable) {
     final idx = argv.indexOf(wantEnable ? '--enable' : '--disable');
     final target = (idx + 1 < argv.length) ? argv[idx + 1] : '';
-    final uuid = resolve(target);
+    final uuid = index.resolve(target);
     if (uuid == null) {
       print('❌ No speaker matching "$target".');
       return;


### PR DESCRIPTION
Remediates a full-application review against the repo's review guidelines (correctness/live-write safety, ponytail, product-principle, docs, tests). Baseline was already healthy — these are incremental hardening + cleanup. `flutter analyze` clean; `flutter test` 151/151.

## Correctness & live-write safety
- **soap_client** — parse the SOAP body **after** the status check, so a non-200 non-XML error body raises `SonosSoapException` (with fault code) instead of `XmlParserException`; callers keyed on the former now run.
- **removeHtRoles** — a transiently-vanished coordinator (the ~15s reshuffle) is no longer read as success; re-asserts the channels are gone before reporting done, like `createGroup`/`separateGroup`.
- **freeSpeaker** — restores room names after dissolving a named group (shared `_restoreZoneNames` helper, also used by `separateGroup`) instead of leaving members under the coordinator's absorbed name.
- **discover()** — falls back to the next reachable player for the topology read instead of trusting `found.first`.
- **bondAndVerify** — rethrows non-transient SOAP faults immediately (only UPnPError 800 is transient) rather than retrying ~160s and masking a malformed map as "channels never joined".
- **renameRoom** — only asserts the new name once topology confirms it.
- **speaker_settings.apply** — returns a failed-write count; the restore step surfaces it instead of silently swallowing every fault.
- engine no longer imports Flutter (`debugPrint` → `dart:developer`).

## Ponytail cleanup (~net -50 lines)
- delete dead `labelForChannel` / `ChannelMap.withEntries`.
- shared `confirmDialog` widget replaces 6 hand-rolled `AlertDialog`s.
- `_AmpWiringNote` reuses the `identifyButtons` builder instead of re-threading 3 identify params.
- `full_layout` ported onto `discover_util`; `discoverIndexed()` extracted and shared by `eq_probe` / `trueplay_probe`.

## Docs & tests
- CLAUDE.md product-principle list corrected (Trueplay **measurement**, EQ **editing**) so it no longer forbids shipped capture/toggle features.
- `sonos_repository` docstring corrected (only zone *names* are persisted; HT undo is in-memory).
- new tests: `getZoneAttributes` parsing, satellite `ip`/`zoneName` extraction, SOAP error-path guard.

## Hardware validation (live Beam 5.1)
- F3 topology failover, `discover_util` port, `discoverIndexed`, diff no-op, and **`bondAndVerify`'s transient-800 re-assert path** all confirmed. Every `AddHTSatellite` faulted with `code=800` and the re-assert loop converged correctly. System verified fully restored afterward.
- F1/F2 live in the Flutter controller layer (not CLI-reachable) — covered by unit tests + the validated engine primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)