### PR TITLE
fix(profiles): remove desktop drag handle, enable long-press reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Fixed
+- **macOS profile reordering** — removed the stray drag-handle icon that collided with each profile card's ⋮ menu, and made long-press-to-drag reordering work on macOS (it previously only responded to the now-removed handle).
+
 ## [0.5.0] - 2026-07-12
 
 ### Added

--- a/lib/features/profiles/profiles_screen.dart
+++ b/lib/features/profiles/profiles_screen.dart
@@ -27,6 +27,11 @@ class ProfilesScreen extends ConsumerWidget {
           : ReorderableListView.builder(
               padding: const EdgeInsets.fromLTRB(12, 0, 12, 96),
               itemCount: list.length,
+              // No default drag handles: on desktop they draw a trailing ≡ icon
+              // (clashes with the card's ⋮ menu) and make dragging start only
+              // from that handle. We wrap each item in a delayed listener below
+              // so long-press-to-drag works on every platform (incl. macOS).
+              buildDefaultDragHandles: false,
               // Drop the default elevated-Material drag proxy (it draws a square
               // highlight/shadow behind the rounded card); the card lifts as-is.
               proxyDecorator: (child, index, animation) =>
@@ -37,31 +42,35 @@ class ProfilesScreen extends ConsumerWidget {
                   .reorder(oldIndex, newIndex),
               itemBuilder: (context, i) {
                 final p = list[i];
-                return Padding(
+                return ReorderableDelayedDragStartListener(
                   key: ValueKey(p.id),
-                  padding: const EdgeInsets.only(bottom: 12),
-                  child: ProfileCard(
-                    profile: p,
-                    onTap: () => context.go('/profiles/edit/${p.id}'),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        IconButton.filled(
-                          onPressed: () =>
-                              applyProfileInteractive(context, ref, p),
-                          tooltip: 'Apply',
-                          icon: const Icon(Icons.play_arrow),
-                        ),
-                        PopupMenuButton<String>(
-                          onSelected: (v) => v == 'edit'
-                              ? context.go('/profiles/edit/${p.id}')
-                              : _confirmDelete(context, ref, p),
-                          itemBuilder: (_) => const [
-                            PopupMenuItem(value: 'edit', child: Text('Edit')),
-                            PopupMenuItem(value: 'delete', child: Text('Delete')),
-                          ],
-                        ),
-                      ],
+                  index: i,
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: ProfileCard(
+                      profile: p,
+                      onTap: () => context.go('/profiles/edit/${p.id}'),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton.filled(
+                            onPressed: () =>
+                                applyProfileInteractive(context, ref, p),
+                            tooltip: 'Apply',
+                            icon: const Icon(Icons.play_arrow),
+                          ),
+                          PopupMenuButton<String>(
+                            onSelected: (v) => v == 'edit'
+                                ? context.go('/profiles/edit/${p.id}')
+                                : _confirmDelete(context, ref, p),
+                            itemBuilder: (_) => const [
+                              PopupMenuItem(value: 'edit', child: Text('Edit')),
+                              PopupMenuItem(
+                                  value: 'delete', child: Text('Delete')),
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 );


### PR DESCRIPTION
## What

On the **Profiles** tab, each card's trailing row showed the Apply button (▶) and the ⋮ menu. On **macOS** a third, unwanted icon appeared crammed against the dots — the reorder **drag handle** (≡) — and it hijacked the drag gesture so long-press did nothing.

Root cause: `ReorderableListView.builder` defaults to `buildDefaultDragHandles: true`, which on *desktop* platforms draws an `Icons.drag_handle` at each item's trailing edge and routes dragging through that handle only.

## Fix

Single behavioral change in `lib/features/profiles/profiles_screen.dart`:

- `buildDefaultDragHandles: false` — removes the desktop ≡ handle (fixes the clash).
- Wrap each item in `ReorderableDelayedDragStartListener` — long-press-to-drag now works on every platform, matching the mobile layout the fixed 420-wide macOS window emulates. `ValueKey(p.id)` moves onto the listener (the widget the builder returns, as `ReorderableListView` requires).

No mobile regression: the default handles already wrapped mobile items in the same delayed listener; this just makes it explicit and extends it to desktop.

## Verification

- `flutter analyze` clean; `flutter test` → all 147 pass.
- Built + drove the macOS app: trailing row is now `▶ ⋮` only — the ≡ handle is gone.
- Also run on iOS simulator + Android emulator (demo mode) to confirm no mobile regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)