### PR TITLE
fix(profiles): single save surface for detail + re-snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ section into the GitHub Release notes regardless of the build suffix
 ## [Unreleased]
 
 ### Changed
-- Profile editing is now a single save surface: the profile screen keeps you on the page after saving (with a toast) instead of jumping back to the list, and re-snapshot no longer instantly overwrites — it recaptures the current setup as an unsaved change you review and commit with Save (dropping the confirmation dialog and the duplicate name/appearance editor).
+- Profile editing is now a single save surface: the profile screen keeps you on the page after saving (with a toast) instead of jumping back to the list, and re-snapshot no longer instantly overwrites — it recaptures the current setup as an unsaved change you review and commit with Save (dropping the confirmation dialog, the duplicate name/appearance editor, and the apply primer from the re-snapshot screen). Captured-settings now show as "Audio settings"/"Volume" chips on each speaker card instead of a text line.
 
 ## [0.5.1] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Changed
+- Profile editing is now a single save surface: the profile screen keeps you on the page after saving (with a toast) instead of jumping back to the list, and re-snapshot no longer instantly overwrites — it recaptures the current setup as an unsaved change you review and commit with Save (dropping the confirmation dialog and the duplicate name/appearance editor).
+
 ## [0.5.1] - 2026-07-15
 
 ### Changed

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -77,7 +77,8 @@ final _router = GoRouter(
                   builder: (_, s) =>
                       ProfileDetailScreen(profileId: s.pathParameters['id']!),
                   // Nested so the stack is [overview, detail, resnapshot] —
-                  // Back returns to the detail page, declaratively (no push).
+                  // the detail screen pushes this and awaits the recaptured
+                  // entities it pops back (see ProfileDetailScreen._resnapshot).
                   routes: [
                     GoRoute(
                       path: 'resnapshot',

--- a/lib/features/profiles/profile.dart
+++ b/lib/features/profiles/profile.dart
@@ -104,17 +104,11 @@ class EntitySnapshot {
         settings: settings ?? this.settings,
       );
 
-  /// A short label for the UI describing what settings are captured, or `''`
-  /// when none — appended to [entitySummary] on the tiles.
-  String get settingsSummary {
-    final vals = settings.values;
-    final audio = vals.any((s) => s.hasAudioSettings);
-    final vol = vals.any((s) => s.hasVolume);
-    if (audio && vol) return 'Audio settings + volume saved';
-    if (audio) return 'Audio settings saved';
-    if (vol) return 'Volume saved';
-    return '';
-  }
+  /// Whether this entity captured any audio settings / volume — drive the
+  /// per-entity chips on the detail screen (mirrors [Profile]'s aggregates).
+  bool get hasAudioSettings =>
+      settings.values.any((s) => s.hasAudioSettings);
+  bool get hasVolume => settings.values.any((s) => s.hasVolume);
 
   Map<String, dynamic> toJson() => {
         'kind': kind.name,

--- a/lib/features/profiles/profile.dart
+++ b/lib/features/profiles/profile.dart
@@ -155,11 +155,8 @@ class Profile {
   });
 
   /// Aggregated across entities — drive the badges on the profile tile.
-  bool get hasAudioSettings =>
-      entities.any((e) => e.settings.values.any((s) => s.hasAudioSettings));
-
-  bool get hasVolume =>
-      entities.any((e) => e.settings.values.any((s) => s.hasVolume));
+  bool get hasAudioSettings => entities.any((e) => e.hasAudioSettings);
+  bool get hasVolume => entities.any((e) => e.hasVolume);
 
   Profile copyWith({
     String? name,

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -6,7 +6,6 @@ import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/app_scaffold.dart';
-import '../widgets/confirm_dialog.dart';
 import 'profile.dart';
 import 'profile_controller.dart';
 import 'profile_ui.dart';
@@ -14,11 +13,11 @@ import 'profile_ui.dart';
 /// Captures a profile from a live snapshot: pick which of the current entities
 /// (home theaters / stereo pairs / rooms) to include, name it, save.
 ///
-/// Two modes: when [profileId] is null this creates a new profile; when set it
-/// **re-snapshots** an existing one — overwriting its captured layout with the
-/// current setup, keeping the same profile (id). Re-snapshot pre-fills the name,
-/// pre-selects the entities that were originally in the profile, and gates the
-/// save behind a confirm dialog since the old layout is lost.
+/// Two modes: when [profileId] is null this creates a new profile (name it +
+/// save). When set it **re-snapshots** an existing one: it drops the name/
+/// appearance editor, pre-selects the entities originally in the profile, and on
+/// confirm hands the recaptured entities back to the detail screen (via
+/// `Navigator.pop`) as an unsaved change — the detail screen's Save commits it.
 class ProfileCreateScreen extends ConsumerStatefulWidget {
   final String? profileId;
   const ProfileCreateScreen({super.key, this.profileId});
@@ -91,7 +90,7 @@ class _State extends ConsumerState<ProfileCreateScreen> {
 
     if (system == null) {
       return Scaffold(
-        appBar: AppBar(title: Text(isResnapshot ? 'Update profile' : 'New profile')),
+        appBar: AppBar(title: Text(isResnapshot ? 'Re-snapshot' : 'New profile')),
         body: const Center(
           child: Padding(
             padding: EdgeInsets.all(32),
@@ -116,37 +115,38 @@ class _State extends ConsumerState<ProfileCreateScreen> {
     final canSave = name.isNotEmpty && !taken && anyIncluded && !_saving;
 
     return AppScaffold(
-      title: isResnapshot ? 'Update profile' : 'New profile',
+      title: isResnapshot ? 'Re-snapshot' : 'New profile',
       bottomOverlay: _BottomButtonBar(
         label: _saving
             ? 'Reading settings…'
             : isResnapshot
-                ? 'Update profile'
+                ? 'Use snapshot'
                 : 'Create profile',
         onPressed: canSave ? () => _save(name, existing) : null,
       ),
       body: ListView(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 96),
         children: [
-          if (existing != null) ...[
+          if (isResnapshot) ...[
+            // Non-destructive: nothing is written until the user saves on the
+            // profile screen, so this is a light note, not a warning.
             Card(
               margin: EdgeInsets.zero,
-              color: theme.colorScheme.errorContainer,
+              color: theme.colorScheme.surfaceContainerHighest,
               child: Padding(
-                padding: const EdgeInsets.all(16),
+                padding: const EdgeInsets.all(12),
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Icon(Icons.warning_amber_rounded,
-                        color: theme.colorScheme.onErrorContainer),
+                    Icon(Icons.info_outline,
+                        size: 20, color: theme.colorScheme.onSurfaceVariant),
                     Gap.s,
                     Expanded(
                       child: Text(
-                        'This replaces everything captured in '
-                        '“${existing.name}”. The previously saved layout '
-                        'will be lost.',
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onErrorContainer,
+                        'Recapture your current setup, then review and save it '
+                        'on the profile screen.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ),
@@ -155,30 +155,35 @@ class _State extends ConsumerState<ProfileCreateScreen> {
               ),
             ),
             Gap.l,
-          ],
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Tap the swatch to pick the icon + colour (kept off the main flow
-              // so the include list stays the focus of the page).
-              AppearanceButton(
-                  iconId: _iconId, color: _color, onTap: _editAppearance),
-              Gap.s,
-              Expanded(
-                child: TextField(
-                  controller: _name,
-                  onChanged: (_) => setState(() {}),
-                  textCapitalization: TextCapitalization.sentences,
-                  decoration: InputDecoration(
-                    labelText: 'Profile name',
-                    border: const OutlineInputBorder(),
-                    errorText: taken ? 'A profile with this name exists' : null,
+          ] else
+            // Name + appearance are edited on the profile screen for an existing
+            // profile; only create-new needs them here.
+            Padding(
+              padding: const EdgeInsets.only(bottom: 24),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Tap the swatch to pick the icon + colour (kept off the main
+                  // flow so the include list stays the focus of the page).
+                  AppearanceButton(
+                      iconId: _iconId, color: _color, onTap: _editAppearance),
+                  Gap.s,
+                  Expanded(
+                    child: TextField(
+                      controller: _name,
+                      onChanged: (_) => setState(() {}),
+                      textCapitalization: TextCapitalization.sentences,
+                      decoration: InputDecoration(
+                        labelText: 'Profile name',
+                        border: const OutlineInputBorder(),
+                        errorText:
+                            taken ? 'A profile with this name exists' : null,
+                      ),
+                    ),
                   ),
-                ),
+                ],
               ),
-            ],
-          ),
-          Gap.l,
+            ),
           Card(
             margin: EdgeInsets.zero,
             color: theme.colorScheme.surfaceContainerHighest,
@@ -281,23 +286,8 @@ class _State extends ConsumerState<ProfileCreateScreen> {
     final router = GoRouter.of(context);
     final notifier = ref.read(profilesProvider.notifier);
 
-    if (existing != null) {
-      // Re-snapshot: gate the overwrite behind an explicit confirm before we
-      // do the (potentially slow) settings read. Not destructive-tinted — it
-      // replaces saved data, not the live speakers.
-      final ok = await confirmDialog(
-        context,
-        title: 'Replace “${existing.name}”?',
-        message: 'The previously captured layout will be permanently replaced '
-            'with your current setup.',
-        confirmLabel: 'Replace',
-        destructive: false,
-      );
-      if (!ok) return;
-    }
-
     // Reading settings is several SOAP calls per speaker — show progress and
-    // enrich the snapshots before saving.
+    // enrich the snapshots before returning/saving them.
     if (_saveAudio || _saveVolume) {
       setState(() => _saving = true);
       try {
@@ -308,16 +298,18 @@ class _State extends ConsumerState<ProfileCreateScreen> {
         if (mounted) setState(() => _saving = false);
       }
     }
+    if (!mounted) return;
 
     if (existing != null) {
-      await notifier.replace(existing.copyWith(
-          name: name, entities: chosen, iconId: _iconId, color: _color));
+      // Re-snapshot: hand the recaptured entities back to the profile screen as
+      // an unsaved change — it commits them on Save, no overwrite here.
+      router.pop(chosen);
     } else {
       final id = DateTime.now().microsecondsSinceEpoch.toString();
       await notifier.add(Profile(
           id: id, name: name, entities: chosen, iconId: _iconId, color: _color));
+      router.go('/profiles');
     }
-    router.go('/profiles');
   }
 }
 

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -184,33 +184,38 @@ class _State extends ConsumerState<ProfileCreateScreen> {
                 ],
               ),
             ),
-          Card(
-            margin: EdgeInsets.zero,
-            color: theme.colorScheme.surfaceContainerHighest,
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Icon(Icons.info_outline,
-                      size: 20, color: theme.colorScheme.onSurfaceVariant),
-                  Gap.s,
-                  Expanded(
-                    child: Text(
-                      'Applying a profile later rebuilds these speakers into this '
-                      'layout. Any speaker that’s part of a different setup at that '
-                      'time is removed from it first — which can dissolve another '
-                      'stereo pair or zone and free its other speakers.',
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+          // Only the create flow needs the "what applying does" primer; on
+          // re-snapshot the profile already exists and the detail screen owns
+          // the review.
+          if (!isResnapshot) ...[
+            Card(
+              margin: EdgeInsets.zero,
+              color: theme.colorScheme.surfaceContainerHighest,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Icon(Icons.info_outline,
+                        size: 20, color: theme.colorScheme.onSurfaceVariant),
+                    Gap.s,
+                    Expanded(
+                      child: Text(
+                        'Applying a profile later rebuilds these speakers into this '
+                        'layout. Any speaker that’s part of a different setup at that '
+                        'time is removed from it first — which can dissolve another '
+                        'stereo pair or zone and free its other speakers.',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
-          ),
-          Gap.l,
+            Gap.l,
+          ],
           Text('Include', style: theme.textTheme.titleSmall),
           Text(
             'Pick which of your current home theaters, pairs and '

--- a/lib/features/profiles/profile_detail_screen.dart
+++ b/lib/features/profiles/profile_detail_screen.dart
@@ -140,10 +140,17 @@ class _State extends ConsumerState<ProfileDetailScreen> {
                 leading: Icon(entityIcon(e.kind)),
                 titleAlignment: ListTileTitleAlignment.center,
                 title: Text(e.label),
-                subtitle: Text(
-                  e.settingsSummary.isEmpty
-                      ? entitySummary(e, system)
-                      : '${entitySummary(e, system)}\n${e.settingsSummary}',
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(entitySummary(e, system)),
+                    if (settingsBadges(
+                            audio: e.hasAudioSettings, volume: e.hasVolume)
+                        case final badges?) ...[
+                      const SizedBox(height: 6),
+                      badges,
+                    ],
+                  ],
                 ),
               ),
             ),

--- a/lib/features/profiles/profile_detail_screen.dart
+++ b/lib/features/profiles/profile_detail_screen.dart
@@ -9,9 +9,9 @@ import 'profile.dart';
 import 'profile_controller.dart';
 import 'profile_ui.dart';
 
-/// A profile's detail view. The captured content (entities) is read-only — it's
-/// only ever set when the profile is created from a snapshot. Here you can edit
-/// the profile name and review what each entity will restore.
+/// A profile's detail view and single save surface: edit the name/appearance,
+/// review what each captured entity will restore, and re-snapshot to replace the
+/// captured layout from the current setup. All edits are unsaved until Save.
 class ProfileDetailScreen extends ConsumerStatefulWidget {
   final String profileId;
   const ProfileDetailScreen({super.key, required this.profileId});
@@ -25,6 +25,10 @@ class _State extends ConsumerState<ProfileDetailScreen> {
   bool _seeded = false;
   late String _iconId;
   late int _color;
+
+  /// Working copy of the entities from a re-snapshot, awaiting Save. Null until
+  /// the user re-snapshots — the stored `profile.entities` is shown until then.
+  List<EntitySnapshot>? _pendingEntities;
 
   @override
   void dispose() {
@@ -63,27 +67,28 @@ class _State extends ConsumerState<ProfileDetailScreen> {
       _seeded = true;
     }
 
+    final entities = _pendingEntities ?? profile.entities;
     final name = _name.text.trim();
     final taken = isProfileNameTaken(profiles, name, exceptId: profile.id);
     final appearanceChanged =
         _iconId != profile.iconId || _color != profile.color;
     final nameChanged = name != profile.name;
-    final changed =
-        (nameChanged || appearanceChanged) && name.isNotEmpty && !taken;
+    final entitiesChanged = _pendingEntities != null;
+    final changed = (nameChanged || appearanceChanged || entitiesChanged) &&
+        name.isNotEmpty &&
+        !taken;
 
     return AppScaffold(
       title: 'Profile',
       actions: [
         IconButton(
           tooltip: 'Re-snapshot from current setup',
-          onPressed: system == null
-              ? null
-              : () => context.go('/profiles/edit/${profile.id}/resnapshot'),
+          onPressed: system == null ? null : () => _resnapshot(profile),
           icon: const Icon(Icons.cameraswitch),
         ),
       ],
-      // Save appears once the name OR the appearance (icon/colour) differs from
-      // what's stored.
+      // Save appears once the name, appearance (icon/colour), or a re-snapshot
+      // differs from what's stored.
       floatingActionButton: changed
           ? FloatingActionButton.extended(
               onPressed: () => _save(profile, name),
@@ -117,14 +122,18 @@ class _State extends ConsumerState<ProfileDetailScreen> {
           Gap.l,
           Text('Included', style: theme.textTheme.titleSmall),
           Text(
-            'Captured when the profile was created. Use the re-snapshot button '
-            '(top right) to recapture from your current setup.',
+            entitiesChanged
+                ? 'Recaptured from your current setup — press Save to keep it.'
+                : 'Captured when the profile was created. Use the re-snapshot '
+                    'button (top right) to recapture from your current setup.',
             style: theme.textTheme.bodySmall?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+              color: entitiesChanged
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
             ),
           ),
           Gap.s,
-          for (final e in profile.entities) ...[
+          for (final e in entities) ...[
             Card(
               margin: EdgeInsets.zero,
               child: ListTile(
@@ -145,10 +154,28 @@ class _State extends ConsumerState<ProfileDetailScreen> {
     );
   }
 
+  /// Open the picker, and on return stash the recaptured entities as an unsaved
+  /// change (committed only when the user taps Save).
+  Future<void> _resnapshot(Profile profile) async {
+    final result = await context.push<List<EntitySnapshot>>(
+        '/profiles/edit/${profile.id}/resnapshot');
+    if (result != null && mounted) {
+      setState(() => _pendingEntities = result);
+    }
+  }
+
   Future<void> _save(Profile profile, String name) async {
-    final router = GoRouter.of(context);
-    await ref.read(profilesProvider.notifier).replace(
-        profile.copyWith(name: name, iconId: _iconId, color: _color));
-    router.go('/profiles');
+    final messenger = ScaffoldMessenger.of(context);
+    await ref.read(profilesProvider.notifier).replace(profile.copyWith(
+          name: name,
+          iconId: _iconId,
+          color: _color,
+          entities: _pendingEntities ?? profile.entities,
+        ));
+    if (!mounted) return;
+    // Stay on the page: clearing pending + the provider update make `changed`
+    // false, so the Save FAB hides itself.
+    setState(() => _pendingEntities = null);
+    messenger.showSnackBar(const SnackBar(content: Text('Profile saved')));
   }
 }

--- a/lib/features/profiles/profile_ui.dart
+++ b/lib/features/profiles/profile_ui.dart
@@ -245,20 +245,12 @@ class ProfileCard extends StatelessWidget {
                       style: theme.textTheme.bodySmall
                           ?.copyWith(color: scheme.onSurfaceVariant),
                     ),
-                    if (profile.hasAudioSettings || profile.hasVolume) ...[
+                    if (settingsBadges(
+                            audio: profile.hasAudioSettings,
+                            volume: profile.hasVolume)
+                        case final badges?) ...[
                       const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 6,
-                        runSpacing: 6,
-                        children: [
-                          if (profile.hasAudioSettings)
-                            const _Badge(
-                                icon: Icons.tune, label: 'Audio settings'),
-                          if (profile.hasVolume)
-                            const _Badge(
-                                icon: Icons.volume_up, label: 'Volume'),
-                        ],
-                      ),
+                      badges,
                     ],
                   ],
                 ),
@@ -272,11 +264,26 @@ class ProfileCard extends StatelessWidget {
   }
 }
 
-/// Small pill on the profile card marking what captured settings it carries.
-class _Badge extends StatelessWidget {
+/// The captured-settings chips ("Audio settings" / "Volume"), or null when
+/// neither is set. Shared by the profile tile (aggregate) and the per-entity
+/// cards on the detail screen.
+Widget? settingsBadges({required bool audio, required bool volume}) {
+  if (!audio && !volume) return null;
+  return Wrap(
+    spacing: 6,
+    runSpacing: 6,
+    children: [
+      if (audio) const SettingsBadge(icon: Icons.tune, label: 'Audio settings'),
+      if (volume) const SettingsBadge(icon: Icons.volume_up, label: 'Volume'),
+    ],
+  );
+}
+
+/// Small pill marking a captured setting (audio or volume).
+class SettingsBadge extends StatelessWidget {
   final IconData icon;
   final String label;
-  const _Badge({required this.icon, required this.label});
+  const SettingsBadge({super.key, required this.icon, required this.label});
 
   @override
   Widget build(BuildContext context) {

--- a/test/profile_test.dart
+++ b/test/profile_test.dart
@@ -89,7 +89,8 @@ void main() {
     expect(s.loudness, isTrue);
     expect(s.volume, 25);
     expect(s.eq, {'NightMode': 1, 'AudioDelay': 2});
-    expect(back.entities.first.settingsSummary, 'Audio settings + volume saved');
+    expect(back.entities.first.hasAudioSettings, isTrue);
+    expect(back.entities.first.hasVolume, isTrue);
     expect(back.hasAudioSettings, isTrue);
     expect(back.hasVolume, isTrue);
   });
@@ -109,17 +110,20 @@ void main() {
     };
     final back = Profile.fromJson(legacy);
     expect(back.entities.first.settings, isEmpty);
-    expect(back.entities.first.settingsSummary, '');
+    expect(back.entities.first.hasAudioSettings, isFalse);
+    expect(back.entities.first.hasVolume, isFalse);
     // Omitted from JSON when empty.
     expect(back.entities.first.toJson().containsKey('settings'), isFalse);
   });
 
-  test('settingsSummary reflects audio-only vs volume-only', () {
+  test('per-entity settings flags reflect audio-only vs volume-only', () {
     final base = EntitySnapshot.fromMember(ZoneGroupMember(uuid: fl, zoneName: 'x'));
-    expect(base.copyWith(settings: {fl: const SpeakerSettings(bass: 1)}).settingsSummary,
-        'Audio settings saved');
-    expect(
-        base.copyWith(settings: {fl: const SpeakerSettings(volume: 10)}).settingsSummary,
-        'Volume saved');
+    final audioOnly = base.copyWith(settings: {fl: const SpeakerSettings(bass: 1)});
+    expect(audioOnly.hasAudioSettings, isTrue);
+    expect(audioOnly.hasVolume, isFalse);
+    final volumeOnly =
+        base.copyWith(settings: {fl: const SpeakerSettings(volume: 10)});
+    expect(volumeOnly.hasAudioSettings, isFalse);
+    expect(volumeOnly.hasVolume, isTrue);
   });
 }


### PR DESCRIPTION
## What & why

Reworks the profile editing UX so **Save is the only thing that persists**, fixing two rough edges the user hit:

1. **Detail Save navigated away.** Editing a profile's name/appearance and tapping Save jumped straight back to the profiles list. Now it **stays on the detail screen**, shows a "Profile saved" toast, and the Save FAB hides itself (no unsaved changes left).
2. **Re-snapshot instantly overwrote** (behind a confirm dialog) and carried a **duplicate name/appearance editor** that re-seeded from the stored profile — silently discarding an unsaved rename typed on the detail screen. Now re-snapshot is a pure picker: it recaptures the current setup and hands the entities back to the detail screen as an **unsaved change** ("Use snapshot"), which you review and commit with Save. This makes the overwrite confirm dialog and the duplicate editor unnecessary, so both are gone.

The detail screen is now the single save surface; its unsaved-changes model covers name, appearance, **and** entities. `ProfileCreateScreen`'s create-new mode (`/profiles/new`) is unchanged — it still names + saves + returns to the list.

## Implementation notes

- Detail screen holds a working copy `_pendingEntities`; re-snapshot navigation switched from `context.go` to `context.push<List<EntitySnapshot>>` so the picked entities pop back into it.
- `_save` writes name + appearance + entities together, guards `setState`/SnackBar with `if (!mounted) return;`, and no longer navigates.
- Re-snapshot mode hides the name/appearance row, replaces the red "layout will be lost" warning with a light note, drops the confirm dialog, and `pop`s the entities instead of persisting. Settings capture (SOAP reads) still runs at re-snapshot time when the audio/volume toggles are on.

## Verification

- `flutter analyze` clean, `flutter test` green (157).
- Pre-merge review (fresh subagent + `/code-review` + `/ponytail-review`): fixed the one real finding (missing `mounted` guard in detail `_save`) and stale doc/comment drift; ponytail review clean.
- Driven end-to-end on the **Android emulator (demo mode)**: detail Save stays put + toast + FAB hides; re-snapshot shows no name/appearance/warning/confirm and returns as an unsaved change with the name preserved; Save commits the recaptured entities; create-new still shows the name field.

## Follow-up (not in scope)

Re-snapshotting then pressing Back without Save discards the pending change silently (consistent with how an unsaved rename already behaves). A `PopScope` "discard unsaved changes?" guard could be added if desired — left out to match the deferred-save model and avoid guarding only one edit type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)