### PR TITLE
feat(docs): generated landing page for GitHub Pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ lib/
   features/        discovery / home_theater / front_surrounds (full HT setup) /
                      group (unified Stereo/Zone/Custom) / profiles / room / widgets
   app.dart, main.dart — go_router StatefulShellRoute (System|Profiles tabs), ProviderScope
-tool/              spike, roundtrip, full_layout, diff_apply_spike, chirp, dump_chime, zone_probe, lr_audiotest, eq_probe, capture_shots, gen_assets.sh (icon/wordmark/splash pipeline)
+tool/              spike, roundtrip, full_layout, diff_apply_spike, chirp, dump_chime, zone_probe, lr_audiotest, eq_probe, capture_shots, gen_assets.sh (icon/wordmark/splash pipeline), gen_site (docs/ landing page)
 ```
 Note: CLI tools must NOT import `sonos_repository.dart` (it pulls in
 `shared_preferences` → Flutter). The pure recipes live in `front_layout.dart` /
@@ -388,6 +388,11 @@ Run on the same Wi-Fi as the Sonos system:
   framed Play/App Store graphic from `design/store.html` in the same run (§2–3 of
   `docs/MARKETING-ASSETS.md`); `--no-capture` re-frames existing shots, `--no-build`
   reuses `build/web`.
+- `tool/gen_site.dart` — no hardware: generates the GitHub Pages landing page
+  `docs/index.html` from `tool/site_template.html`, reusing the tagline from
+  `pubspec.yaml` + the four `SHOTS` captions from `design/store.html` (no
+  copy-pasted text; screenshots/badges/logo reused in place from `docs/`). Re-run
+  and commit after copy changes.
 - `tool/gen_assets.sh` — regenerates ALL app-icon / wordmark / splash / Icon-Composer
   layer assets from the **single source `design/export.html`** (one `?mode=` each,
   rendered headless), then runs `flutter_launcher_icons` + `flutter_native_splash`

--- a/docs/MARKETING-ASSETS.md
+++ b/docs/MARKETING-ASSETS.md
@@ -31,6 +31,12 @@ When features ship, update all four in one pass, cross-checking `CHANGELOG.md`:
 3. `design/store.html` — the `SHOTS` captions + the feature/tablet blurbs.
 4. `README.md` screenshot alt text.
 
+The landing page (`docs/index.html`, served by GitHub Pages) is **generated** —
+`dart run tool/gen_site.dart` reuses the tagline from `pubspec.yaml` and the four
+`SHOTS` captions from `design/store.html` (no text is copy-pasted), filling
+`tool/site_template.html`. Re-run it after changing either source, and commit the
+regenerated `docs/index.html`.
+
 ## 2. Screenshots — the four canonical screens
 
 Sonority markets four screens: **overview**, **home-theater detail**,

--- a/tool/gen_site.dart
+++ b/tool/gen_site.dart
@@ -1,0 +1,57 @@
+// Generates docs/index.html (the GitHub Pages landing page) from the marketing
+// copy that already lives in the repo — no text is duplicated:
+//   * tagline   <- pubspec.yaml `description:`
+//   * captions  <- design/store.html `SHOTS` array (the store-graphic source)
+// Screenshots/badges/logo are reused in place from docs/. Run after copy changes:
+//   dart run tool/gen_site.dart
+import 'dart:io';
+
+void main() {
+  final root = Directory.current.path;
+  String read(String p) => File('$root/$p').readAsStringSync();
+
+  final tagline = RegExp(r'^description:\s*"(.*)"', multiLine: true)
+      .firstMatch(read('pubspec.yaml'))
+      ?.group(1);
+  if (tagline == null || tagline.isEmpty) {
+    stderr.writeln('gen_site: could not read description: from pubspec.yaml');
+    exit(1);
+  }
+
+  // ponytail: regex-couples to the SHOTS object shape in store.html; the count
+  // assert below fails loudly if that literal ever drifts. Cheaper than a JS parser.
+  final shots = RegExp(
+    r"src\s*:\s*'([^']*)'\s*,\s*head\s*:\s*'([^']*)'\s*,\s*sub\s*:\s*'([^']*)'",
+    dotAll: true,
+  ).allMatches(read('design/store.html')).toList();
+  if (shots.length != 4) {
+    stderr.writeln('gen_site: expected 4 SHOTS in design/store.html, got ${shots.length}');
+    exit(1);
+  }
+
+  final template = read('tool/site_template.html');
+  final rowStart = template.indexOf('<!--ROW-->');
+  final rowEnd = template.indexOf('<!--/ROW-->');
+  if (rowStart < 0 || rowEnd < 0) {
+    stderr.writeln('gen_site: ROW markers missing in tool/site_template.html');
+    exit(1);
+  }
+  final row = template.substring(rowStart + '<!--ROW-->'.length, rowEnd);
+
+  final rows = shots.map((m) {
+    final src = m.group(1)!.replaceFirst('shots/', 'screenshots/');
+    return row
+        .replaceAll('{{SHOT}}', src)
+        .replaceAll('{{HEAD}}', m.group(2)!)
+        .replaceAll('{{SUB}}', m.group(3)!);
+  }).join();
+
+  final html = template
+      .substring(0, rowStart)
+      .replaceAll('{{TAGLINE}}', tagline) +
+      rows +
+      template.substring(rowEnd + '<!--/ROW-->'.length);
+
+  File('$root/docs/index.html').writeAsStringSync(html);
+  stdout.writeln('wrote docs/index.html (${shots.length} sections)');
+}

--- a/tool/site_template.html
+++ b/tool/site_template.html
@@ -69,7 +69,7 @@
     <header>
       <img class="logo" src="icon.png" alt="Sonority">
       <h1>Sonority</h1>
-      <p class="tag">Home-theater layouts, speaker groups and one-tap profiles for Sonos that the official app won't create.</p>
+      <p class="tag">{{TAGLINE}}</p>
       <div class="badges">
         <a href="https://apps.apple.com/us/app/sonority-for-sonos/id6785994018"><img src="badges/app-store.png" alt="Download on the App Store"></a>
         <a href="https://apps.apple.com/us/app/sonority-for-sonos/id6785994018"><img src="badges/mac-app-store.png" alt="Download on the Mac App Store"></a>
@@ -79,39 +79,15 @@
     </header>
 
     <main>
-
+<!--ROW-->
       <section class="feature">
-        <div class="phone"><img src="screenshots/01-overview.png" alt=""></div>
+        <div class="phone"><img src="{{SHOT}}" alt=""></div>
         <div class="copy">
-          <h2>Your whole<br>Sonos system</h2>
-          <p class="grey">Home theaters, speaker groups and every room — at a glance.</p>
+          <h2>{{HEAD}}</h2>
+          <p class="grey">{{SUB}}</p>
         </div>
       </section>
-
-      <section class="feature">
-        <div class="phone"><img src="screenshots/02-home-theater.png" alt=""></div>
-        <div class="copy">
-          <h2>Dedicated<br>front speakers</h2>
-          <p class="grey">Add discrete front L / R to your soundbar — a home theater the Sonos app won’t build.</p>
-        </div>
-      </section>
-
-      <section class="feature">
-        <div class="phone"><img src="screenshots/03-group.png" alt=""></div>
-        <div class="copy">
-          <h2>Stereo pairs,<br>zones &amp; more</h2>
-          <p class="grey">Bond any speakers into one room — even mismatched models the app blocks.</p>
-        </div>
-      </section>
-
-      <section class="feature">
-        <div class="phone"><img src="screenshots/04-profiles.png" alt=""></div>
-        <div class="copy">
-          <h2>Save &amp; restore<br>your layouts</h2>
-          <p class="grey">Snapshot your setup and rebuild fronts, surrounds and groups in one tap.</p>
-        </div>
-      </section>
-
+<!--/ROW-->
     </main>
 
     <footer>


### PR DESCRIPTION
## What

Replaces the bare 35-line `docs/index.html` with a fancier — but still simplistic — dark-brand landing page served by GitHub Pages (`main` / `/docs` → casperverswijvelt.be/Sonority/):

- **Hero** — logo lockup, tagline, App Store / Mac App Store / Google Play badges, and a GitHub link.
- **Four alternating sections** — each a CSS phone frame around a marketing screenshot with its caption.
- **Footer** — Privacy / Support / GitHub + the trademark disclaimer.
- Responsive: sections collapse to a single column on narrow screens.

## No copy-pasted text — generated

`tool/gen_site.dart` builds `docs/index.html` from `tool/site_template.html`, reusing existing sources:
- tagline ← `pubspec.yaml` `description:`
- 4 captions ← the `SHOTS` array in `design/store.html` (the store-graphic source of truth)
- screenshots / badges / logo ← referenced in place from `docs/` (no copying)

Re-run after copy changes: `dart run tool/gen_site.dart`. A self-check exits non-zero if it doesn't find exactly 4 captions + a tagline. `design/store.html` is untouched, so the store-graphics pipeline can't regress.

## Verification

- `flutter analyze` + `dart analyze tool/gen_site.dart`: clean.
- Rendered `docs/index.html` in Chrome at desktop (1200px) and mobile (420px) widths — hero, badges, all four phone-framed sections, and footer render correctly; layout stacks on mobile.
- `git diff design/store.html`: empty.

Docs synced: `docs/MARKETING-ASSETS.md` §1 + CLAUDE.md tool list. No CHANGELOG entry (docs/marketing artifact, not a shipped app change) and no version bump (feature branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)