### PR TITLE
feat(home-theater): rename "Remove all extra speakers" to "Separate"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ section into the GitHub Release notes regardless of the build suffix
 ### Changed
 - Profile editing is now a single save surface: the profile screen keeps you on the page after saving (with a toast) instead of jumping back to the list, and re-snapshot no longer instantly overwrites — it recaptures the current setup as an unsaved change you review and commit with Save (dropping the confirmation dialog, the duplicate name/appearance editor, and the apply primer from the re-snapshot screen). Captured-settings now show as "Audio settings"/"Volume" chips on each speaker card instead of a text line.
 - The version/changelog viewer (tap the version chip) now opens as a bottom sheet matching the new Diagnostics screen.
+- Renamed the home-theater "Remove all extra speakers" button to "Separate" (with a "Separate home theater?" confirmation), consistent with the speaker-groups wording.
 
 ## [0.5.1] - 2026-07-15
 

--- a/lib/features/home_theater/home_theater_screen.dart
+++ b/lib/features/home_theater/home_theater_screen.dart
@@ -77,13 +77,15 @@ class HomeTheaterScreen extends ConsumerWidget {
               member: member,
               device: device,
               bonded: bonded,
-              onRemoveGroup: (channels, label) => _confirmRemoveGroup(
+              onRemoveGroup: (channels, label, {bool separateAll = false}) =>
+                  _confirmRemoveGroup(
                 context,
                 ref,
                 member,
                 device,
                 channels,
                 label,
+                separateAll: separateAll,
               ),
               onConfigure: () => context.push('/theater/$soundbarUuid/fronts'),
             ),
@@ -115,15 +117,19 @@ class HomeTheaterScreen extends ConsumerWidget {
     ZoneGroupMember member,
     SonosDevice device,
     Set<SonosChannel> channels,
-    String label,
-  ) async {
+    String label, {
+    bool separateAll = false,
+  }) async {
     final ok = await confirmDialog(
       context,
       icon: Icons.link_off,
-      title: 'Remove $label?',
-      message: 'These speakers will be un-bonded and become standalone rooms '
-          'again. The rest of your home theater stays as it is.',
-      confirmLabel: 'Remove',
+      title: separateAll ? 'Separate home theater?' : 'Remove $label?',
+      message: separateAll
+          ? 'All extra speakers will be un-bonded and become standalone rooms '
+              'again, leaving just the soundbar.'
+          : 'These speakers will be un-bonded and become standalone rooms '
+              'again. The rest of your home theater stays as it is.',
+      confirmLabel: separateAll ? 'Separate' : 'Remove',
     );
     if (!ok || !context.mounted) return;
 
@@ -131,7 +137,7 @@ class HomeTheaterScreen extends ConsumerWidget {
     // No success toast — the progress screen already showed the outcome.
     await showBondingProgress(
       context,
-      title: 'Remove $label',
+      title: separateAll ? 'Separate home theater' : 'Remove $label',
       run: () => controller.removeHtRoles(
         soundbar: member,
         soundbarDevice: device,
@@ -167,7 +173,8 @@ class _Content extends StatelessWidget {
   final ZoneGroupMember member;
   final SonosDevice device;
   final List<SonosDevice> bonded;
-  final void Function(Set<SonosChannel> channels, String label) onRemoveGroup;
+  final void Function(Set<SonosChannel> channels, String label,
+      {bool separateAll}) onRemoveGroup;
   final VoidCallback onConfigure;
 
   const _Content({
@@ -269,10 +276,11 @@ class _Content extends StatelessWidget {
           Gap.l,
           DestructiveButton(
             icon: Icons.link_off,
-            label: 'Remove all extra speakers',
+            label: 'Separate',
             onPressed: () => onRemoveGroup(
               {for (final g in present) ...g.channels},
               'all extra speakers',
+              separateAll: true,
             ),
           ),
         ],


### PR DESCRIPTION
Renames the home-theater detail's **Remove all extra speakers** button to **Separate**, matching the speaker-groups wording. The confirmation dialog is now titled *Separate home theater?* with an updated body ("All extra speakers will be un-bonded and become standalone rooms again, leaving just the soundbar.").

Per-group removes (Fronts / Surrounds / Sub) still read **Remove** — only the whole-HT teardown changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)