### PR TITLE
fix(diagnostics): fold HT satellite IP into map line, drop duplicate rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ section into the GitHub Release notes regardless of the build suffix
 - Diagnostics: a new screen (bug icon, top-right) shows a hide-nothing technical view of your system — including hidden speakers, IPs, MAC addresses and firmware — and can package it, the raw topology, raw device info, your saved profiles and app logs into a zip to share via the system share sheet, email straight to the developer, or save to disk. App logs and phone network info are optional toggles.
 
 ### Changed
+- Diagnostics: home-theater blocks in the topology view no longer print each satellite twice — the satellite's IP is now folded into its `HTSatChanMapSet` line instead of repeating the UUID and channel on a separate line.
 - Profile editing is now a single save surface: the profile screen keeps you on the page after saving (with a toast) instead of jumping back to the list, and re-snapshot no longer instantly overwrites — it recaptures the current setup as an unsaved change you review and commit with Save (dropping the confirmation dialog, the duplicate name/appearance editor, and the apply primer from the re-snapshot screen). Captured-settings now show as "Audio settings"/"Volume" chips on each speaker card instead of a text line.
 - The version/changelog viewer (tap the version chip) now opens as a bottom sheet matching the new Diagnostics screen.
 

--- a/lib/features/diagnostics/diagnostics_bundle.dart
+++ b/lib/features/diagnostics/diagnostics_bundle.dart
@@ -167,10 +167,21 @@ String topologyText(SonosSystem system) {
           b.writeln('      $line');
         }
       }
-      _writeMap(b, 'HTSatChanMapSet', m.htSatChanMapSet);
+      // Fold each satellite's IP into its HTSatChanMapSet line so the UUID +
+      // channel aren't printed twice (the map is the only home a satellite has —
+      // it's a <Satellite> child, not its own member/device block).
+      final satIps = {for (final s in m.satellites) s.uuid: s.ip};
+      _writeMap(b, 'HTSatChanMapSet', m.htSatChanMapSet, ips: satIps);
       _writeMap(b, 'ChannelMapSet', m.channelMapSet,
           note: m.isGroup ? m.groupKind.name : null);
+      // Lossless residual: surface any <Satellite> the raw map didn't list (a
+      // raw-vs-parsed mismatch a diagnostics dump must not hide). Normally none.
+      final mapUuids = {
+        for (final e in (m.htSatChanMapSet ?? '').split(';'))
+          if (e.isNotEmpty) e.split(':').first,
+      };
       for (final s in m.satellites) {
+        if (mapUuids.contains(s.uuid)) continue;
         b.writeln(
           '      └ [${s.channels.map((c) => c.token).join(',')}] ${s.uuid}'
           ' · ${s.ip ?? '?'}',
@@ -217,13 +228,16 @@ List<String> _deviceLines(SonosDevice d) {
 }
 
 /// Writes a channel-map set one `UUID:tokens` entry per line — far more legible
-/// than the raw single-line `;`-joined blob.
-void _writeMap(StringBuffer b, String label, String? map, {String? note}) {
+/// than the raw single-line `;`-joined blob. When [ips] is given, appends ` · IP`
+/// to any entry whose UUID is in the map (used to fold HT satellite IPs in).
+void _writeMap(StringBuffer b, String label, String? map,
+    {String? note, Map<String, String?>? ips}) {
   if (map == null || map.isEmpty) return;
   b.writeln('      $label:${note != null ? '  ($note)' : ''}');
   for (final entry in map.split(';')) {
     if (entry.trim().isEmpty) continue;
-    b.writeln('        $entry');
+    final ip = ips?[entry.split(':').first];
+    b.writeln('        $entry${ip != null ? ' · $ip' : ''}');
   }
 }
 

--- a/test/diagnostics_test.dart
+++ b/test/diagnostics_test.dart
@@ -98,6 +98,62 @@ void main() {
     expect(topologyText(ht), isNot(contains('not in topology groups')));
   });
 
+  test('topologyText folds an HT satellite IP into its map line (no └ dup)', () {
+    final ht = SonosSystem(
+      groups: const [
+        ZoneGroup(coordinatorUuid: 'BAR', members: [
+          ZoneGroupMember(
+            uuid: 'BAR',
+            zoneName: 'Living',
+            htSatChanMapSet: 'BAR:CC;SAT:LR',
+            satellites: [
+              SonosSatellite(
+                  uuid: 'SAT',
+                  zoneName: 'Living',
+                  channels: [SonosChannel.leftRear],
+                  ip: '192.168.1.50'),
+            ],
+          ),
+        ]),
+      ],
+      devicesByUuid: {
+        'BAR': const SonosDevice(uuid: 'BAR', roomName: 'Living', modelName: 'Sonos Beam'),
+      },
+    );
+    final text = topologyText(ht);
+    // Satellite IP is appended to its map row...
+    expect(text, contains('SAT:LR · 192.168.1.50'));
+    // ...the coordinator's own CC row stays plain (its IP is in its device block)...
+    expect(text, isNot(contains('BAR:CC ·')));
+    // ...and no residual └ line for a map-covered satellite.
+    expect(text, isNot(contains('└')));
+  });
+
+  test('topologyText keeps a residual └ line for a satellite absent from the map', () {
+    final ht = SonosSystem(
+      groups: const [
+        ZoneGroup(coordinatorUuid: 'BAR', members: [
+          ZoneGroupMember(
+            uuid: 'BAR',
+            zoneName: 'Living',
+            htSatChanMapSet: 'BAR:CC',
+            satellites: [
+              SonosSatellite(
+                  uuid: 'GHOST',
+                  zoneName: 'Living',
+                  channels: [SonosChannel.rightRear],
+                  ip: '192.168.1.51'),
+            ],
+          ),
+        ]),
+      ],
+      devicesByUuid: {
+        'BAR': const SonosDevice(uuid: 'BAR', roomName: 'Living', modelName: 'Sonos Beam'),
+      },
+    );
+    expect(topologyText(ht), contains('└ [RR] GHOST · 192.168.1.51'));
+  });
+
   test('inlineJsonPrefs inlines JSON string values as real nested JSON', () {
     final out = inlineJsonPrefs({
       'profiles': '[{"id":"1","name":"My setup"}]',


### PR DESCRIPTION
## What

In the Diagnostics topology view (and bundled `topology.txt`), a home-theater coordinator printed each satellite **twice**:

1. In the raw `HTSatChanMapSet:` block as `UUID:channel`.
2. Again as a `└ [CH] UUID · IP` line.

Everything but the **IP** was duplicated. This folds the satellite IP into its `HTSatChanMapSet` row and drops the separate `└` block.

**Before**
```
HTSatChanMapSet:
  RINCON_542…:CC
  RINCON_949…:SW
  RINCON_5CAAFDB4E69401400:RF
  …
└ [SW] RINCON_949… · 192.168.69.106
└ [RF] RINCON_5CAAFDB4E69401400 · 192.168.69.111
  …
```

**After**
```
HTSatChanMapSet:
  RINCON_542…:CC
  RINCON_949…:SW · 192.168.69.106
  RINCON_5CAAFDB4E69401400:RF · 192.168.69.111
  …
```

## Lossless

Kept a **residual** `└` line for any satellite whose UUID is absent from the raw map — a raw-vs-parsed mismatch (e.g. the ~15s topology lag) that a hide-nothing diagnostics dump must still surface. The coordinator's own `…:CC` row stays plain (its IP is already in the device block). The `ChannelMapSet`/zone path is untouched (zone members print their own IP blocks).

Only affects `topologyText()`, which both the in-app Diagnostics sheet and the bundled `topology.txt` render — so both update from one change.

## Tests

Two new cases in `test/diagnostics_test.dart`: IP folded into the map line with no `└` for a map-covered satellite; residual `└` retained for a satellite missing from the map. `flutter analyze` clean, `flutter test` green (165 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)