### PR TITLE
fix(ci): macOS TestFlight signing + surface failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,9 +254,9 @@ jobs:
 
       - name: Build & upload macOS → TestFlight
         if: env.HAS_SIGNING == 'true'
-        # Best-effort: macOS TestFlight processing is finicky and this job blocks
-        # nothing, so a failure here shouldn't fail the run.
-        continue-on-error: true
+        # A failure here turns the run red so it's never silently green — but it
+        # still blocks nothing: macos-testflight isn't in publish-github's needs,
+        # so the GitHub Release ships regardless.
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Fixed
+- Internal: the macOS TestFlight CI job was silently failing at fastlane `match` (it tried to fetch a nonexistent macOS profile for the iOS-only ProfileWidget) yet showing green via `continue-on-error`. macOS `match` now fetches the app profile only, and the step no longer masks failures.
+
 ## [0.5.0] - 2026-07-12
 
 ### Added

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,6 +81,10 @@ def ci_signing(platform)
     platform: platform,
     readonly: true,
     api_key: asc_key,
+    # The Matchfile lists both app ids, but ProfileWidget is an iOS-only extension
+    # (no macOS target/profile) — so macOS match must fetch the app profile only,
+    # else it fails looking for a nonexistent macOS widget profile.
+    app_identifier: platform == "macos" ? [APP_ID] : [APP_ID, WIDGET_APP_ID],
     additional_cert_types: platform == "macos" ? ["mac_installer_distribution"] : nil,
   )
   proj = platform == "macos" ? "macos/Runner.xcodeproj" : "ios/Runner.xcodeproj"
@@ -180,7 +184,10 @@ platform :mac do
   desc "Create/refresh the shared macOS signing assets in the match repo"
   lane :certificates do
     # App Store distribution cert (+ installer) for TestFlight / Mac App Store.
+    # app_identifier: [APP_ID] only — the widget is iOS-only, so don't try to
+    # create a macOS widget profile (see ci_signing).
     match(type: "appstore", platform: "macos", readonly: false, api_key: asc_key,
+          app_identifier: [APP_ID],
           additional_cert_types: ["mac_installer_distribution"])
     # NB: the Developer ID Application cert (for the notarized .dmg) canNOT be
     # created via the App Store Connect API — Apple restricts creation to the


### PR DESCRIPTION
## Problem

The `macOS — TestFlight` CI job reports **green** but never uploads to TestFlight. It dies in ~2.5 min at fastlane `match` (vs iOS's ~9 min full run), masked by `continue-on-error: true`.

**Root cause:** `fastlane/Matchfile` globally lists both bundle ids — `be.casperverswijvelt.sonority` **and** `...ProfileWidget`. `ProfileWidget` is an iOS-only WidgetKit extension, so macOS `match` (readonly) fails fetching a macOS profile for it (`AppStore_...ProfileWidget.provisionprofile`) that doesn't — and shouldn't — exist. Regression from the iOS widget addition (builds 50010/50011); build 50009 ran the full macOS upload.

The macOS build has no widget target — `ci_signing` only signs `["Runner"]` and `archive_apple("macos")` only maps the app id. The widget only leaked in via the Matchfile global.

## Changes

- **`fastlane/Fastfile`** — scope macOS `match` to `app_identifier: [APP_ID]` in both `ci_signing` and the `mac certificates` lane. iOS keeps both ids (unchanged; iOS TestFlight already passes).
- **`.github/workflows/release.yml`** — remove `continue-on-error: true` from the macOS TestFlight step so a real failure turns the run red. It still doesn't block the GitHub Release (`macos-testflight` isn't in `publish-github`'s `needs`).
- **`CHANGELOG.md`** — internal `Fixed` note.

## Verification

Static checks done (Ruby syntax + YAML parse OK). End-to-end needs a real tag on `main`: watch the `macos-testflight` job reach `upload_to_testflight` and run its full length instead of dying at `match`. Verifying after it hits main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)