### PR TITLE
feat: diagnostics view + shareable bundle; shared modal sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Added
+- Diagnostics: a new screen (bug icon, top-right) shows a hide-nothing technical view of your system — including hidden speakers, IPs, MAC addresses and firmware — and can package it, the raw topology, raw device info, your saved profiles and app logs into a zip to share via the system share sheet, email straight to the developer, or save to disk. App logs and phone network info are optional toggles.
+
 ## [0.5.1] - 2026-07-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Changed
+- The version/changelog viewer (tap the version chip) now opens as a bottom sheet matching the new Diagnostics screen.
+
 ### Added
 - Diagnostics: a new screen (bug icon, top-right) shows a hide-nothing technical view of your system — including hidden speakers, IPs, MAC addresses and firmware — and can package it, the raw topology, raw device info, your saved profiles and app logs into a zip to share via the system share sheet, email straight to the developer, or save to disk. App logs and phone network info are optional toggles.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -485,6 +485,27 @@ pkill -x Sonority                          # quit (AppleScript quit gets cancell
   ⚠️ action names/EQType tokens assumed standard-UPnP — **verify with
   `tool/eq_probe.dart` on hardware** before shipping.
 - ✅ **Room renaming** from the room / HT detail pages (`renameRoom` + `rename_dialog`).
+- ✅ **Diagnostics** (`features/diagnostics/`) — a bug-icon app-bar action opens a
+  modal bottom sheet with a hide-nothing technical topology view (invisible
+  members, IP/MAC/serial/firmware, raw channel maps — reads `system.groups[].members`
+  unfiltered + `devicesByUuid`, and the new `SonosDevice.mac/serial/software/
+  hardwareVersion` parsed in `device_description.dart`). Packages a **structured
+  zip** (`diagnostics_bundle.dart`): README, `parsed_topology.json`,
+  `topology.txt`, fresh `raw_topology.xml` (`ZoneTopologyClient.getRawState`),
+  raw `device_descriptions/*.xml` (`DeviceDescriptionClient.fetchRaw`),
+  `app_state.json` (all app SharedPreferences), plus optional `logs.txt` +
+  `network.txt` toggles (both default on). Shares via `share_plus`, a prefilled
+  developer email (`flutter_email_sender`, iOS/Android/macOS), or save-to-disk
+  via a native save dialog on every platform (`file_saver`; macOS needs the
+  `files.user-selected.read-write` sandbox entitlement — self-granted, no Apple
+  request). Collection is
+  **read-only** (re-fetch of GetZoneGroupState + descriptions, no writes). Logs
+  come from an app-wide ring buffer `DiagnosticsLog` (SOAP faults in
+  `soap_client.dart`, discovery method/counts, bond retries mirrored from the
+  per-op log, uncaught errors from `main.dart`) — separate from the per-op
+  `operationLogProvider` that still scopes the progress screen's log view. The
+  `dart:io` bits (OS/network/temp-file) sit behind a `diagnostics_platform.dart`
+  conditional-import barrel so the demo web build still compiles.
 - ✅ Trueplay read + toggle (`room_calibration.dart` + `trueplay_control.dart`) on
   all speakers/HTs — toggles the iOS-measured calibration the Sonos app won't
   expose for unofficial fronts. Measurement stays iOS-only (out of scope).

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -81,5 +81,12 @@
             <data
                 android:scheme="https"/>
         </intent>
+        <!-- flutter_email_sender: resolve a mail app for "Email to developer". -->
+        <intent>
+            <action
+                android:name="android.intent.action.SENDTO"/>
+            <data
+                android:scheme="mailto"/>
+        </intent>
     </queries>
 </manifest>

--- a/docs/app-store/listing.md
+++ b/docs/app-store/listing.md
@@ -58,6 +58,7 @@ WHAT YOU CAN DO
 • Config profiles — snapshot your whole layout and rebuild it in one tap after moving speakers around. Each profile gets its own icon and colour, and can also capture and restore per-speaker audio settings (bass, treble, loudness, night sound, speech enhancement, sub and surround levels, lip-sync) and, optionally, volume.
 • Apply a profile without opening the app — from a home-screen widget (small, medium or large) or a long-press on the app icon.
 • Rename rooms, identify which physical speaker is which by blinking its status light (or a short chime on iPhone/iPad), and toggle a speaker’s room-calibration tuning.
+• Diagnostics — a technical, hide-nothing view of your system when something isn’t working, which you can share with support or email to the developer to get help.
 
 Every change is made over your local network, is shown to you before it’s applied, and is fully reversible from within the app.
 
@@ -84,6 +85,7 @@ Sonority is an independent app and is not affiliated with, authorized, maintaine
 • Profiles can now capture and restore per-speaker audio settings and volume
 • Rename rooms; toggle room-calibration tuning
 • Dedicated front speakers on a soundbar (a single Amp works too)
+• Diagnostics: a technical system view you can share for help when something’s wrong
 ```
 
 ## Support / marketing URLs

--- a/lib/data/models/sonos_models.dart
+++ b/lib/data/models/sonos_models.dart
@@ -49,6 +49,14 @@ class SonosDevice {
   final String? modelNumber; // e.g. "S27"
   final String? ip;
 
+  /// Extra identity/firmware fields from device_description.xml, surfaced only
+  /// in the diagnostics view + bundle (never used for logic). Nullable because a
+  /// topology-only device (unreachable description) won't have them.
+  final String? mac;
+  final String? serial;
+  final String? softwareVersion;
+  final String? hardwareVersion;
+
   /// False when we couldn't read this player's device_description.xml: it's
   /// present in the authoritative topology but its model/capabilities are
   /// unknown, so the UI surfaces it disabled with a warning rather than
@@ -61,6 +69,10 @@ class SonosDevice {
     required this.modelName,
     this.modelNumber,
     this.ip,
+    this.mac,
+    this.serial,
+    this.softwareVersion,
+    this.hardwareVersion,
     this.reachable = true,
   });
 
@@ -102,6 +114,10 @@ class SonosDevice {
         modelName: modelName,
         modelNumber: modelNumber,
         ip: ip ?? this.ip,
+        mac: mac,
+        serial: serial,
+        softwareVersion: softwareVersion,
+        hardwareVersion: hardwareVersion,
         reachable: reachable,
       );
 

--- a/lib/data/sonos/device_description.dart
+++ b/lib/data/sonos/device_description.dart
@@ -21,6 +21,19 @@ class DeviceDescriptionClient {
     return _parse(res.body, ip: uri.host);
   }
 
+  /// Returns the raw `device_description.xml` body verbatim — for the diagnostics
+  /// bundle, which wants the full document (capability flags, min-app-version
+  /// gates, household id, …) that [_parse] deliberately ignores.
+  Future<String> fetchRaw(String locationUrl) async {
+    final res = await _http
+        .get(Uri.parse(locationUrl))
+        .timeout(const Duration(seconds: 5));
+    if (res.statusCode != 200) {
+      throw Exception('device_description.xml ${res.statusCode} from $locationUrl');
+    }
+    return res.body;
+  }
+
   SonosDevice _parse(String xml, {required String ip}) {
     final doc = XmlDocument.parse(xml);
     final device = doc.findAllElements('device').first;
@@ -39,6 +52,10 @@ class DeviceDescriptionClient {
       modelName: text('modelName') ?? 'Sonos',
       modelNumber: text('modelNumber'),
       ip: ip,
+      mac: text('MACAddress'),
+      serial: text('serialNum'),
+      softwareVersion: text('softwareVersion') ?? text('displayVersion'),
+      hardwareVersion: text('hardwareVersion'),
     );
   }
 }

--- a/lib/data/sonos/diagnostics_log.dart
+++ b/lib/data/sonos/diagnostics_log.dart
@@ -1,0 +1,32 @@
+/// App-wide rolling log for the diagnostics bundle.
+///
+/// Unlike the per-operation `operationLogProvider` (which is cleared at the start
+/// of each bonding op so the progress screen only shows that op), this is a
+/// single process-lifetime ring buffer that captures everything worth
+/// escalating: SOAP faults/timeouts thrown anywhere, discovery details, bond
+/// retries, and uncaught Flutter/platform errors. Pure Dart (no Flutter) so the
+/// engine and CLI tools can write to it directly.
+///
+/// ponytail: in-memory only, capped ring buffer — no disk persistence. Add a
+/// file sink only if users turn out to be unable to reproduce a bug live before
+/// sharing.
+class DiagnosticsLog {
+  DiagnosticsLog._();
+
+  static const _max = 500;
+  static final List<String> _lines = [];
+
+  /// Appends [line], timestamped `HH:MM:SS`, dropping the oldest past [_max].
+  static void add(String line) {
+    final now = DateTime.now();
+    String two(int n) => n.toString().padLeft(2, '0');
+    final ts = '${two(now.hour)}:${two(now.minute)}:${two(now.second)}';
+    _lines.add('$ts  $line');
+    if (_lines.length > _max) _lines.removeRange(0, _lines.length - _max);
+  }
+
+  /// A snapshot of the buffered lines, oldest first.
+  static List<String> get lines => List.unmodifiable(_lines);
+
+  static void clear() => _lines.clear();
+}

--- a/lib/data/sonos/soap_client.dart
+++ b/lib/data/sonos/soap_client.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart';
+
+import 'diagnostics_log.dart';
 
 /// Minimal SOAP client for the Sonos local UPnP API (port 1400).
 ///
@@ -26,19 +30,28 @@ class SonosSoapClient {
     final uri = Uri.parse('http://$ip:$port$controlPath');
     final body = buildEnvelope(serviceType: serviceType, action: action, args: args);
 
-    final res = await _http.post(
-      uri,
-      headers: {
-        'Content-Type': 'text/xml; charset="utf-8"',
-        'SOAPACTION': '"$serviceType#$action"',
-        // Sonos players are unreliable with HTTP keep-alive: a pooled socket the
-        // player has already closed makes the next request hang until timeout
-        // (very visible when firing many calls in a row, like the LED blink).
-        // Closing per request avoids reusing a dead connection.
-        'Connection': 'close',
-      },
-      body: body,
-    ).timeout(timeout);
+    final http.Response res;
+    try {
+      res = await _http.post(
+        uri,
+        headers: {
+          'Content-Type': 'text/xml; charset="utf-8"',
+          'SOAPACTION': '"$serviceType#$action"',
+          // Sonos players are unreliable with HTTP keep-alive: a pooled socket the
+          // player has already closed makes the next request hang until timeout
+          // (very visible when firing many calls in a row, like the LED blink).
+          // Closing per request avoids reusing a dead connection.
+          'Connection': 'close',
+        },
+        body: body,
+      ).timeout(timeout);
+    } on TimeoutException {
+      // Recorded for the diagnostics bundle: outside a bonding op these are just
+      // thrown and lost. (In a bonding op a timeout is expected/benign — the
+      // write still lands — but capturing it here is harmless.)
+      DiagnosticsLog.add('SOAP $action @ $ip timed out after ${timeout.inSeconds}s');
+      rethrow;
+    }
 
     if (res.statusCode != 200) {
       // A fault body is usually XML, but a truncated/empty/non-XML error body
@@ -46,7 +59,7 @@ class SonosSoapClient {
       final doc = _tryParse(res.body);
       final fault = doc?.findAllElements('faultstring');
       final code = doc?.findAllElements('errorCode');
-      throw SonosSoapException(
+      final ex = SonosSoapException(
         action,
         statusCode: res.statusCode,
         faultCode: (code == null || code.isEmpty) ? null : code.first.innerText,
@@ -54,11 +67,14 @@ class SonosSoapClient {
             ? res.reasonPhrase
             : fault.first.innerText,
       );
+      DiagnosticsLog.add('SOAP fault @ $ip: $ex');
+      throw ex;
     }
 
     final doc = XmlDocument.parse(res.body);
     final bodies = doc.findAllElements('Body', namespace: '*');
     if (bodies.isEmpty) {
+      DiagnosticsLog.add('SOAP $action @ $ip: missing SOAP Body in response');
       throw SonosSoapException(action, faultString: 'Missing SOAP Body in response');
     }
     return bodies.first;

--- a/lib/data/sonos/sonos_repository.dart
+++ b/lib/data/sonos/sonos_repository.dart
@@ -10,6 +10,7 @@ import 'cancellation.dart';
 import 'channel_map.dart' show ChannelMap;
 import 'device_description.dart';
 import 'device_properties.dart';
+import 'diagnostics_log.dart';
 import 'room_calibration.dart';
 import 'soap_client.dart';
 import 'ssdp_discovery.dart';
@@ -59,6 +60,7 @@ class SonosRepository {
           // and recovered topology-only later. Log so it's diagnosable.
           developer.log('device_description fetch failed for $loc: $e',
               name: 'sonority.discover');
+          DiagnosticsLog.add('discovery: device_description fetch failed for $loc: $e');
           return null;
         }
       }),
@@ -86,6 +88,9 @@ class SonosRepository {
     if (groups == null) {
       throw Exception('Could not read the Sonos topology from any player: $lastErr');
     }
+    DiagnosticsLog.add(
+        'discovery: ${found.length} device(s) described, topology has '
+        '${groups.expand((g) => g.members).length} member(s) in ${groups.length} group(s)');
 
     // Topology is authoritative; SSDP and the per-device description fetch are
     // both lossy. Re-fetch any visible member we don't yet have a description
@@ -124,6 +129,16 @@ class SonosRepository {
 
     return SonosSystem(groups: groups, devicesByUuid: devicesByUuid);
   }
+
+  /// Raw, double-decoded `GetZoneGroupState` XML from the player at [ip] — for
+  /// the diagnostics bundle. Reuses the topology client so the bundle builder
+  /// doesn't re-instantiate SOAP plumbing.
+  Future<String> rawTopology(String ip) => _topology.getRawState(ip);
+
+  /// Raw `device_description.xml` body from the player at [ip] — for the
+  /// diagnostics bundle. Uses the well-known Sonos description path.
+  Future<String> rawDeviceDescription(String ip) =>
+      _descriptions.fetchRaw('http://$ip:${SonosSoapClient.port}/xml/device_description.xml');
 
   /// Re-read topology from a known device IP (cheaper than full discovery).
   Future<SonosSystem> refresh(SonosSystem previous, String ip) async {
@@ -190,7 +205,7 @@ class SonosRepository {
         // coordinator (401) will never converge — surface it immediately instead
         // of retrying for ~160s and masking it as "channels never joined".
         if (e.faultCode != '800') rethrow;
-        onNote?.call('attempt $attempt: write error 800, re-asserting');
+        onNote?.call('attempt $attempt: write error 800 (mid-reshuffle), re-asserting');
       } catch (e) {
         // Bonding is eventually-consistent (confirmed on hardware): a write can
         // partially apply then settle, or return a transient UPnPError (e.g. 800
@@ -198,13 +213,13 @@ class SonosRepository {
         // channels bonded. Re-asserting the SAME map then converges (took ~4
         // tries on a real Beam rebuild). So treat ANY write error as "go verify",
         // and only fail if the topology never reaches the target.
-        onNote?.call('attempt $attempt: write error, re-asserting');
+        onNote?.call('attempt $attempt: write error ($e), re-asserting');
       }
       await interruptibleDelay(_bondSettle, cancel);
       try {
         system = system == null ? await discover() : await refresh(system, ip);
-      } catch (_) {
-        onNote?.call('attempt $attempt: topology read failed, retrying');
+      } catch (e) {
+        onNote?.call('attempt $attempt: topology read failed ($e), retrying');
         continue;
       }
       final member = system.allMembers

--- a/lib/data/sonos/ssdp_discovery_io.dart
+++ b/lib/data/sonos/ssdp_discovery_io.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'diagnostics_log.dart';
+
 /// Discovers Sonos players on the local network via SSDP.
 ///
 /// Sonos uses SSDP (not mDNS). We send an `M-SEARCH` UDP datagram to the
@@ -56,7 +58,14 @@ class SsdpDiscovery {
     } finally {
       socket?.close();
     }
-    if (locations.isEmpty) return _scanSubnet();
+    if (locations.isEmpty) {
+      DiagnosticsLog.add(
+          'discovery: SSDP multicast found none — falling back to unicast /24 sweep');
+      final swept = await _scanSubnet();
+      DiagnosticsLog.add('discovery: unicast sweep found ${swept.length}');
+      return swept;
+    }
+    DiagnosticsLog.add('discovery: SSDP multicast found ${locations.length}');
     return locations;
   }
 

--- a/lib/data/sonos/zone_topology.dart
+++ b/lib/data/sonos/zone_topology.dart
@@ -13,7 +13,13 @@ class ZoneTopologyClient {
   static const _control = '/ZoneGroupTopology/Control';
 
   /// Query any reachable player [ip]; it returns the whole system's topology.
-  Future<List<ZoneGroup>> getZoneGroups(String ip) async {
+  Future<List<ZoneGroup>> getZoneGroups(String ip) async =>
+      parseZoneGroupState(await getRawState(ip));
+
+  /// The raw, unescaped inner `<ZoneGroupState>` XML — the double-decoded
+  /// topology document, for the diagnostics bundle (and reused by
+  /// [getZoneGroups]). Returns `''` if the response carries no state element.
+  Future<String> getRawState(String ip) async {
     final body = await _soap.call(
       ip: ip,
       controlPath: _control,
@@ -24,13 +30,12 @@ class ZoneTopologyClient {
     // The response carries the topology as an escaped XML string inside
     // <ZoneGroupState>. innerText unescapes it; parse again.
     final stateEls = body.findAllElements('ZoneGroupState');
-    if (stateEls.isEmpty) return const [];
-    final inner = stateEls.first.innerText;
-    return parseZoneGroupState(inner);
+    return stateEls.isEmpty ? '' : stateEls.first.innerText;
   }
 
   /// Parses the inner `<ZoneGroupState>` XML into groups. Public for testing.
   static List<ZoneGroup> parseZoneGroupState(String xml) {
+    if (xml.isEmpty) return const [];
     final doc = XmlDocument.parse(xml);
     final groups = <ZoneGroup>[];
 

--- a/lib/features/diagnostics/diagnostics_bundle.dart
+++ b/lib/features/diagnostics/diagnostics_bundle.dart
@@ -156,25 +156,24 @@ String topologyText(SonosSystem system) {
     final g = system.groups[gi];
     b.writeln('\nGroup ${gi + 1}  (coordinator ${g.coordinatorUuid})');
     for (final m in g.members) {
-      final d = system.devicesByUuid[m.uuid];
       b.writeln(
         '  ${m.invisible ? '○' : '●'} ${m.zoneName}'
         '${m.invisible ? '  [hidden]' : ''}',
       );
       b.writeln('      uuid: ${m.uuid}');
-      if (d != null) b.writeln('      ${_deviceLine(d)}');
-      if (m.htSatChanMapSet?.isNotEmpty ?? false) {
-        b.writeln('      HTSatChanMapSet: ${m.htSatChanMapSet}');
+      final d = system.devicesByUuid[m.uuid];
+      if (d != null) {
+        for (final line in _deviceLines(d)) {
+          b.writeln('      $line');
+        }
       }
-      if (m.channelMapSet?.isNotEmpty ?? false) {
-        b.writeln(
-          '      ChannelMapSet: ${m.channelMapSet}  (${m.groupKind.name})',
-        );
-      }
+      _writeMap(b, 'HTSatChanMapSet', m.htSatChanMapSet);
+      _writeMap(b, 'ChannelMapSet', m.channelMapSet,
+          note: m.isGroup ? m.groupKind.name : null);
       for (final s in m.satellites) {
         b.writeln(
-          '      └ satellite ${s.zoneName}  ${s.uuid}  '
-          '[${s.channels.map((c) => c.token).join(',')}]  ip ${s.ip ?? '?'}',
+          '      └ [${s.channels.map((c) => c.token).join(',')}] ${s.uuid}'
+          ' · ${s.ip ?? '?'}',
         );
       }
     }
@@ -195,18 +194,37 @@ String topologyText(SonosSystem system) {
   if (orphans.isNotEmpty) {
     b.writeln('\nDevices not in topology groups:');
     for (final d in orphans) {
-      b.writeln('  - ${d.roomName}  ${d.uuid}\n      ${_deviceLine(d)}');
+      b.writeln('  - ${d.roomName}  ${d.uuid}');
+      for (final line in _deviceLines(d)) {
+        b.writeln('      $line');
+      }
     }
   }
   return b.toString();
 }
 
-String _deviceLine(SonosDevice d) {
+/// Per-device detail split across short lines (kept narrow so the on-screen
+/// monospace view doesn't wrap mid-token).
+List<String> _deviceLines(SonosDevice d) {
   final model =
       '${d.modelName}${d.modelNumber != null ? ' [${d.modelNumber}]' : ''}';
-  return 'model: $model   ip: ${d.ip ?? '?'}   mac: ${d.mac ?? '?'}   '
-      'serial: ${d.serial ?? '?'}   sw: ${d.softwareVersion ?? '?'}   '
-      'hw: ${d.hardwareVersion ?? '?'}${d.reachable ? '' : '   (UNREACHABLE)'}';
+  return [
+    '$model${d.reachable ? '' : '   (UNREACHABLE)'}',
+    'ip ${d.ip ?? '?'}   mac ${d.mac ?? '?'}',
+    'serial ${d.serial ?? '?'}',
+    'sw ${d.softwareVersion ?? '?'}   hw ${d.hardwareVersion ?? '?'}',
+  ];
+}
+
+/// Writes a channel-map set one `UUID:tokens` entry per line — far more legible
+/// than the raw single-line `;`-joined blob.
+void _writeMap(StringBuffer b, String label, String? map, {String? note}) {
+  if (map == null || map.isEmpty) return;
+  b.writeln('      $label:${note != null ? '  ($note)' : ''}');
+  for (final entry in map.split(';')) {
+    if (entry.trim().isEmpty) continue;
+    b.writeln('        $entry');
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/lib/features/diagnostics/diagnostics_bundle.dart
+++ b/lib/features/diagnostics/diagnostics_bundle.dart
@@ -1,0 +1,275 @@
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../data/models/sonos_models.dart';
+import '../../data/sonos/diagnostics_log.dart';
+import '../../data/sonos/sonos_repository.dart';
+import '../widgets/version_badge.dart' show fullVersionLabel;
+import 'diagnostics_platform.dart';
+
+/// Which optional sources to fold into the bundle (both default on in the UI).
+/// The core files — README, parsed_topology.json, topology.txt, raw_topology.xml,
+/// device_descriptions/, app_state.json — are always included.
+class DiagnosticsOptions {
+  const DiagnosticsOptions({
+    this.includeLogs = true,
+    this.includeNetwork = true,
+  });
+  final bool includeLogs;
+  final bool includeNetwork;
+}
+
+/// Builds the diagnostics zip and returns its file path. Re-fetches the raw
+/// topology + per-device descriptions fresh (a few read-only HTTP calls — no
+/// Sonos writes), serializes the live [system], dumps app-owned prefs, and adds
+/// logs/network per [options]. Structured with named files so a human can browse
+/// it and an agent can parse `parsed_topology.json` directly.
+Future<String> buildDiagnosticsZip({
+  required SonosSystem system,
+  required SonosRepository repo,
+  required PackageInfo package,
+  required DateTime now,
+  DiagnosticsOptions options = const DiagnosticsOptions(),
+}) async {
+  final archive = Archive();
+  void add(String name, String content) {
+    final bytes = utf8.encode(content);
+    archive.addFile(ArchiveFile(name, bytes.length, bytes));
+  }
+
+  // Core topology views.
+  add(
+    'parsed_topology.json',
+    const JsonEncoder.withIndent('  ').convert(topologyJson(system)),
+  );
+  add('topology.txt', topologyText(system));
+
+  // Raw GetZoneGroupState from any reachable player.
+  final probeIp = system.devicesByUuid.values
+      .map((d) => d.ip)
+      .firstWhere((ip) => ip != null, orElse: () => null);
+  add(
+    'raw_topology.xml',
+    await _tryFetch(
+      () => repo.rawTopology(probeIp!),
+      onNull: probeIp == null ? 'No reachable player to query.' : null,
+    ),
+  );
+
+  // Raw per-device descriptions (capability flags, min-app-version, household id).
+  for (final d in system.devicesByUuid.values) {
+    final ip = d.ip;
+    if (ip == null) continue;
+    add(
+      'device_descriptions/${_fileSafe(d.roomName)}_${d.uuid}.xml',
+      await _tryFetch(() => repo.rawDeviceDescription(ip)),
+    );
+  }
+
+  // App-owned persisted state (profiles + pre-group room-name snapshots).
+  add('app_state.json', await _appStateJson());
+
+  if (options.includeNetwork) {
+    add('network.txt', await networkInterfacesText());
+  }
+  add('README.txt', _readme(system, package, now, options));
+
+  // logs.txt LAST — snapshot the app log only after every other step has run, so
+  // any SOAP fault / error logged while fetching the raw topology or the device
+  // descriptions above is captured in the same bundle.
+  if (options.includeLogs) {
+    final lines = DiagnosticsLog.lines;
+    add(
+      'logs.txt',
+      lines.isEmpty ? '(no log lines captured yet)' : lines.join('\n'),
+    );
+  }
+
+  final zipped = ZipEncoder().encode(archive);
+  return writeTempFile('sonority-diagnostics-${_stamp(now)}.zip', zipped);
+}
+
+// ── Pure serialization (unit-tested) ───────────────────────────────────────
+
+/// Machine-readable dump of the whole system, INCLUDING invisible members and
+/// the raw channel-map strings (nothing hidden — this is the diagnostics view).
+Map<String, dynamic> topologyJson(SonosSystem system) => {
+  'groups': [
+    for (final g in system.groups)
+      {
+        'coordinatorUuid': g.coordinatorUuid,
+        'members': [
+          for (final m in g.members)
+            {
+              'uuid': m.uuid,
+              'zoneName': m.zoneName,
+              'invisible': m.invisible,
+              'location': m.location,
+              'ip': m.ip,
+              'isHomeTheater': m.isHomeTheater,
+              'isGroup': m.isGroup,
+              'groupKind': m.groupKind.name,
+              'htSatChanMapSet': m.htSatChanMapSet,
+              'channelMapSet': m.channelMapSet,
+              'satellites': [
+                for (final s in m.satellites)
+                  {
+                    'uuid': s.uuid,
+                    'zoneName': s.zoneName,
+                    'ip': s.ip,
+                    'channels': [for (final c in s.channels) c.token],
+                  },
+              ],
+            },
+        ],
+      },
+  ],
+  'devices': [
+    for (final d in system.devicesByUuid.values)
+      {
+        'uuid': d.uuid,
+        'roomName': d.roomName,
+        'modelName': d.modelName,
+        'modelNumber': d.modelNumber,
+        'typeLabel': d.typeLabel,
+        'ip': d.ip,
+        'mac': d.mac,
+        'serial': d.serial,
+        'softwareVersion': d.softwareVersion,
+        'hardwareVersion': d.hardwareVersion,
+        'reachable': d.reachable,
+        'isSoundbar': d.isSoundbar,
+        'isSub': d.isSub,
+        'isAmp': d.isAmp,
+      },
+  ],
+};
+
+/// Human-readable mirror of the on-screen technical view — the same string is
+/// shown in the diagnostics sheet and written to `topology.txt`.
+String topologyText(SonosSystem system) {
+  final b = StringBuffer('=== Sonos topology ===\n');
+  for (var gi = 0; gi < system.groups.length; gi++) {
+    final g = system.groups[gi];
+    b.writeln('\nGroup ${gi + 1}  (coordinator ${g.coordinatorUuid})');
+    for (final m in g.members) {
+      final d = system.devicesByUuid[m.uuid];
+      b.writeln(
+        '  ${m.invisible ? '○' : '●'} ${m.zoneName}'
+        '${m.invisible ? '  [hidden]' : ''}',
+      );
+      b.writeln('      uuid: ${m.uuid}');
+      if (d != null) b.writeln('      ${_deviceLine(d)}');
+      if (m.htSatChanMapSet?.isNotEmpty ?? false) {
+        b.writeln('      HTSatChanMapSet: ${m.htSatChanMapSet}');
+      }
+      if (m.channelMapSet?.isNotEmpty ?? false) {
+        b.writeln(
+          '      ChannelMapSet: ${m.channelMapSet}  (${m.groupKind.name})',
+        );
+      }
+      for (final s in m.satellites) {
+        b.writeln(
+          '      └ satellite ${s.zoneName}  ${s.uuid}  '
+          '[${s.channels.map((c) => c.token).join(',')}]  ip ${s.ip ?? '?'}',
+        );
+      }
+    }
+  }
+  // Any device not surfaced above (defensive — usually none). HT satellites are
+  // <Satellite> children rather than ZoneGroupMembers, so count them as
+  // represented too, else every bonded surround/sub reads as an "orphan".
+  final memberUuids = {
+    for (final g in system.groups)
+      for (final m in g.members) ...[
+        m.uuid,
+        for (final s in m.satellites) s.uuid,
+      ],
+  };
+  final orphans = system.devicesByUuid.values.where(
+    (d) => !memberUuids.contains(d.uuid),
+  );
+  if (orphans.isNotEmpty) {
+    b.writeln('\nDevices not in topology groups:');
+    for (final d in orphans) {
+      b.writeln('  - ${d.roomName}  ${d.uuid}\n      ${_deviceLine(d)}');
+    }
+  }
+  return b.toString();
+}
+
+String _deviceLine(SonosDevice d) {
+  final model =
+      '${d.modelName}${d.modelNumber != null ? ' [${d.modelNumber}]' : ''}';
+  return 'model: $model   ip: ${d.ip ?? '?'}   mac: ${d.mac ?? '?'}   '
+      'serial: ${d.serial ?? '?'}   sw: ${d.softwareVersion ?? '?'}   '
+      'hw: ${d.hardwareVersion ?? '?'}${d.reachable ? '' : '   (UNREACHABLE)'}';
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+Future<String> _appStateJson() async {
+  final prefs = await SharedPreferences.getInstance();
+  final map = {for (final k in prefs.getKeys()) k: prefs.get(k)};
+  return const JsonEncoder.withIndent('  ').convert(map);
+}
+
+Future<String> _tryFetch(
+  Future<String> Function() fetch, {
+  String? onNull,
+}) async {
+  if (onNull != null) return onNull;
+  try {
+    final s = await fetch();
+    return s.isEmpty ? '(empty response)' : s;
+  } catch (e) {
+    return '(fetch failed: $e)';
+  }
+}
+
+String _readme(
+  SonosSystem system,
+  PackageInfo package,
+  DateTime now,
+  DiagnosticsOptions o,
+) {
+  final files = [
+    'README.txt              — this file',
+    'parsed_topology.json    — machine-readable system dump (all members incl. hidden)',
+    'topology.txt            — human-readable version of the same',
+    'raw_topology.xml        — raw GetZoneGroupState from a player',
+    'device_descriptions/    — raw device_description.xml per speaker',
+    'app_state.json          — the app\'s stored profiles + saved room names',
+    if (o.includeLogs)
+      'logs.txt                — app diagnostics log (SOAP faults, retries, discovery, errors)',
+    if (o.includeNetwork)
+      'network.txt             — this device\'s network interfaces',
+  ];
+  return '''
+Sonority diagnostics bundle
+===========================
+App:       ${fullVersionLabel(package)}  (${package.version}+${package.buildNumber})
+Platform:  ${osDescription()}
+Captured:  ${now.toIso8601String()}
+System:    ${system.devicesByUuid.length} device(s), ${system.groups.length} group(s)
+
+Contents
+--------
+${files.join('\n')}
+
+Note: the topology contains room names, IP and MAC addresses, and model/serial
+info — the data needed to debug bonding/discovery. The optional sources above
+were included per the toggles in the app when this bundle was created.
+''';
+}
+
+String _fileSafe(String s) => s.replaceAll(RegExp(r'[^A-Za-z0-9._-]'), '_');
+
+String _stamp(DateTime t) {
+  String two(int n) => n.toString().padLeft(2, '0');
+  return '${t.year}${two(t.month)}${two(t.day)}-'
+      '${two(t.hour)}${two(t.minute)}${two(t.second)}';
+}

--- a/lib/features/diagnostics/diagnostics_bundle.dart
+++ b/lib/features/diagnostics/diagnostics_bundle.dart
@@ -213,8 +213,25 @@ String _deviceLine(SonosDevice d) {
 
 Future<String> _appStateJson() async {
   final prefs = await SharedPreferences.getInstance();
-  final map = {for (final k in prefs.getKeys()) k: prefs.get(k)};
-  return const JsonEncoder.withIndent('  ').convert(map);
+  final raw = {for (final k in prefs.getKeys()) k: prefs.get(k)};
+  return const JsonEncoder.withIndent('  ').convert(inlineJsonPrefs(raw));
+}
+
+/// SharedPreferences only stores strings, but the app stores most values as JSON
+/// (profiles, name snapshots). Inline any string that is itself valid JSON as
+/// real nested JSON so the dump is readable/parseable instead of a wall of
+/// escaped quotes; plain (non-JSON) strings and non-string prefs pass through.
+Map<String, dynamic> inlineJsonPrefs(Map<String, Object?> raw) => {
+      for (final e in raw.entries)
+        e.key: e.value is String ? _tryJsonDecode(e.value as String) : e.value,
+    };
+
+Object? _tryJsonDecode(String s) {
+  try {
+    return jsonDecode(s);
+  } catch (_) {
+    return s;
+  }
 }
 
 Future<String> _tryFetch(

--- a/lib/features/diagnostics/diagnostics_platform.dart
+++ b/lib/features/diagnostics/diagnostics_platform.dart
@@ -1,0 +1,6 @@
+// The diagnostics bundle needs `dart:io` (OS version, network interfaces, and
+// writing the zip to a temp file), which doesn't exist on web. This barrel picks
+// the real IO implementation everywhere except web, where throwing/empty stubs
+// keep the screenshot-only demo web build compiling (see demo_mode.dart).
+export 'diagnostics_platform_io.dart'
+    if (dart.library.html) 'diagnostics_platform_web.dart';

--- a/lib/features/diagnostics/diagnostics_platform_io.dart
+++ b/lib/features/diagnostics/diagnostics_platform_io.dart
@@ -1,0 +1,37 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+
+/// e.g. `android 34` / `macos Version 15.3 (Build 24D60)`.
+String osDescription() =>
+    '${Platform.operatingSystem} ${Platform.operatingSystemVersion}';
+
+/// The device's network interfaces + addresses (no netmask — `dart:io` doesn't
+/// expose it). Only useful for "speakers not found" discovery bugs, but it's the
+/// one signal available when the topology comes back empty.
+Future<String> networkInterfacesText() async {
+  final ifaces = await NetworkInterface.list(
+    includeLoopback: false,
+    includeLinkLocal: true,
+  );
+  final b = StringBuffer();
+  for (final i in ifaces) {
+    b.writeln('${i.name}:');
+    for (final a in i.addresses) {
+      b.writeln('  ${a.address}  (${a.type.name})');
+    }
+  }
+  final s = b.toString().trimRight();
+  return s.isEmpty ? '(no interfaces)' : s;
+}
+
+/// Writes [bytes] to a temp file named [name] and returns its path.
+// ponytail: no cleanup — the zip is consumed asynchronously by the share/email
+// sheet (deleting it here would race), and the OS reclaims the temp dir. Add a
+// sweep only if leftover bundles ever matter.
+Future<String> writeTempFile(String name, List<int> bytes) async {
+  final dir = await getTemporaryDirectory();
+  final file = File('${dir.path}/$name');
+  await file.writeAsBytes(bytes);
+  return file.path;
+}

--- a/lib/features/diagnostics/diagnostics_platform_web.dart
+++ b/lib/features/diagnostics/diagnostics_platform_web.dart
@@ -1,0 +1,9 @@
+// Web stubs — the diagnostics bundle is never built on web (the only web build
+// is the screenshot-only demo). These exist purely so the app compiles for web.
+
+String osDescription() => 'web';
+
+Future<String> networkInterfacesText() async => '(unavailable on web)';
+
+Future<String> writeTempFile(String name, List<int> bytes) async =>
+    throw UnsupportedError('Diagnostics bundle is not available on web');

--- a/lib/features/diagnostics/diagnostics_sheet.dart
+++ b/lib/features/diagnostics/diagnostics_sheet.dart
@@ -156,7 +156,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
           ? const Center(child: Text('No system discovered yet.'))
           : Scrollbar(
               child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(horizontal: 20),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: SelectableText(
                   topologyText(system),
                   style: const TextStyle(
@@ -192,7 +192,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
             dense: true,
           ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
             child: Text(
               'Always included: topology (room names, IPs, MACs, models), raw '
               'device descriptions, and your saved profiles/room names.',
@@ -204,7 +204,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
           SafeArea(
             top: false,
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
               child: Row(
                 children: [
                   Expanded(

--- a/lib/features/diagnostics/diagnostics_sheet.dart
+++ b/lib/features/diagnostics/diagnostics_sheet.dart
@@ -202,7 +202,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
             child: Text(
               'Always included: topology (room names, IPs, MACs, models), raw '
               'device descriptions, and your saved profiles/room names.',

--- a/lib/features/diagnostics/diagnostics_sheet.dart
+++ b/lib/features/diagnostics/diagnostics_sheet.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart';
@@ -154,11 +156,13 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
       title: 'Diagnostics',
       body: system == null
           ? const Center(child: Text('No system discovered yet.'))
-          : Scrollbar(
-              child: SingleChildScrollView(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
+          : SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: SizedBox(
+                width: double.infinity,
                 child: SelectableText(
                   topologyText(system),
+                  selectionWidthStyle: ui.BoxWidthStyle.tight,
                   style: const TextStyle(
                     fontFamily: 'monospace',
                     fontSize: 11,

--- a/lib/features/diagnostics/diagnostics_sheet.dart
+++ b/lib/features/diagnostics/diagnostics_sheet.dart
@@ -183,6 +183,9 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
               'SOAP faults, bond retries, discovery, errors (logs.txt)',
             ),
             dense: true,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.zero,
+            ),
           ),
           SwitchListTile(
             value: _includeNetwork,
@@ -194,6 +197,9 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
               "This device's network interface addresses (network.txt)",
             ),
             dense: true,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.zero,
+            ),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),

--- a/lib/features/diagnostics/diagnostics_sheet.dart
+++ b/lib/features/diagnostics/diagnostics_sheet.dart
@@ -1,0 +1,300 @@
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+import 'package:flutter/material.dart';
+import 'package:flutter_email_sender/flutter_email_sender.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:file_saver/file_saver.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../state/sonos_controller.dart';
+import '../widgets/app_scaffold.dart' show ScrolledUnderDivider;
+import 'diagnostics_bundle.dart';
+
+const _devEmail = 'casperverswijveltdev@gmail.com';
+
+/// Which share-bar action is in flight, so the spinner shows on the button that
+/// was actually pressed (not always the primary one).
+enum _Action { email, share, save }
+
+/// Opens the diagnostics bottom sheet: a hide-nothing technical topology view
+/// plus a way to package it (+ raw data, logs) into a zip and escalate it.
+Future<void> showDiagnosticsSheet(BuildContext context) =>
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      showDragHandle: true,
+      builder: (_) => const FractionallySizedBox(
+        heightFactor: 0.92,
+        child: _DiagnosticsSheet(),
+      ),
+    );
+
+class _DiagnosticsSheet extends ConsumerStatefulWidget {
+  const _DiagnosticsSheet();
+
+  @override
+  ConsumerState<_DiagnosticsSheet> createState() => _DiagnosticsSheetState();
+}
+
+class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
+  bool _includeLogs = true;
+  bool _includeNetwork = true;
+  _Action? _busy; // null = idle; else the action currently running
+
+  bool get _isBusy => _busy != null;
+
+  Future<String?> _collect() async {
+    final system = ref.read(sonosControllerProvider).value;
+    if (system == null) return null;
+    final pkg = await PackageInfo.fromPlatform();
+    return buildDiagnosticsZip(
+      system: system,
+      repo: ref.read(sonosRepositoryProvider),
+      package: pkg,
+      now: DateTime.now(),
+      options: DiagnosticsOptions(
+        includeLogs: _includeLogs,
+        includeNetwork: _includeNetwork,
+      ),
+    );
+  }
+
+  // flutter_email_sender supports iOS, Android and macOS (recipient + plaintext
+  // body + attachment — the only fields we set; it drops cc/bcc/HTML on macOS,
+  // which we don't use). Web uses mailto with no attachment, so exclude it and
+  // fall back to Share there.
+  bool get _emailSupported =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.macOS);
+
+  Future<void> _run(
+    _Action which,
+    Future<void> Function(String path) action,
+  ) async {
+    setState(() => _busy = which);
+    try {
+      final String path;
+      try {
+        final built = await _collect();
+        if (built == null) {
+          _snack('No system to collect — scan first.');
+          return;
+        }
+        path = built;
+      } catch (e) {
+        _snack('Could not build the diagnostics bundle: $e');
+        return;
+      }
+      try {
+        await action(path);
+      } catch (e) {
+        _snack('Could not complete the action: $e');
+      }
+    } finally {
+      if (mounted) setState(() => _busy = null);
+    }
+  }
+
+  Future<void> _save(String path) async {
+    // file_saver opens a native save dialog on every platform; filePath lets it
+    // copy the temp zip to the chosen location without loading it into Dart.
+    final saved = await FileSaver.instance.saveAs(
+      name: path.split('/').last.replaceAll('.zip', ''),
+      filePath: path,
+      fileExtension: 'zip',
+      mimeType: MimeType.zip,
+    );
+    if (saved != null) _snack('Saved to $saved');
+  }
+
+  /// Spinner on the button whose action is running, else its normal icon.
+  Widget _busyIcon(_Action which, IconData icon) => _busy == which
+      ? const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        )
+      : Icon(icon);
+
+  Future<void> _email(String path) => FlutterEmailSender.send(
+    Email(
+      subject: 'Sonority diagnostics',
+      recipients: const [_devEmail],
+      body:
+          'Describe what went wrong (what you tried, what you expected, '
+          'what happened):\n\n\n'
+          '——— the diagnostics bundle is attached below ———',
+      attachmentPaths: [path],
+    ),
+  );
+
+  Future<void> _share(String path) {
+    // iPad requires a non-null sharePositionOrigin or share_plus throws/crashes;
+    // anchor the popover to the sheet. Ignored on other platforms.
+    final box = context.findRenderObject() as RenderBox?;
+    final origin = box != null && box.hasSize
+        ? box.localToGlobal(Offset.zero) & box.size
+        : null;
+    return SharePlus.instance.share(
+      ShareParams(
+        files: [XFile(path)],
+        subject: 'Sonority diagnostics',
+        sharePositionOrigin: origin,
+      ),
+    );
+  }
+
+  void _snack(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final system = ref.watch(sonosControllerProvider).value;
+
+    // ScrollNotificationObserver so the reused ScrolledUnderDivider under the
+    // header can react to the body's scroll — a modal sheet lives in the overlay
+    // and doesn't see the home Scaffold's observer.
+    return ScrollNotificationObserver(
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 8),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.bug_report_outlined,
+                  color: theme.colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text('Diagnostics', style: theme.textTheme.titleLarge),
+              ],
+            ),
+          ),
+          const ScrolledUnderDivider(),
+          Expanded(
+            child: system == null
+                ? const Center(child: Text('No system discovered yet.'))
+                : Scrollbar(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: SelectableText(
+                        topologyText(system),
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 11,
+                          height: 1.35,
+                        ),
+                      ),
+                    ),
+                  ),
+          ),
+          const Divider(height: 1),
+          SwitchListTile(
+            value: _includeLogs,
+            onChanged: _isBusy ? null : (v) => setState(() => _includeLogs = v),
+            title: const Text('Include app logs'),
+            subtitle: const Text(
+              'SOAP faults, bond retries, discovery, errors (logs.txt)',
+            ),
+            dense: true,
+          ),
+          SwitchListTile(
+            value: _includeNetwork,
+            onChanged: _isBusy
+                ? null
+                : (v) => setState(() => _includeNetwork = v),
+            title: const Text('Include phone network info'),
+            subtitle: const Text(
+              "This device's network interface addresses (network.txt)",
+            ),
+            dense: true,
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 4),
+            child: Text(
+              'Always included: topology (room names, IPs, MACs, models), raw '
+              'device descriptions, and your saved profiles/room names.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: FilledButton.icon(
+                      onPressed: (_isBusy || system == null)
+                          ? null
+                          : () => _run(
+                              _emailSupported ? _Action.email : _Action.share,
+                              _emailSupported ? _email : _share,
+                            ),
+                      style: FilledButton.styleFrom(
+                        minimumSize: const Size(0, 52),
+                      ),
+                      icon: _busyIcon(
+                        _emailSupported ? _Action.email : _Action.share,
+                        _emailSupported ? Icons.mail_outline : Icons.share,
+                      ),
+                      label: Text(
+                        _busy ==
+                                (_emailSupported
+                                    ? _Action.email
+                                    : _Action.share)
+                            ? 'Collecting…'
+                            : _emailSupported
+                            ? 'Email to developer'
+                            : 'Share diagnostics',
+                      ),
+                    ),
+                  ),
+                  // The generic share sheet as a secondary action — redundant with
+                  // the primary button when email isn't supported, so drop it there.
+                  if (_emailSupported) ...[
+                    const SizedBox(width: 8),
+                    FilledButton.tonal(
+                      onPressed: (_isBusy || system == null)
+                          ? null
+                          : () => _run(_Action.share, _share),
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 14),
+                        minimumSize: const Size(0, 52),
+                      ),
+                      child: _busyIcon(_Action.share, Icons.share),
+                    ),
+                  ],
+                  // Explicit save-to-disk (native save dialog). Off on web,
+                  // where the bundle build (dart:io) can't run anyway.
+                  if (!kIsWeb) ...[
+                    const SizedBox(width: 8),
+                    FilledButton.tonal(
+                      onPressed: (_isBusy || system == null)
+                          ? null
+                          : () => _run(_Action.save, _save),
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 14),
+                        minimumSize: const Size(0, 52),
+                      ),
+                      child: _busyIcon(_Action.save, Icons.save_alt),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/diagnostics/diagnostics_sheet.dart
+++ b/lib/features/diagnostics/diagnostics_sheet.dart
@@ -8,7 +8,7 @@ import 'package:file_saver/file_saver.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../state/sonos_controller.dart';
-import '../widgets/app_scaffold.dart' show ScrolledUnderDivider;
+import '../widgets/sheet_scaffold.dart';
 import 'diagnostics_bundle.dart';
 
 const _devEmail = 'casperverswijveltdev@gmail.com';
@@ -20,16 +20,7 @@ enum _Action { email, share, save }
 /// Opens the diagnostics bottom sheet: a hide-nothing technical topology view
 /// plus a way to package it (+ raw data, logs) into a zip and escalate it.
 Future<void> showDiagnosticsSheet(BuildContext context) =>
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      showDragHandle: true,
-      builder: (_) => const FractionallySizedBox(
-        heightFactor: 0.92,
-        child: _DiagnosticsSheet(),
-      ),
-    );
+    showAppSheet<void>(context, const _DiagnosticsSheet());
 
 class _DiagnosticsSheet extends ConsumerStatefulWidget {
   const _DiagnosticsSheet();
@@ -158,43 +149,27 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
     final theme = Theme.of(context);
     final system = ref.watch(sonosControllerProvider).value;
 
-    // ScrollNotificationObserver so the reused ScrolledUnderDivider under the
-    // header can react to the body's scroll — a modal sheet lives in the overlay
-    // and doesn't see the home Scaffold's observer.
-    return ScrollNotificationObserver(
-      child: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.fromLTRB(20, 4, 20, 8),
-            child: Row(
-              children: [
-                Icon(
-                  Icons.bug_report_outlined,
-                  color: theme.colorScheme.primary,
-                ),
-                const SizedBox(width: 8),
-                Text('Diagnostics', style: theme.textTheme.titleLarge),
-              ],
-            ),
-          ),
-          const ScrolledUnderDivider(),
-          Expanded(
-            child: system == null
-                ? const Center(child: Text('No system discovered yet.'))
-                : Scrollbar(
-                    child: SingleChildScrollView(
-                      padding: const EdgeInsets.symmetric(horizontal: 20),
-                      child: SelectableText(
-                        topologyText(system),
-                        style: const TextStyle(
-                          fontFamily: 'monospace',
-                          fontSize: 11,
-                          height: 1.35,
-                        ),
-                      ),
-                    ),
+    return SheetScaffold(
+      icon: Icons.bug_report_outlined,
+      title: 'Diagnostics',
+      body: system == null
+          ? const Center(child: Text('No system discovered yet.'))
+          : Scrollbar(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: SelectableText(
+                  topologyText(system),
+                  style: const TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 11,
+                    height: 1.35,
                   ),
-          ),
+                ),
+              ),
+            ),
+      footer: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
           const Divider(height: 1),
           SwitchListTile(
             value: _includeLogs,

--- a/lib/features/discovery/discovery_screen.dart
+++ b/lib/features/discovery/discovery_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
+import '../diagnostics/diagnostics_sheet.dart';
 import '../widgets/bondable_speaker_tile.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/diagram_labels.dart';
@@ -56,6 +57,11 @@ class DiscoveryScreen extends ConsumerWidget {
       onRefresh: state.value != null ? () => controller.scan() : null,
       actions: [
         const VersionBadge(),
+        IconButton(
+          tooltip: 'Diagnostics',
+          onPressed: () => showDiagnosticsSheet(context),
+          icon: const Icon(Icons.bug_report_outlined),
+        ),
         // Only when there's a discovered system to refresh; the error state
         // uses its own CTA button to scan.
         if (state.value != null)

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -224,7 +224,7 @@ class _State extends ConsumerState<ProfileCreateScreen> {
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          Gap.s,
+          Gap.m,
           for (final e in _entities) ...[
             _SelectableEntityCard(
               entity: e,
@@ -243,7 +243,7 @@ class _State extends ConsumerState<ProfileCreateScreen> {
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          Gap.s,
+          Gap.m,
           Card(
             margin: EdgeInsets.zero,
             child: Column(

--- a/lib/features/profiles/profile_detail_screen.dart
+++ b/lib/features/profiles/profile_detail_screen.dart
@@ -132,7 +132,7 @@ class _State extends ConsumerState<ProfileDetailScreen> {
                   : theme.colorScheme.onSurfaceVariant,
             ),
           ),
-          Gap.s,
+          Gap.m,
           for (final e in entities) ...[
             Card(
               margin: EdgeInsets.zero,

--- a/lib/features/widgets/sheet_scaffold.dart
+++ b/lib/features/widgets/sheet_scaffold.dart
@@ -46,7 +46,7 @@ class SheetScaffold extends StatelessWidget {
       child: Column(
         children: [
           Padding(
-            padding: const EdgeInsets.fromLTRB(20, 4, 20, 8),
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
             child: Row(
               children: [
                 if (icon != null) ...[

--- a/lib/features/widgets/sheet_scaffold.dart
+++ b/lib/features/widgets/sheet_scaffold.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import 'app_scaffold.dart' show ScrolledUnderDivider;
+
+/// Opens [child] as the app's standard tall modal bottom sheet (drag handle,
+/// ~92% height, safe-area aware). Pair with [SheetScaffold] for the header +
+/// scroll-under divider chrome. Shared by the diagnostics + version/changelog
+/// sheets so they present identically.
+Future<T?> showAppSheet<T>(BuildContext context, Widget child) =>
+    showModalBottomSheet<T>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      showDragHandle: true,
+      // Present over the tab shell's NavigationBar so the sheet is a full modal.
+      useRootNavigator: true,
+      builder: (_) => FractionallySizedBox(heightFactor: 0.92, child: child),
+    );
+
+/// A modal-sheet body: a header row (optional leading [icon], [title], optional
+/// [trailing]) over a [ScrolledUnderDivider] that fades in as [body] scrolls
+/// under it, then the scrollable [body] filling the rest, and an optional
+/// pinned [footer]. The [body] should be its own scroll view.
+class SheetScaffold extends StatelessWidget {
+  const SheetScaffold({
+    super.key,
+    required this.title,
+    required this.body,
+    this.icon,
+    this.trailing,
+    this.footer,
+  });
+
+  final String title;
+  final IconData? icon;
+  final Widget? trailing;
+  final Widget body;
+  final Widget? footer;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // A modal sheet lives in the overlay and doesn't see the home Scaffold's
+    // ScrollNotificationObserver, so provide our own for ScrolledUnderDivider.
+    return ScrollNotificationObserver(
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 8),
+            child: Row(
+              children: [
+                if (icon != null) ...[
+                  Icon(icon, color: theme.colorScheme.primary),
+                  const SizedBox(width: 8),
+                ],
+                Expanded(
+                  child: Text(title, style: theme.textTheme.titleLarge),
+                ),
+                if (trailing != null) trailing!,
+              ],
+            ),
+          ),
+          const ScrolledUnderDivider(),
+          Expanded(child: body),
+          if (footer != null) footer!,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/widgets/version_badge.dart
+++ b/lib/features/widgets/version_badge.dart
@@ -83,7 +83,7 @@ Future<void> showVersionSheet(BuildContext context, PackageInfo info) {
           final md = snap.data;
           if (md == null) return const SizedBox.shrink();
           return SingleChildScrollView(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: _ChangelogView(parseChangelog(md)),
           );
         },
@@ -91,7 +91,7 @@ Future<void> showVersionSheet(BuildContext context, PackageInfo info) {
       footer: SafeArea(
         top: false,
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
           child: SizedBox(
             width: double.infinity,
             child: FilledButton.tonalIcon(

--- a/lib/features/widgets/version_badge.dart
+++ b/lib/features/widgets/version_badge.dart
@@ -3,11 +3,13 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'sheet_scaffold.dart';
+
 const _repoUrl = 'https://github.com/CasperVerswijvelt/Sonority';
 
 /// Muted `v<version>` label for an app-bar `actions:` slot. Reads the built
 /// package version at runtime so it tracks pubspec automatically. Tapping it
-/// opens a dialog with the full version, the changelog and a GitHub link.
+/// opens a bottom sheet with the changelog and a GitHub link.
 class VersionBadge extends StatelessWidget {
   const VersionBadge({super.key});
 
@@ -25,7 +27,7 @@ class VersionBadge extends StatelessWidget {
           child: Center(
             child: _VersionPill(
               'v${info.version}',
-              onTap: () => showVersionDialog(context, info),
+              onTap: () => showVersionSheet(context, info),
             ),
           ),
         );
@@ -34,7 +36,8 @@ class VersionBadge extends StatelessWidget {
   }
 }
 
-/// The muted rounded pill, shared by the app-bar badge and the dialog header.
+/// The muted rounded pill, shared by the app-bar badge and the changelog
+/// sheet's header (where it shows the full `v<version>-<build>` label).
 class _VersionPill extends StatelessWidget {
   const _VersionPill(this.text, {this.onTap});
   final String text;
@@ -65,52 +68,44 @@ class _VersionPill extends StatelessWidget {
   }
 }
 
-/// Version + changelog dialog opened by tapping the [VersionBadge].
-Future<void> showVersionDialog(BuildContext context, PackageInfo info) {
-  return showDialog<void>(
-    context: context,
-    builder: (ctx) => AlertDialog(
-      title: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          const Text('Sonority'),
-          _VersionPill(fullVersionLabel(info)),
-        ],
+/// Changelog sheet opened by tapping the [VersionBadge]. Uses the same
+/// modal-sheet chrome (drag handle + scroll-under divider) as the diagnostics
+/// sheet via [SheetScaffold].
+Future<void> showVersionSheet(BuildContext context, PackageInfo info) {
+  return showAppSheet<void>(
+    context,
+    SheetScaffold(
+      title: 'Changelog',
+      trailing: _VersionPill(fullVersionLabel(info)),
+      body: FutureBuilder<String>(
+        future: rootBundle.loadString('CHANGELOG.md'),
+        builder: (ctx, snap) {
+          final md = snap.data;
+          if (md == null) return const SizedBox.shrink();
+          return SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: _ChangelogView(parseChangelog(md)),
+          );
+        },
       ),
-      content: SizedBox(
-        width: double.maxFinite,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: FutureBuilder<String>(
-                future: rootBundle.loadString('CHANGELOG.md'),
-                builder: (ctx, snap) {
-                  final md = snap.data;
-                  if (md == null) return const SizedBox.shrink();
-                  return SingleChildScrollView(
-                    child: _ChangelogView(parseChangelog(md)),
-                  );
-                },
+      footer: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+          child: SizedBox(
+            width: double.infinity,
+            child: FilledButton.tonalIcon(
+              onPressed: () => launchUrl(
+                Uri.parse(_repoUrl),
+                mode: LaunchMode.externalApplication,
               ),
+              style: FilledButton.styleFrom(minimumSize: const Size(0, 52)),
+              icon: const Icon(Icons.open_in_new),
+              label: const Text('GitHub'),
             ),
-          ],
+          ),
         ),
       ),
-      actions: [
-        TextButton(
-          onPressed: () => launchUrl(
-            Uri.parse(_repoUrl),
-            mode: LaunchMode.externalApplication,
-          ),
-          child: const Text('GitHub'),
-        ),
-        TextButton(
-          onPressed: () => Navigator.pop(ctx),
-          child: const Text('Close'),
-        ),
-      ],
     ),
   );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,27 @@
+import 'dart:ui' show PlatformDispatcher;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'data/sonos/diagnostics_log.dart';
 import 'demo/demo_mode.dart';
 import 'features/profiles/profile_widget.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
+  // Capture uncaught errors into the rolling diagnostics log so they land in a
+  // shared bundle. Keep the default console/redscreen behaviour intact.
+  final priorOnError = FlutterError.onError;
+  FlutterError.onError = (details) {
+    DiagnosticsLog.add('FlutterError: ${details.exceptionAsString()}');
+    priorOnError?.call(details);
+  };
+  PlatformDispatcher.instance.onError = (error, stack) {
+    DiagnosticsLog.add('Uncaught: $error');
+    return false; // not handled — let the platform log it too.
+  };
   // Single portrait layout everywhere (no landscape to design for).
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -5,6 +5,7 @@ import '../data/models/sonos_models.dart';
 import '../data/sonos/apply_progress.dart';
 import '../data/sonos/cancellation.dart';
 import '../data/sonos/channel_map.dart';
+import '../data/sonos/diagnostics_log.dart';
 import '../data/sonos/front_layout.dart' as front_layout;
 import '../data/sonos/identify_service.dart';
 import '../data/sonos/led_identify.dart';
@@ -68,7 +69,10 @@ final operationLogProvider =
 final identifyServiceProvider = Provider<IdentifyServiceClient>((ref) {
   final service = IdentifyServiceClient(
     null,
-    kDebugMode ? (m) => debugPrint('[identify] $m') : null,
+    (m) {
+      if (kDebugMode) debugPrint('[identify] $m');
+      DiagnosticsLog.add('[identify] $m');
+    },
   );
   ref.onDispose(service.dispose);
   return service;
@@ -80,7 +84,10 @@ final identifyServiceProvider = Provider<IdentifyServiceClient>((ref) {
 final ledIdentifyProvider = Provider<LedIdentifyClient>((ref) {
   return LedIdentifyClient(
     null,
-    kDebugMode ? (m) => debugPrint('[led] $m') : null,
+    (m) {
+      if (kDebugMode) debugPrint('[led] $m');
+      DiagnosticsLog.add('[led] $m');
+    },
   );
 });
 
@@ -901,7 +908,12 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   ApplyProgress _newTracker(List<ApplyStep> steps) => ApplyProgress(
         steps,
         onChange: ref.read(applyProgressProvider.notifier).set,
-        onLog: ref.read(operationLogProvider.notifier).add,
+        onLog: (line) {
+          // The per-op log drives the progress screen (cleared each op); the
+          // app-wide DiagnosticsLog keeps a rolling copy for the bundle.
+          ref.read(operationLogProvider.notifier).add(line);
+          DiagnosticsLog.add(line);
+        },
       );
 
   /// Phase emitters bound to one parent (entity) step, so call sites don't

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,21 @@ import FlutterMacOS
 import Foundation
 
 import dynamic_color
+import file_saver
+import flutter_email_sender_method_channel
 import package_info_plus
 import path_provider_foundation
+import share_plus
 import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
+  FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
+  FlutterEmailSenderPlugin.register(with: registry.registrar(forPlugin: "FlutterEmailSenderPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<!-- Diagnostics "Save" button — write the zip to the location the user picks
+	     in the save panel (file_saver → NSSavePanel). -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,5 +8,9 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<!-- Diagnostics "Save" button — write the zip to the location the user picks
+	     in the save panel (file_saver → NSSavePanel). -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -34,7 +34,7 @@ packages:
     source: hosted
     version: "2.0.3"
   archive:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: archive
       sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -153,6 +161,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.10.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: dd58dc3861eb36edb13b217efc006a1c21e5bbc341de8c229b85634fa5e362e4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   dynamic_color:
     dependency: "direct main"
     description:
@@ -185,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_saver:
+    dependency: "direct main"
+    description:
+      name: file_saver
+      sha256: "68c9a085d9bb4546e0a31d1e583a48d7c17a6987d538788ea064f0043b1fc02d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   fixnum:
     dependency: transitive
     description:
@@ -203,6 +235,38 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_email_sender:
+    dependency: "direct main"
+    description:
+      name: flutter_email_sender
+      sha256: "0e1bc57128cef5bbc4c92c7d6d2768e61166c9118dcb961b7453c78531b382ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.1"
+  flutter_email_sender_method_channel:
+    dependency: transitive
+    description:
+      name: flutter_email_sender_method_channel
+      sha256: f40d2893b6f3e16d771b65fd9ffaeada44b65e95a02bcf532ed55775a0a96a60
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  flutter_email_sender_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_email_sender_platform_interface
+      sha256: "576fb2b08790040693bd02b1911ad51bf52ccabba87dc2964d6805552f27c39a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_email_sender_web:
+    dependency: transitive
+    description:
+      name: flutter_email_sender_web
+      sha256: cf47a07211d2e802f4638a8e17bfc87de0ee5c93f91d16051c0ed5ad01781c65
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -464,7 +528,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -575,6 +639,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.3.2"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.1.0"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -949,5 +1029,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.1"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,17 @@ dependencies:
   # Home-screen widget bridge (shared data + tap handling). Native widget UI is
   # per-platform; see docs/WIDGETS-SETUP.md. profile_widget.dart.
   home_widget: ^0.9.2+1
+  # Diagnostics bundle (features/diagnostics/): OS share sheet (share_plus),
+  # prefilled developer email with the zip attached (flutter_email_sender —
+  # mailto: can't attach, so this is the only option), save-to-disk via a native
+  # dialog on every platform (file_saver), plus zipping (archive) and a temp dir
+  # to stage the zip (path_provider). archive + path_provider were already
+  # transitive; promoted here so we can import them directly.
+  share_plus: ^11.0.0
+  flutter_email_sender: ^10.0.1
+  file_saver: ^0.4.0
+  archive: ^4.0.9
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:

--- a/test/changelog_parser_test.dart
+++ b/test/changelog_parser_test.dart
@@ -64,7 +64,7 @@ void main() {
     expect(fullVersionLabel(info('0.5', '50008')), 'v0.5 (50008)');
   });
 
-  testWidgets('version dialog shows version+build and the bundled changelog',
+  testWidgets('changelog sheet shows the header, version pill and changelog',
       (tester) async {
     final info = PackageInfo(
       appName: 'Sonority',
@@ -75,13 +75,14 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: Builder(
         builder: (ctx) => TextButton(
-          onPressed: () => showVersionDialog(ctx, info),
+          onPressed: () => showVersionSheet(ctx, info),
           child: const Text('open'),
         ),
       ),
     ));
     await tester.tap(find.text('open'));
     await tester.pumpAndSettle();
+    expect(find.text('Changelog'), findsOneWidget);
     expect(find.text('v0.5.0-8'), findsOneWidget);
     // Real CHANGELOG.md asset loaded and parsed. Match the header shape, not a
     // literal version/date — those change on every release cut.

--- a/test/diagnostics_test.dart
+++ b/test/diagnostics_test.dart
@@ -68,7 +68,10 @@ void main() {
     expect(text, contains('[hidden]'));
     expect(text, contains('192.168.1.10'));
     expect(text, contains('AA:BB:CC:00:00:01'));
-    expect(text, contains('L:LF,LF;R:RF,RF'));
+    // The channel map is broken one entry per line (not the joined blob).
+    expect(text, contains('L:LF,LF'));
+    expect(text, contains('R:RF,RF'));
+    expect(text, isNot(contains('L:LF,LF;R:RF,RF')));
   });
 
   test('topologyText does not mislabel a bonded HT satellite as an orphan', () {

--- a/test/diagnostics_test.dart
+++ b/test/diagnostics_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/data/models/sonos_models.dart';
+import 'package:sonority/data/sonos/diagnostics_log.dart';
+import 'package:sonority/features/diagnostics/diagnostics_bundle.dart';
+
+void main() {
+  // A stereo pair: the left half is visible + carries the ChannelMapSet, the
+  // right half is a separate Invisible member (the case the normal UI hides).
+  final system = SonosSystem(
+    groups: const [
+      ZoneGroup(coordinatorUuid: 'L', members: [
+        ZoneGroupMember(
+          uuid: 'L',
+          zoneName: 'Bedroom',
+          location: 'http://192.168.1.10:1400/xml/device_description.xml',
+          channelMapSet: 'L:LF,LF;R:RF,RF',
+        ),
+        ZoneGroupMember(uuid: 'R', zoneName: 'Bedroom', invisible: true),
+      ]),
+    ],
+    devicesByUuid: {
+      'L': const SonosDevice(
+        uuid: 'L',
+        roomName: 'Bedroom',
+        modelName: 'Sonos One',
+        modelNumber: 'S13',
+        ip: '192.168.1.10',
+        mac: 'AA:BB:CC:00:00:01',
+        serial: 'SER-1',
+        softwareVersion: '83.1-abc',
+      ),
+      'R': const SonosDevice(
+        uuid: 'R',
+        roomName: 'Bedroom',
+        modelName: 'Sonos One',
+        modelNumber: 'S13',
+        ip: '192.168.1.11',
+      ),
+    },
+  );
+
+  group('topologyJson', () {
+    test('includes the invisible member the normal UI filters out', () {
+      final json = topologyJson(system);
+      final members = (json['groups'] as List).first['members'] as List;
+      expect(members.length, 2);
+      final hidden = members.firstWhere((m) => m['uuid'] == 'R');
+      expect(hidden['invisible'], true);
+    });
+
+    test('carries the raw channel-map strings and per-device identity', () {
+      final json = topologyJson(system);
+      final visible = ((json['groups'] as List).first['members'] as List)
+          .firstWhere((m) => m['uuid'] == 'L');
+      expect(visible['channelMapSet'], 'L:LF,LF;R:RF,RF');
+
+      final dev = (json['devices'] as List).firstWhere((d) => d['uuid'] == 'L');
+      expect(dev['mac'], 'AA:BB:CC:00:00:01');
+      expect(dev['serial'], 'SER-1');
+      expect(dev['softwareVersion'], '83.1-abc');
+    });
+  });
+
+  test('topologyText marks hidden members and shows IP/MAC', () {
+    final text = topologyText(system);
+    expect(text, contains('[hidden]'));
+    expect(text, contains('192.168.1.10'));
+    expect(text, contains('AA:BB:CC:00:00:01'));
+    expect(text, contains('L:LF,LF;R:RF,RF'));
+  });
+
+  test('topologyText does not mislabel a bonded HT satellite as an orphan', () {
+    final ht = SonosSystem(
+      groups: const [
+        ZoneGroup(coordinatorUuid: 'BAR', members: [
+          ZoneGroupMember(
+            uuid: 'BAR',
+            zoneName: 'Living',
+            htSatChanMapSet: 'BAR:CC;SAT:LR',
+            satellites: [
+              SonosSatellite(
+                  uuid: 'SAT', zoneName: 'Living', channels: [SonosChannel.leftRear]),
+            ],
+          ),
+        ]),
+      ],
+      devicesByUuid: {
+        'BAR': const SonosDevice(uuid: 'BAR', roomName: 'Living', modelName: 'Sonos Beam'),
+        // The satellite is a discovered device but NOT a ZoneGroupMember.
+        'SAT': const SonosDevice(uuid: 'SAT', roomName: 'Living', modelName: 'Sonos One'),
+      },
+    );
+    expect(topologyText(ht), isNot(contains('not in topology groups')));
+  });
+
+  test('DiagnosticsLog is a capped ring buffer, oldest dropped first', () {
+    DiagnosticsLog.clear();
+    for (var i = 0; i < 600; i++) {
+      DiagnosticsLog.add('line $i');
+    }
+    final lines = DiagnosticsLog.lines;
+    expect(lines.length, 500);
+    // The first 100 were evicted; the newest survives.
+    expect(lines.first, contains('line 100'));
+    expect(lines.last, contains('line 599'));
+    DiagnosticsLog.clear();
+  });
+}

--- a/test/diagnostics_test.dart
+++ b/test/diagnostics_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonority/data/models/sonos_models.dart';
 import 'package:sonority/data/sonos/diagnostics_log.dart';
@@ -91,6 +93,25 @@ void main() {
       },
     );
     expect(topologyText(ht), isNot(contains('not in topology groups')));
+  });
+
+  test('inlineJsonPrefs inlines JSON string values as real nested JSON', () {
+    final out = inlineJsonPrefs({
+      'profiles': '[{"id":"1","name":"My setup"}]',
+      'pair_snapshot_X': '{"left":{"name":"Keuken"}}',
+      'plain': 'not json',
+      'count': 3,
+    });
+    // JSON strings become real structures (not escaped strings)...
+    expect(out['profiles'], isA<List<dynamic>>());
+    expect((out['profiles'] as List).first['name'], 'My setup');
+    expect(out['pair_snapshot_X'], isA<Map<String, dynamic>>());
+    expect((out['pair_snapshot_X'] as Map)['left']['name'], 'Keuken');
+    // ...while non-JSON strings and non-string values pass through unchanged.
+    expect(out['plain'], 'not json');
+    expect(out['count'], 3);
+    // The whole thing re-encodes without escaped-JSON-in-string.
+    expect(jsonEncode(out), isNot(contains(r'\"')));
   });
 
   test('DiagnosticsLog is a capped ring buffer, oldest dropped first', () {


### PR DESCRIPTION
## Diagnostics

Adds a **Diagnostics** screen (bug icon in the discovery app bar) as a self-serve fallback + escalation path when something isn't working.

- **Technical topology view** — hides nothing: invisible/hidden members, satellites, IP, MAC, serial, sw/hw firmware, raw channel maps.
- **Shareable structured zip** — README, `parsed_topology.json`, human `topology.txt`, fresh `raw_topology.xml`, per-device `device_descriptions/*.xml`, `app_state.json` (stored profiles + saved room names), plus optional `logs.txt` and `network.txt` toggles (both default on).
- **Three actions:** Share (`share_plus`, with `sharePositionOrigin` for iPad), Email to developer (`flutter_email_sender`, iOS/Android/macOS — recipient + plaintext body + zip attached), and Save to disk (`file_saver` native dialog; macOS `NSSavePanel` → `files.user-selected.read-write` entitlement). Spinner shows on the pressed button.
- **App-wide `DiagnosticsLog` ring buffer** captures SOAP faults/timeouts, discovery method + counts, bond retries (now with the real error), and uncaught errors. The per-op progress log stays scoped to its operation; `logs.txt` is snapshotted last so faults during collection are captured.
- Collection is **read-only** (re-fetch of `GetZoneGroupState` + device descriptions — no bonding/apply/rename writes).
- `dart:io` (OS/network/temp-file) sits behind a conditional-import barrel so the demo web build still compiles.

## Shared modal sheet + changelog

- Extracted the sheet chrome (tall drag-handle modal + header + `ScrolledUnderDivider`) into a reusable `SheetScaffold` + `showAppSheet` (`features/widgets/sheet_scaffold.dart`).
- The version/changelog viewer moves from an `AlertDialog` to the same bottom sheet ("Changelog" header + version pill, scroll-under divider, full-width GitHub button). Both sheets present via the root navigator so they overlay the tab bar as full modals.

## Engine additions (`lib/data/sonos/`)

- `SonosDevice` gains `mac`/`serial`/`softwareVersion`/`hardwareVersion` (diagnostics-only), parsed in `device_description.dart`.
- `ZoneTopologyClient.getRawState` + `DeviceDescriptionClient.fetchRaw` for the raw artifacts.

## Dependencies

Added: `share_plus`, `flutter_email_sender` (10.x, adds macOS), `file_saver` (pulls `dio`); promoted `archive` + `path_provider` from transitive to direct.

## Testing

`flutter analyze` clean, `flutter test` (162) green. New tests: topology JSON/text serialization (invisible members, raw maps, HT-satellite-not-orphan), `DiagnosticsLog` ring-buffer eviction, and the changelog sheet widget test. Verified end-to-end on real hardware via the Android app (debug + release/R8: share, email intent, save-to-Downloads); macOS + iOS + web builds and plugin registration confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)