### PR TITLE
Faster, dialog-free abort that reports like an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Changed
+- Aborting a profile apply now stops immediately (no confirmation dialog) and marks the step it stopped on as "Aborted" with a Retry option, instead of just closing — and aborting during the initial network scan now stops within a moment rather than waiting for the scan to finish.
+
 ## [0.5.0] - 2026-07-12
 
 ### Added

--- a/lib/data/sonos/apply_progress.dart
+++ b/lib/data/sonos/apply_progress.dart
@@ -90,6 +90,15 @@ class ApplyProgress {
     _log(id, '✗', detail);
   }
 
+  /// Fails whichever top-level step is currently active (and its active child)
+  /// with [detail]. No-op if nothing is active. Used to attach an abort reason
+  /// to the step that was running when the user hit Abort.
+  void failActive(String detail) {
+    final i = _steps.indexWhere(
+        (s) => s.parentId == null && s.status == ApplyStatus.active);
+    if (i >= 0) fail(_steps[i].id, detail);
+  }
+
   /// Seeds pending phase sub-steps under [parentId] (the phases knowable
   /// upfront); conditional phases are inserted later by [startSub].
   void seedSubs(String parentId, List<(String id, String label)> subs) {

--- a/lib/data/sonos/cancellation.dart
+++ b/lib/data/sonos/cancellation.dart
@@ -7,11 +7,15 @@
 /// cancelled token throws [OperationCancelled], which unwinds the sequence.
 library;
 
+import 'dart:async';
+
 /// Thrown by [CancellationToken.throwIfCancelled] when an operation was aborted.
+/// [toString] is also the reason shown against the aborted progress step, so
+/// keep it terse.
 class OperationCancelled implements Exception {
   const OperationCancelled();
   @override
-  String toString() => 'Operation aborted';
+  String toString() => 'Aborted';
 }
 
 /// A one-shot cancel flag. Create one per operation, hand it to the worker, and
@@ -47,4 +51,31 @@ Future<void> interruptibleDelay(
     remaining -= step;
   }
   token.throwIfCancelled();
+}
+
+/// Resolves with [work], or throws [OperationCancelled] the instant [token]
+/// trips — WITHOUT waiting for [work]. For work that can't itself be
+/// interrupted (e.g. an SSDP discovery socket): this stops callers waiting on
+/// it while the underlying future runs to completion in the background.
+Future<T> untilCancelled<T>(
+  Future<T> work,
+  CancellationToken token, {
+  Duration slice = const Duration(milliseconds: 250),
+}) {
+  final out = Completer<T>();
+  work.then((v) {
+    if (!out.isCompleted) out.complete(v);
+  }, onError: (Object e, StackTrace s) {
+    if (!out.isCompleted) out.completeError(e, s);
+  });
+  () async {
+    while (!out.isCompleted) {
+      if (token.isCancelled) {
+        if (!out.isCompleted) out.completeError(const OperationCancelled());
+        return;
+      }
+      await Future<void>.delayed(slice);
+    }
+  }();
+  return out.future;
 }

--- a/lib/features/widgets/apply_progress_view.dart
+++ b/lib/features/widgets/apply_progress_view.dart
@@ -15,7 +15,12 @@ import '../../data/sonos/apply_progress.dart';
 class ApplyProgressView extends StatelessWidget {
   final List<ApplyStep> steps;
 
-  const ApplyProgressView({super.key, required this.steps});
+  /// The op was aborted by the user. The aborted step still renders red (with
+  /// its "Aborted" reason), but the header stays neutral — an abort isn't a
+  /// "something went wrong".
+  final bool aborted;
+
+  const ApplyProgressView({super.key, required this.steps, this.aborted = false});
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +28,7 @@ class ApplyProgressView extends StatelessWidget {
     if (steps.isEmpty) {
       return const Center(child: CircularProgressIndicator());
     }
-    final failed = steps.any((s) => s.isFailed);
+    final failed = steps.any((s) => s.isFailed) && !aborted;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -53,6 +58,9 @@ class ApplyProgressView extends StatelessWidget {
                         i + 1 < steps.length && !steps[i + 1].isChild,
                     hasChildren: !steps[i].isChild &&
                         steps.any((s) => s.parentId == steps[i].id),
+                    hasFailedChild: !steps[i].isChild &&
+                        steps.any(
+                            (s) => s.parentId == steps[i].id && s.isFailed),
                   ),
               ],
             ),
@@ -73,11 +81,13 @@ class _TimelineRow extends StatelessWidget {
   final bool isLast;
   final bool nextIsParent;
   final bool hasChildren;
+  final bool hasFailedChild;
   const _TimelineRow(
       {required this.step,
       required this.isLast,
       required this.nextIsParent,
-      required this.hasChildren});
+      required this.hasChildren,
+      required this.hasFailedChild});
 
   @override
   Widget build(BuildContext context) {
@@ -144,7 +154,10 @@ class _TimelineRow extends StatelessWidget {
                       ),
                     ),
                   ),
-                  if (step.isFailed && !hasChildren)
+                  // Show the reason on the step itself unless a child already
+                  // carries it (a mid-phase failure lives on the failing
+                  // sub-step; an abort before any sub-step started stays here).
+                  if (step.isFailed && !hasFailedChild)
                     Padding(
                       padding: const EdgeInsets.only(top: 2),
                       child: Text(step.detail ?? 'Failed.',

--- a/lib/features/widgets/bonding_progress_screen.dart
+++ b/lib/features/widgets/bonding_progress_screen.dart
@@ -76,40 +76,24 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
       await widget.run();
       if (mounted) setState(() => _finished = true);
     } on OperationCancelled {
-      // User abort — the controller already restored a usable state.
-      if (mounted) navigator.pop(BondingOutcome.aborted);
+      // Abort button → surface like a failure (the step reads 'Aborted', Retry
+      // re-runs). A pre-flight confirm decline (no Abort pressed) just closes.
+      if (!_aborting) {
+        if (mounted) navigator.pop(BondingOutcome.aborted);
+      } else if (mounted) {
+        setState(() => _finished = _failed = true);
+      }
     } catch (_) {
       // The failing step + the raw log carry the reason; show Retry/Done.
       if (mounted) setState(() => _finished = _failed = true);
     }
   }
 
-  Future<void> _confirmAbort() async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        icon: const Icon(Icons.warning_amber),
-        title: const Text('Abort?'),
-        content: const Text(
-            'Stopping now can leave your speakers in an in-between state — some '
-            'changes may be half-applied. You can re-apply afterwards to fix it.'),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Keep going')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(
-                foregroundColor: Theme.of(ctx).colorScheme.error),
-            child: const Text('Abort'),
-          ),
-        ],
-      ),
-    );
-    if (ok == true && mounted) {
-      setState(() => _aborting = true);
-      ref.read(sonosControllerProvider.notifier).cancelActiveOperation();
-    }
+  // No confirm dialog — abort should stop as fast as possible. The aborted step
+  // is marked in the timeline and re-applying afterwards fixes any half-state.
+  void _abort() {
+    setState(() => _aborting = true);
+    ref.read(sonosControllerProvider.notifier).cancelActiveOperation();
   }
 
   void _retry() {
@@ -158,16 +142,19 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
         ),
         body: _showLogs
             ? const _RawLogView()
-            : ApplyProgressView(steps: steps),
+            : ApplyProgressView(steps: steps, aborted: _aborting),
         bottomNavigationBar: SafeArea(
           child: _BottomBar(
             finished: _finished,
             failed: _failed,
             aborting: _aborting,
-            onAbort: _confirmAbort,
+            onAbort: _abort,
             onRetry: _retry,
-            onDone: () => Navigator.of(context).pop(
-                _failed ? BondingOutcome.failed : BondingOutcome.success),
+            onDone: () => Navigator.of(context).pop(_aborting
+                ? BondingOutcome.aborted
+                : _failed
+                    ? BondingOutcome.failed
+                    : BondingOutcome.success),
           ),
         ),
       ),

--- a/lib/features/widgets/bonding_progress_screen.dart
+++ b/lib/features/widgets/bonding_progress_screen.dart
@@ -56,7 +56,12 @@ class BondingProgressScreen extends ConsumerStatefulWidget {
 class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
   bool _finished = false;
   bool _failed = false;
+  // _aborting: the Abort button was pressed (drives its "Aborting…" label and
+  // the cancel). _aborted: the op actually ended via cancellation — only this
+  // drives the outcome/header, so a late abort that the op outran still reports
+  // its true success/failure.
   bool _aborting = false;
+  bool _aborted = false;
   bool _showLogs = false;
 
   @override
@@ -70,6 +75,7 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
       _finished = false;
       _failed = false;
       _aborting = false;
+      _aborted = false;
     });
     final navigator = Navigator.of(context);
     try {
@@ -81,7 +87,7 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
       if (!_aborting) {
         if (mounted) navigator.pop(BondingOutcome.aborted);
       } else if (mounted) {
-        setState(() => _finished = _failed = true);
+        setState(() => _finished = _failed = _aborted = true);
       }
     } catch (_) {
       // The failing step + the raw log carry the reason; show Retry/Done.
@@ -142,7 +148,7 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
         ),
         body: _showLogs
             ? const _RawLogView()
-            : ApplyProgressView(steps: steps, aborted: _aborting),
+            : ApplyProgressView(steps: steps, aborted: _aborted),
         bottomNavigationBar: SafeArea(
           child: _BottomBar(
             finished: _finished,
@@ -150,7 +156,7 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
             aborting: _aborting,
             onAbort: _abort,
             onRetry: _retry,
-            onDone: () => Navigator.of(context).pop(_aborting
+            onDone: () => Navigator.of(context).pop(_aborted
                 ? BondingOutcome.aborted
                 : _failed
                     ? BondingOutcome.failed

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -102,6 +104,28 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   /// an in-flight SOAP write still completes, but the sequence stops before the
   /// next step — which is why the UI warns it can leave an in-between state.
   void cancelActiveOperation() => _activeOp?.cancel();
+
+  /// Resolves with [work], or throws [OperationCancelled] the instant [token]
+  /// trips — WITHOUT waiting for [work]. SSDP discovery isn't interruptible, so
+  /// this just stops the UI waiting; the socket self-closes within its timeout.
+  Future<T> _untilCancelled<T>(Future<T> work, CancellationToken token) {
+    final out = Completer<T>();
+    work.then((v) {
+      if (!out.isCompleted) out.complete(v);
+    }, onError: (Object e, StackTrace s) {
+      if (!out.isCompleted) out.completeError(e, s);
+    });
+    () async {
+      while (!out.isCompleted) {
+        if (token.isCancelled) {
+          if (!out.isCompleted) out.completeError(const OperationCancelled());
+          return;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+      }
+    }();
+    return out.future;
+  }
 
   @override
   Future<SonosSystem?> build() => _discover();
@@ -230,6 +254,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         tracker.done('bond');
         return sys;
       } on OperationCancelled {
+        tracker.fail('bond', 'Aborted');
         rethrow;
       } catch (e) {
         tracker.fail('bond', '$e');
@@ -297,18 +322,18 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       // Step 1 — scan. Reuse an in-flight app-launch discovery (also lets it
       // commit so its late completion can't clobber the applied state below);
       // otherwise run a fresh scan since a launch's earlier scan may be stale.
-      // (discover()/SSDP isn't interruptible, so scan-abort lands the instant
-      // discovery returns — the throwIfCancelled right after.)
+      // (discover()/SSDP isn't interruptible, so we race it against the token
+      // via [_untilCancelled]: an abort stops the UI waiting in ~250ms while the
+      // socket self-closes in the background — the throwIfCancelled right after
+      // turns that into a clean stop before any write.)
       tracker.start(_scanStepId);
+      final scanFuture =
+          state.isLoading ? future : scan().then((_) => state.value);
       SonosSystem? scanned;
       try {
-        if (state.isLoading) {
-          scanned = await future;
-        } else {
-          await scan();
-          scanned = state.value;
-        }
-      } catch (_) {/* handled below */}
+        scanned = await _untilCancelled(scanFuture, cancel);
+      } catch (_) {/* aborted → rethrown by throwIfCancelled below; other errors
+                       → scanned stays null → handled below */}
       cancel.throwIfCancelled(); // aborted during the scan? stop before any write
       if (scanned == null) {
         tracker.fail(
@@ -346,6 +371,10 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       previous = scanned;
     } catch (_) {
       _activeOp = null;
+      // Abort during scan/pre-flight: mark the step that was running. No-op for
+      // the "not found" path (scan step already failed) and a confirm decline
+      // (no step active), so only a real abort attaches the reason.
+      tracker.failActive('Aborted');
       rethrow;
     }
 
@@ -384,6 +413,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         await _restoreSettings(e, sys, ph);
         tracker.done(e.primaryUuid);
       } on OperationCancelled {
+        tracker.fail(e.primaryUuid, 'Aborted');
         rethrow;
       } catch (err) {
         tracker.fail(e.primaryUuid, '$err');
@@ -663,6 +693,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         tracker.done('remove');
         return sys;
       } on OperationCancelled {
+        tracker.fail('remove', 'Aborted');
         rethrow;
       } catch (e) {
         tracker.fail('remove', '$e');
@@ -742,6 +773,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         tracker.done('group');
         return system;
       } on OperationCancelled {
+        tracker.fail('group', 'Aborted');
         rethrow;
       } catch (e) {
         tracker.fail('group', '$e');
@@ -817,6 +849,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         tracker.done('ungroup');
         return system;
       } on OperationCancelled {
+        tracker.fail('ungroup', 'Aborted');
         rethrow;
       } catch (e) {
         tracker.fail('ungroup', '$e');

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -104,28 +102,6 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   /// an in-flight SOAP write still completes, but the sequence stops before the
   /// next step — which is why the UI warns it can leave an in-between state.
   void cancelActiveOperation() => _activeOp?.cancel();
-
-  /// Resolves with [work], or throws [OperationCancelled] the instant [token]
-  /// trips — WITHOUT waiting for [work]. SSDP discovery isn't interruptible, so
-  /// this just stops the UI waiting; the socket self-closes within its timeout.
-  Future<T> _untilCancelled<T>(Future<T> work, CancellationToken token) {
-    final out = Completer<T>();
-    work.then((v) {
-      if (!out.isCompleted) out.complete(v);
-    }, onError: (Object e, StackTrace s) {
-      if (!out.isCompleted) out.completeError(e, s);
-    });
-    () async {
-      while (!out.isCompleted) {
-        if (token.isCancelled) {
-          if (!out.isCompleted) out.completeError(const OperationCancelled());
-          return;
-        }
-        await Future<void>.delayed(const Duration(milliseconds: 250));
-      }
-    }();
-    return out.future;
-  }
 
   @override
   Future<SonosSystem?> build() => _discover();
@@ -253,10 +229,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         );
         tracker.done('bond');
         return sys;
-      } on OperationCancelled {
-        tracker.fail('bond', 'Aborted');
-        rethrow;
       } catch (e) {
+        // OperationCancelled lands here too — its toString is 'Aborted'.
         tracker.fail('bond', '$e');
         rethrow;
       }
@@ -331,7 +305,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           state.isLoading ? future : scan().then((_) => state.value);
       SonosSystem? scanned;
       try {
-        scanned = await _untilCancelled(scanFuture, cancel);
+        scanned = await untilCancelled(scanFuture, cancel);
       } catch (_) {/* aborted → rethrown by throwIfCancelled below; other errors
                        → scanned stays null → handled below */}
       cancel.throwIfCancelled(); // aborted during the scan? stop before any write
@@ -412,10 +386,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         // Restore captured EQ/volume last — bonding can reset EQ.
         await _restoreSettings(e, sys, ph);
         tracker.done(e.primaryUuid);
-      } on OperationCancelled {
-        tracker.fail(e.primaryUuid, 'Aborted');
-        rethrow;
       } catch (err) {
+        // OperationCancelled lands here too — its toString is 'Aborted'.
         tracker.fail(e.primaryUuid, '$err');
         rethrow;
       }
@@ -692,10 +664,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         );
         tracker.done('remove');
         return sys;
-      } on OperationCancelled {
-        tracker.fail('remove', 'Aborted');
-        rethrow;
       } catch (e) {
+        // OperationCancelled lands here too — its toString is 'Aborted'.
         tracker.fail('remove', '$e');
         rethrow;
       }
@@ -772,10 +742,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         }
         tracker.done('group');
         return system;
-      } on OperationCancelled {
-        tracker.fail('group', 'Aborted');
-        rethrow;
       } catch (e) {
+        // OperationCancelled lands here too — its toString is 'Aborted'.
         tracker.fail('group', '$e');
         rethrow;
       }
@@ -848,10 +816,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         }
         tracker.done('ungroup');
         return system;
-      } on OperationCancelled {
-        tracker.fail('ungroup', 'Aborted');
-        rethrow;
       } catch (e) {
+        // OperationCancelled lands here too — its toString is 'Aborted'.
         tracker.fail('ungroup', '$e');
         rethrow;
       }

--- a/test/apply_progress_test.dart
+++ b/test/apply_progress_test.dart
@@ -126,6 +126,26 @@ void main() {
     expect(p.steps.firstWhere((s) => s.id == 'e2').detail, 'freeing');
   });
 
+  test('failActive fails the running top-level step (and its active child)', () {
+    final p = tracker([]);
+    p.start('e1');
+    p.startSub('e1', 'e1/bond', 'Bond 3 speakers');
+    p.failActive('Aborted');
+    expect(p.steps.first.status, ApplyStatus.failed);
+    final bond = p.steps.firstWhere((s) => s.id == 'e1/bond');
+    expect(bond.status, ApplyStatus.failed);
+    expect(bond.detail, 'Aborted');
+  });
+
+  test('failActive is a no-op when nothing is active', () {
+    final p = tracker([]);
+    p.start('e1');
+    p.done('e1'); // e1 done, e2 still pending → nothing active
+    p.failActive('Aborted');
+    expect(p.steps.map((s) => s.status),
+        [ApplyStatus.done, ApplyStatus.pending]);
+  });
+
   test('raw log indents child lines', () {
     final log = <String>[];
     final p = tracker(log);

--- a/test/cancellation_test.dart
+++ b/test/cancellation_test.dart
@@ -45,6 +45,40 @@ void main() {
     });
   });
 
+  group('untilCancelled', () {
+    test('resolves with the work result when never cancelled', () async {
+      final t = CancellationToken();
+      final r = await untilCancelled(
+          Future<int>.delayed(const Duration(milliseconds: 20), () => 42), t);
+      expect(r, 42);
+    });
+
+    test('propagates the work error when never cancelled', () async {
+      final t = CancellationToken();
+      await expectLater(
+        untilCancelled(
+            Future<int>.error(StateError('boom')), t),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('throws OperationCancelled promptly, not waiting out slow work',
+        () async {
+      final t = CancellationToken();
+      final sw = Stopwatch()..start();
+      Future<void>.delayed(const Duration(milliseconds: 30), t.cancel);
+      await expectLater(
+        // Work that would take 10s — must not be awaited once cancelled.
+        untilCancelled(
+            Future<int>.delayed(const Duration(seconds: 10), () => 1), t,
+            slice: const Duration(milliseconds: 10)),
+        throwsA(isA<OperationCancelled>()),
+      );
+      sw.stop();
+      expect(sw.elapsed, lessThan(const Duration(seconds: 2)));
+    });
+  });
+
   group('ApplyProgress.onLog', () {
     test('emits a line for start / note / done / fail', () {
       final log = <String>[];


### PR DESCRIPTION
## What

Reworks how aborting a bonding operation (profile apply, home-theater setup, group create/separate) behaves, per user feedback while applying a profile from a home-screen widget.

- **Faster scan abort.** SSDP discovery isn't interruptible, so pressing Abort during the initial "Scan network…" step used to wait out the full discovery. A new `untilCancelled` helper races the cancel token against discovery so the abort lands in ~250ms (the socket self-closes in the background), on both the fresh-scan and cold-launch-reuse paths.
- **No confirmation dialog.** The Abort button cancels directly — you may want to stop *immediately*.
- **Abort surfaces like a failure.** The step it stopped on turns red reading **"Aborted"** (on the active sub-step when one is running, otherwise on the step itself), with **Done / Retry**, instead of silently closing. The header stays neutral (an abort isn't "something went wrong"), and Done still returns the aborted outcome so callers don't misreport it.

## Notes
- Removing the abort confirm dialog is safe: cancellation is cooperative (an in-flight SOAP write finishes, then stops at the next checkpoint), the last-known system state is restored, and apply is diff-based / re-appliable. The destructive gate stays on the *apply* confirm, not the abort.
- The scan-step abort only exists on the widget / app-shortcut launch path (iOS/Android); in-app apply aborts mid-bond.

## Review
Pre-merge review (fresh subagent + `/code-review` + `/ponytail-review`) run and addressed in the second commit:
- Fixed a late-abort mislabel — outcome/header now key off an `_aborted` flag set only when cancellation is actually caught, so an abort the op outran still reports its true result.
- Centralized the "Aborted" reason on `OperationCancelled.toString()` and dropped five redundant per-op catch blocks.
- Moved the cancel-race helper into `cancellation.dart` alongside the other cancel primitives, with unit tests.

## Testing
- `flutter analyze` clean; all **152** tests pass (added unit tests for `ApplyProgress.failActive` and `untilCancelled`).
- Verified on an Android emulator against the live Sonos system: scan-step abort shows the red "Aborted" step + Done/Retry with no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)