### PR TITLE
ios: carry multicast entitlement for on-device SSDP discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Changed
+- iOS: carry the multicast entitlement so on-device SSDP discovery works over multicast (the unicast subnet sweep is kept as a fallback).
+
 ## [0.5.1] - 2026-07-15
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,20 +393,25 @@ Run on the same Wi-Fi as the Sonos system:
 ## Platform notes
 - iOS: `Info.plist` has `NSLocalNetworkUsageDescription` + `NSBonjourServices`
   (mandatory on iOS 14+ or all LAN traffic is silently blocked).
-- **iOS device multicast is blocked (cost a real TestFlight bug):** physical
-  iPhones silently drop multicast sends (SSDP M-SEARCH) unless the app carries
-  the *restricted* `com.apple.developer.networking.multicast` entitlement —
-  the iOS target has no entitlements file. Simulator doesn't enforce it (sim
-  worked, device didn't); the local-network permission prompt covers unicast
-  only. Fix: `SsdpDiscovery.discover()` falls back to a unicast TCP :1400
-  sweep of each interface's /24 (assumed /24 — `dart:io` exposes no netmask;
-  ~600ms, one hit suffices since topology recovers the rest). Also helps
-  multicast-filtering mesh/guest networks. **Future improvement:** request the
-  multicast entitlement from Apple (developer.apple.com → "Multicast Networking
-  Entitlement Request", days–weeks), enable the capability on the App ID, add
-  `ios/Runner/Runner.entitlements` + `CODE_SIGN_ENTITLEMENTS` in the pbxproj,
-  regenerate match profiles (`docs/SIGNING.md`) — restores native SSDP on
-  device; keep the sweep as fallback regardless.
+- **iOS device multicast needs the restricted entitlement (cost a real
+  TestFlight bug):** physical iPhones silently drop multicast sends (SSDP
+  M-SEARCH) unless the app carries the *restricted*
+  `com.apple.developer.networking.multicast` entitlement. Simulator doesn't
+  enforce it (sim worked, device didn't); the local-network permission prompt
+  covers unicast only. Backstop: `SsdpDiscovery.discover()` falls back to a
+  unicast TCP :1400 sweep of each interface's /24 (assumed /24 — `dart:io`
+  exposes no netmask; ~600ms, one hit suffices since topology recovers the
+  rest); also helps multicast-filtering mesh/guest networks — **kept as a
+  fallback regardless.** **Status:** the entitlement has been **requested** from
+  Apple (developer.apple.com → "Multicast Networking Entitlement Request",
+  discovery `239.255.255.250:1900`) and the key is in
+  `ios/Runner/Runner.entitlements` (already wired via `CODE_SIGN_ENTITLEMENTS`
+  for the iOS target — no pbxproj change). **Pending Apple's grant** (a signed
+  build before then fails signing): once granted, enable **Multicast Networking**
+  on the `be.casperverswijvelt.sonority` App ID (main app only) and regenerate
+  the match `appstore` profile via `bundle exec fastlane ios certificates`
+  (readonly CI otherwise pulls a stale profile). See `docs/PUBLISHING-APPLE.md`.
+  macOS needs nothing (the capability isn't applicable there).
 - macOS: entitlements include `network.client` + `network.server`; window is locked
   to a fixed **420×880 portrait** (`MainFlutterWindow.swift`) so the UI only ever
   handles one mobile layout.

--- a/docs/PUBLISHING-APPLE.md
+++ b/docs/PUBLISHING-APPLE.md
@@ -34,6 +34,28 @@ Open `ios/Runner.xcworkspace` and `macos/Runner.xcworkspace`:
 3. `ITSAppUsesNonExemptEncryption=false` is already in both `Info.plist`s, so
    uploads won't prompt for export compliance.
 
+### 2b. Multicast entitlement (iOS discovery)
+
+SSDP discovery multicasts `M-SEARCH` to `239.255.255.250:1900`; on physical
+iPhones that send is silently dropped unless the app carries the **restricted**
+`com.apple.developer.networking.multicast` entitlement. (A unicast /24 sweep in
+`ssdp_discovery_io.dart` is kept as a fallback regardless. macOS needs nothing —
+the capability isn't applicable there.)
+
+- ✅ **Done:** entitlement **requested** from Apple (developer.apple.com →
+  "Multicast Networking Entitlement Request", discovery `239.255.255.250:1900`);
+  the key is in `ios/Runner/Runner.entitlements`.
+- ⏳ **After Apple grants it:**
+  1. Identifiers → `be.casperverswijvelt.sonority` → enable **Multicast
+     Networking** → Save. (Main app only — **not** the `…ProfileWidget` App ID.)
+  2. Regenerate the shared profile so it carries the entitlement:
+     `bundle exec fastlane ios certificates`. Otherwise CI's readonly `match`
+     pulls a stale profile and signing/upload fails.
+  3. Only then merge / cut a signed build. **A signed iOS build before the grant
+     fails signing** ("provisioning profile doesn't include the … multicast
+     entitlement") — local `Archive` / `fastlane ios beta` and the CI
+     `ios-testflight` lane; the `ios-unsigned` job is unaffected.
+
 ### 3. Create the app records
 
 App Store Connect → **Apps → +** → New App, for the bundle id

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.be.casperverswijvelt.sonority</string>


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until Apple grants the multicast entitlement

`com.apple.developer.networking.multicast` is a **restricted** entitlement. Merging this before Apple grants it — and before it's enabled on the App ID and baked into the regenerated match profile — bakes the key into `main` and **breaks the signed `ios-testflight` CI lane** ("provisioning profile doesn't include the … multicast entitlement"). The `ios-unsigned` job and `flutter analyze`/`test` are unaffected.

**Before merging:**
1. ✅ Entitlement **requested** from Apple (discovery `239.255.255.250:1900`) — done.
2. ⏳ Apple grants it (days–weeks).
3. ⏳ Enable **Multicast Networking** on the `be.casperverswijvelt.sonority` App ID (main app only — not the widget).
4. ⏳ Regenerate the shared profile: `bundle exec fastlane ios certificates` (readonly CI otherwise pulls a stale profile).
5. Then merge.

## What this does

Physical iPhones silently drop the SSDP `M-SEARCH` multicast send without this entitlement, so today discovery relies on the unicast /24 sweep fallback in `ssdp_discovery_io.dart`. Adding the entitlement restores native multicast discovery on-device; the unicast sweep stays as a fallback (also helps multicast-filtering guest/mesh networks).

- No Dart change — the send-only M-SEARCH is already correct; the entitlement is a bare boolean.
- No pbxproj change — `Runner.entitlements` is already wired via `CODE_SIGN_ENTITLEMENTS`.
- **macOS: nothing** — the multicast add-on capability isn't applicable there.

## Changes
- `ios/Runner/Runner.entitlements` — add `com.apple.developer.networking.multicast`.
- `docs/PUBLISHING-APPLE.md` — new §2b with the done/pending steps.
- `CLAUDE.md` — iOS platform note updated to current status.
- `CHANGELOG.md` — one line under `[Unreleased]`.

## Verification
- `flutter analyze` + `flutter test` (157) green; entitlements plist lints OK.
- Post-grant: cold-launch a signed build on a physical iPhone on the Sonos Wi-Fi and confirm discovery finds speakers within the multicast window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)