### PR TITLE
fix(docs): serve LFS screenshots via media endpoint on Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,7 @@
     <main>
 
       <section class="feature">
-        <div class="phone"><img src="screenshots/01-overview.png" alt=""></div>
+        <div class="phone"><img src="https://media.githubusercontent.com/media/CasperVerswijvelt/Sonority/main/docs/screenshots/01-overview.png" alt=""></div>
         <div class="copy">
           <h2>Your whole<br>Sonos system</h2>
           <p class="grey">Home theaters, speaker groups and every room — at a glance.</p>
@@ -89,7 +89,7 @@
       </section>
 
       <section class="feature">
-        <div class="phone"><img src="screenshots/02-home-theater.png" alt=""></div>
+        <div class="phone"><img src="https://media.githubusercontent.com/media/CasperVerswijvelt/Sonority/main/docs/screenshots/02-home-theater.png" alt=""></div>
         <div class="copy">
           <h2>Dedicated<br>front speakers</h2>
           <p class="grey">Add discrete front L / R to your soundbar — a home theater the Sonos app won’t build.</p>
@@ -97,7 +97,7 @@
       </section>
 
       <section class="feature">
-        <div class="phone"><img src="screenshots/03-group.png" alt=""></div>
+        <div class="phone"><img src="https://media.githubusercontent.com/media/CasperVerswijvelt/Sonority/main/docs/screenshots/03-group.png" alt=""></div>
         <div class="copy">
           <h2>Stereo pairs,<br>zones &amp; more</h2>
           <p class="grey">Bond any speakers into one room — even mismatched models the app blocks.</p>
@@ -105,7 +105,7 @@
       </section>
 
       <section class="feature">
-        <div class="phone"><img src="screenshots/04-profiles.png" alt=""></div>
+        <div class="phone"><img src="https://media.githubusercontent.com/media/CasperVerswijvelt/Sonority/main/docs/screenshots/04-profiles.png" alt=""></div>
         <div class="copy">
           <h2>Save &amp; restore<br>your layouts</h2>
           <p class="grey">Snapshot your setup and rebuild fronts, surrounds and groups in one tap.</p>

--- a/tool/gen_site.dart
+++ b/tool/gen_site.dart
@@ -39,7 +39,15 @@ void main() {
   final row = template.substring(rowStart + '<!--ROW-->'.length, rowEnd);
 
   final rows = shots.map((m) {
-    final src = m.group(1)!.replaceFirst('shots/', 'screenshots/');
+    // Screenshots live in Git LFS; GitHub Pages serves the LFS *pointer*, not
+    // the image, so point at the media endpoint that resolves LFS instead.
+    final src = m
+        .group(1)!
+        .replaceFirst(
+          'shots/',
+          'https://media.githubusercontent.com/media/'
+              'CasperVerswijvelt/Sonority/main/docs/screenshots/',
+        );
     return row
         .replaceAll('{{SHOT}}', src)
         .replaceAll('{{HEAD}}', m.group(2)!)


### PR DESCRIPTION
GitHub Pages serves the Git LFS *pointer* (131 bytes of text) instead of the image, so the landing-page screenshots at casperverswijvelt.be/Sonority were broken.

Fix: point the screenshot `<img>` srcs at `media.githubusercontent.com/media/...`, GitHub's endpoint that resolves LFS. The PNGs stay in LFS. Verified the endpoint returns the real 177972-byte PNG.

- `tool/gen_site.dart` — screenshot srcs use the LFS media URL (so regeneration keeps the fix)
- `docs/index.html` — regenerated

Note: URLs are pinned to the `main` branch, fine as long as Pages publishes from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)