### PR TITLE
feat(identify): make chime easy to localize by ear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Changed
+- Identify chime is now a repeated percussive ping (sharp attack, bright harmonics) instead of a soft two-tone sine — it's far easier to tell which speaker it's coming from by ear.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/lib/core/tone_generator.dart
+++ b/lib/core/tone_generator.dart
@@ -1,29 +1,54 @@
 import 'dart:math';
 import 'dart:typed_data';
 
-/// Generates a short, distinctive two-tone "chime" as 16-bit mono PCM WAV
-/// bytes. Produced in code so the identify-speaker feature needs no bundled
-/// binary asset — we just serve these bytes over a tiny local HTTP server and
-/// point a Sonos speaker at the URL.
+/// Generates a short, distinctive "chime" as 16-bit mono PCM WAV bytes.
+/// Produced in code so the identify-speaker feature needs no bundled binary
+/// asset — we just serve these bytes over a tiny local HTTP server and point a
+/// Sonos speaker at the URL.
+///
+/// The waveform is tuned to be **easy to localize by ear** (tell which physical
+/// speaker it's coming from): a short train of repeated percussive plucks, each
+/// with a sharp attack + fast decay and rich harmonics. Humans localize sound
+/// from onset transients (interaural time differences) and high-frequency
+/// content (interaural level differences) — a slow, pure sine tone (the old
+/// chime) has neither and is nearly impossible to point at. Sharp attacks,
+/// broadband harmonics, and repetition all directly help; a rising arpeggio
+/// keeps it pleasant and clearly intentional rather than static-like.
 Uint8List generateChimeWav() {
   const sampleRate = 44100;
   // Lead-in/out silence matters: Sonos can clip the first fraction of a second
   // while the amp powers up, and a too-short clip may not render at all.
   const leadSilence = 6615; // ~0.15s
-  const segSamples = 19845; // ~0.45s per tone
+  const pluckSamples = 4900; // ~0.11s per pluck
+  const gapSamples = 4410; // ~0.10s of silence between plucks
   const tailSilence = 8820; // ~0.20s
-  const freqs = [880.0, 1318.5]; // A5 then E6 — a pleasant rising ding-dong
-  final total = leadSilence + segSamples * freqs.length + tailSilence;
+  const attackSamples = 66; // ~1.5ms linear rise — sharp onset, no DC click
+  const decayRate = 5.0; // exponential decay over each pluck (e^-5 ≈ 0.007 tail)
+  // Ascending A-major arpeggio (A5 C#6 E6 A6): four distinct onsets to localize.
+  const freqs = [880.0, 1108.73, 1318.51, 1760.0];
+  // Harmonic weights (fundamental + overtones) — the overtones add the
+  // high-frequency energy that carries direction. Normalized so peaks stay near
+  // the old chime's 0.45 amplitude (the identify volume-bump assumes that).
+  const harmonics = [1.0, 0.5, 0.33, 0.25, 0.2];
+  final weightSum = harmonics.reduce((a, b) => a + b);
+
+  final total =
+      leadSilence + (pluckSamples + gapSamples) * freqs.length + tailSilence;
   final pcm = Int16List(total); // zero-filled = silence
 
   var idx = leadSilence;
   for (final f in freqs) {
-    for (var i = 0; i < segSamples; i++) {
-      // Half-sine envelope so each tone fades in/out without clicks.
-      final env = sin(pi * i / segSamples);
-      final sample = 0.45 * env * sin(2 * pi * f * i / sampleRate);
+    for (var i = 0; i < pluckSamples; i++) {
+      final attack = i < attackSamples ? i / attackSamples : 1.0;
+      final decay = exp(-decayRate * i / pluckSamples);
+      var wave = 0.0;
+      for (var h = 0; h < harmonics.length; h++) {
+        wave += harmonics[h] * sin(2 * pi * f * (h + 1) * i / sampleRate);
+      }
+      final sample = 0.45 * attack * decay * wave / weightSum;
       pcm[idx++] = (sample * 32767).round().clamp(-32768, 32767);
     }
+    idx += gapSamples; // silence between plucks (already zero-filled)
   }
   return _wrapWavMono16(pcm, sampleRate);
 }

--- a/test/tone_generator_test.dart
+++ b/test/tone_generator_test.dart
@@ -24,4 +24,29 @@ void main() {
     expect(wav.length, 44 + dataSize, reason: 'header + declared data size');
     expect(bd.getUint32(4, Endian.little), 36 + dataSize, reason: 'RIFF size');
   });
+
+  test('has a sharp onset transient (loud within ~10ms of the first pluck)', () {
+    // Localizability depends on a sharp attack: the sound must reach near-peak
+    // amplitude almost immediately, not ramp up slowly like the old sine chime.
+    final wav = generateChimeWav();
+    final bd = ByteData.sublistView(wav);
+    final samples = <int>[];
+    for (var off = 44; off + 1 < wav.length; off += 2) {
+      samples.add(bd.getInt16(off, Endian.little));
+    }
+
+    const leadSilence = 6615; // must match tone_generator.dart
+    const onsetWindow = 441; // ~10ms
+    var peak = 0, onsetPeak = 0;
+    for (var i = 0; i < samples.length; i++) {
+      final a = samples[i].abs();
+      if (a > peak) peak = a;
+      if (i >= leadSilence && i < leadSilence + onsetWindow && a > onsetPeak) {
+        onsetPeak = a;
+      }
+    }
+    expect(peak, greaterThan(0));
+    expect(onsetPeak, greaterThan(peak * 0.5),
+        reason: 'reaches >50% of peak within ~10ms — a sharp attack');
+  });
 }


### PR DESCRIPTION
## What

Reworks the identify-speaker audio chime (`lib/core/tone_generator.dart`) from a soft two-tone sine into a **repeated percussive pluck** — a rising A-major arpeggio with a sharp attack, exponential decay, and a harmonic stack.

## Why

A user reported the old chime is hard to pin a *direction* to. That's expected, not their ears: pure sine tones in the ~1–3 kHz band are close to the worst case for human localization, and the smoothed half-sine envelope stripped out the sharp onset transient — the single strongest directional cue. The new waveform adds the three things that make a sound easy to localize: **sharp onset transients, high-frequency harmonic content, and repetition**, while staying pleasant/intentional rather than static-like.

## Notes

- Still 16-bit mono 44.1 kHz PCM, ~1.19 s (comfortably under the 1800 ms restore wait in `identify_service_io.dart`); peak amplitude stays ≤ 0.45 so the volume-bump logic is unaffected.
- Mono is intentional — identify plays on one standalone box, so the direction located is *which speaker in the room*, not L/R within one.
- New test asserts the load-bearing property: the clip reaches >50% of peak within ~10 ms (a sharp attack), which the old sine chime did not.

## Verification

- `flutter analyze` + `flutter test` green (181 tests).
- WAV dumped via `tool/dump_chime.dart` and inspected (mono, 1.19 s).
- Real by-ear acceptance on hardware via `tool/chirp.dart <room>` still pending (reviewer not near the Sonos system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)