### PR TITLE
fix(ui): use w300 for apply-progress subtitles (Roboto has no w200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Fixed
+- Apply-progress sub-step subtitles no longer render with a broken synthetic font weight on Android (Roboto has no `w200`; use `w300`).
+
 ## [0.5.0] - 2026-07-12
 
 ### Added

--- a/lib/features/widgets/apply_progress_view.dart
+++ b/lib/features/widgets/apply_progress_view.dart
@@ -179,7 +179,7 @@ class _TimelineRow extends StatelessWidget {
                       child: Text(step.detail!,
                           style: theme.textTheme.bodySmall?.copyWith(
                               color: scheme.onSurfaceVariant,
-                              fontWeight: FontWeight.w200)),
+                              fontWeight: FontWeight.w300)),
                     ),
                 ],
               ),


### PR DESCRIPTION
## Problem
In the apply-progress stepper ("Applying …" screen), each phase sub-step shows a grey subtitle like *"layout unchanged — nothing to do"*. It rendered fine on iOS/macOS but looked broken on Android (see screenshots below).

## Root cause
The subtitle style hard-coded `FontWeight.w200`. Apple's system font (SF Pro) has a genuine extra-light `w200`, so it looked fine. Android's default font is **Roboto**, which ships no `w200` weight — the platform fell back to a synthetically thinned glyph that reads as broken/uneven. This was the only `w200`/`w100` usage in the codebase, and no custom font is bundled.

## Fix
One line in `lib/features/widgets/apply_progress_view.dart`: `FontWeight.w200` → `FontWeight.w300`. `w300` (Light) is the closest real Roboto weight to the intended extra-light look, so it stays subtly lighter than the default `bodySmall` (w400) and renders identically across all platforms.

## Verify
- `flutter analyze` clean, `flutter test` green (147 passing).
- Cosmetic-only change; no logic touched, so no new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)