### PR TITLE
fix(home-theater): reassign moved satellites in place, no strip + calmer progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Changed
+- Reconfiguring a home theater (e.g. swapping which speakers are fronts vs surrounds) no longer unbonds speakers that are only moving to a different channel — they're reassigned in place, so the setup no longer briefly drops to one speaker per side. The progress screen shows a single calm "Applying…" step (Sonos can still take up to a minute to settle) instead of a scary per-attempt retry log.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,11 +160,23 @@ Note: CLI tools must NOT import `sonos_repository.dart` (it pulls in
     fine (confirmed on hardware, `tool/diff_apply_spike.dart`). So
     `SonosController._applyHtTarget` diffs current-vs-target
     (`front_layout.diffHtLayout`): **no-op when unchanged** (zero writes — the
-    common re-apply case), else `RemoveHTSatellite` ONLY the satellites that
-    move/leave, then additively `bondAndVerify` the target. This is both faster
-    and *more reliable* than the old strip-to-bare path — adding only the missing
-    satellite(s) converges in ~1 attempt, whereas a full rebuild-from-bare is the
-    flaky case that needs many re-asserts. **A whole layout is applied in ONE
+    common re-apply case), else `RemoveHTSatellite` ONLY the satellites the target
+    **drops entirely** (a genuine *leave* — a removed sub, or a speaker replaced by
+    a different one), then additively `bondAndVerify` the target. This is both
+    faster and *more reliable* than the old strip-to-bare path — adding only the
+    missing satellite(s) converges in ~1 attempt, whereas a full rebuild-from-bare
+    is the flaky case that needs many re-asserts.
+    **A moved satellite is NOT removed first — it reassigns in place.** A speaker
+    that merely changes channel (e.g. a fronts↔surrounds swap) stays in the target
+    map, so it's never *dropped* and `AddHTSatellite` reassigns it — no strip.
+    Hardware A/B/C-tested (`tool/reassign_spike.dart` in git history; the check now
+    lives in `tool/diff_apply_spike.dart` case c): stripping the movers first
+    (remove-both, or remove-one) bought **no** reliability over re-asserting
+    directly — a swap 800s mid-reshuffle and re-asserts several times *either way*
+    (the retries are Sonos-inherent, not ours) — and only guaranteed the alarming
+    "one speaker per side" in-between state. So `diffHtLayout.toRemove` is
+    leaves-only; the bond phase shows one steady "Applying…" note with the
+    per-attempt churn routed to the op log (`ph.log`), not the timeline. **A whole layout is applied in ONE
     `bondAndVerify`, never staged.** A/B-tested on a real Beam (single vs
     surrounds-then-fronts, 3 trials each): single-call rebuilt the full 5.1 from
     bare in a steady **6 re-asserts** every time; **staging was worse** (each

--- a/lib/data/sonos/apply_progress.dart
+++ b/lib/data/sonos/apply_progress.dart
@@ -156,6 +156,12 @@ class ApplyProgress {
     if (id != null) note(id, detail);
   }
 
+  /// Log-only progress line: appends technical per-attempt detail (e.g.
+  /// "attempt 3: RF not bonded yet") to the raw log WITHOUT touching the
+  /// visible timeline, so a long-running phase can show one calm steady
+  /// subtitle while the log keeps the full retry history for diagnostics.
+  void logActive(String line) => onLog?.call('    $line');
+
   void _closeActiveChildOf(String parentId, ApplyStatus status,
       [String? detail]) {
     final id = _activeChildId;

--- a/lib/data/sonos/front_layout.dart
+++ b/lib/data/sonos/front_layout.dart
@@ -76,9 +76,18 @@ class HtDiff {
   /// nothing to write at all.
   final bool isNoOp;
 
-  /// Satellite UUIDs bonded now whose channel assignment differs from [target]
-  /// (dropped, moved, or replaced). These must be `RemoveHTSatellite`'d before
-  /// the additive bond — `AddHTSatellite` 800s on a map that would drop them.
+  /// Satellite UUIDs bonded now that the target no longer keeps at all — a
+  /// genuine LEAVE (a dropped sub, or a speaker replaced by a different one).
+  /// These must be `RemoveHTSatellite`'d first — `AddHTSatellite` 800s on a map
+  /// that would drop a still-bonded speaker.
+  ///
+  /// A satellite that merely MOVES channel (stays in the target on a different
+  /// channel, e.g. a fronts↔surrounds swap) is deliberately NOT here: it's left
+  /// bonded and `AddHTSatellite` reassigns it in place. Removing movers first is
+  /// what forced the "one speaker per side" in-between state, and it bought no
+  /// reliability — a swap 800s mid-reshuffle and re-asserts several times either
+  /// way (hardware-tested, `tool/diff_apply_spike.dart` case c), so we skip the
+  /// strip and let the re-assert converge on the full target.
   final Set<String> toRemove;
 
   /// The target map to bond, unchanged — `bondAndVerify` adds whatever's missing.
@@ -123,15 +132,18 @@ HtDiff diffHtLayout({
     if (set.isNotEmpty) (tgt[e.uuid] ??= <SonosChannel>{}).addAll(set);
   }
 
-  // A satellite bonded now must go first if target doesn't keep it on the exact
-  // same channel set (dropped / moved / replaced).
+  // Only satellites the target drops entirely must be RemoveHTSatellite'd first
+  // (a genuine leave — the case AddHTSatellite 800s on). A satellite that stays
+  // in the target on a different channel is left bonded and reassigned in place.
   final toRemove = <String>{
     for (final e in cur.entries)
-      if (!_sameChannels(tgt[e.key], e.value)) e.key,
+      if (!tgt.containsKey(e.key)) e.key,
   };
 
-  // No removals AND target adds no new satellites ⇒ identical layout.
-  final isNoOp = toRemove.isEmpty && tgt.length == cur.length;
+  // Identical layout ⇒ no-op: same satellites, each on the exact same channels.
+  // (A pure move has an empty toRemove but is NOT a no-op — it still writes.)
+  final isNoOp = cur.length == tgt.length &&
+      cur.entries.every((e) => _sameChannels(tgt[e.key], e.value));
 
   return HtDiff(isNoOp: isNoOp, toRemove: toRemove, target: target);
 }

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -27,6 +27,7 @@ typedef Phases = ({
   void Function(List<(String, String)>) seed,
   void Function(String id, String label) phase,
   void Function(String) note,
+  void Function(String) log,
   void Function({String? detail}) skipPhase,
 });
 
@@ -586,18 +587,25 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       return sys;
     }
     if (diff.toRemove.isNotEmpty) {
-      ph.phase('remove', 'Remove ${diff.toRemove.length} changed speakers');
+      // Only genuine leaves reach here (a dropped sub / a replaced speaker) —
+      // a speaker that merely moves channel stays bonded and reassigns in place.
+      ph.phase('remove', 'Remove ${diff.toRemove.length} speakers no longer used');
       await _repo.removeHtSatellites(
           soundbarIp: bar.ip!, uuids: diff.toRemove, cancel: _activeOp);
       ph.note('waiting for Sonos to settle');
       sys = await _settleRead(sys, bar.ip!);
     }
     ph.phase('bond', bondLabel);
+    // One calm, steady subtitle for the whole (re-)assert loop; the per-attempt
+    // retry churn stays in the log (ph.log) rather than flickering the timeline
+    // — a swap 800s and re-asserts several times, which reads as alarming
+    // otherwise even though it's normal Sonos settling.
+    ph.note('Applying — Sonos can take up to a minute to settle.');
     return _repo.bondAndVerify(
         coordinator: bar,
         target: target,
         previous: sys,
-        onNote: ph.note,
+        onNote: ph.log,
         cancel: _activeOp);
   }
 
@@ -946,6 +954,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
             [for (final (id, label) in subs) ('$parentId/$id', label)]),
         phase: (id, label) => t.startSub(parentId, '$parentId/$id', label),
         note: t.noteActive,
+        log: t.logActive,
         skipPhase: t.skipSub,
       );
 

--- a/test/front_layout_diff_test.dart
+++ b/test/front_layout_diff_test.dart
@@ -40,14 +40,25 @@ void main() {
     expect(d.toRemove, {sub});
   });
 
-  test('swap (LR↔RR): both surrounds must be removed first', () {
+  test('swap (LR↔RR): movers stay bonded — nothing removed, not a no-op', () {
     final d = diffHtLayout(
       current: bar(full),
-      // lr now on RR, rr now on LR — each moved channel.
+      // lr now on RR, rr now on LR — each moved channel but stays in the map,
+      // so AddHTSatellite reassigns in place (no RemoveHTSatellite needed).
       target: target('$beam:CC;$fl:LF;$fr:RF;$rr:LR;$lr:RR;$sub:SW'),
     );
     expect(d.isNoOp, isFalse);
-    expect(d.toRemove, {lr, rr});
+    expect(d.toRemove, isEmpty);
+  });
+
+  test('front↔surround swap: movers stay bonded — nothing removed', () {
+    final d = diffHtLayout(
+      current: bar(full),
+      // fr↔lr exchange channels; both remain in the target on a new channel.
+      target: target('$beam:CC;$fl:LF;$lr:RF;$fr:LR;$rr:RR;$sub:SW'),
+    );
+    expect(d.isNoOp, isFalse);
+    expect(d.toRemove, isEmpty);
   });
 
   test('replace (different speaker on a channel): old one removed', () {

--- a/test/ht_wysiwyg_apply_test.dart
+++ b/test/ht_wysiwyg_apply_test.dart
@@ -61,6 +61,23 @@ void main() {
     expect(d.isNoOp, isFalse);
   });
 
+  test('swap fronts↔surrounds: movers stay bonded, nothing removed', () {
+    final d = apply(
+      bar('$beam:CC;$fl:LF;$fr:RF;$lr:LR;$rr:RR;$sub:SW'),
+      {
+        // fr and lr exchange roles; both remain bonded on a new channel, so the
+        // apply reassigns in place rather than stripping them first.
+        SonosChannel.leftFront: fl,
+        SonosChannel.rightFront: lr,
+        SonosChannel.leftRear: fr,
+        SonosChannel.rightRear: rr,
+      },
+      subs: [sub],
+    );
+    expect(d.toRemove, isEmpty);
+    expect(d.isNoOp, isFalse);
+  });
+
   test('unchanged selection is a zero-write no-op', () {
     final d = apply(
       bar('$beam:CC;$fl:LF;$fr:RF;$sub:SW'),

--- a/tool/diff_apply_spike.dart
+++ b/tool/diff_apply_spike.dart
@@ -7,8 +7,9 @@
 //   (b) ADDITIVE: remove ONE satellite (the sub), then AddHTSatellite the full
 //                 target (a superset, drops nobody) WITHOUT stripping the rest.
 //                 Does the sub re-bond while fronts/rears stay put?
-//   (c) CHANGE  : swap two surround UUIDs (LR↔RR). diffHtLayout flags both as
-//                 toRemove → remove both, then AddHTSatellite the swapped target.
+//   (c) CHANGE  : swap two surround UUIDs (LR↔RR). Both stay in the target on a
+//                 new channel, so diffHtLayout removes NEITHER (a move reassigns
+//                 in place); AddHTSatellite the swapped target and re-assert.
 //                 Does it converge?
 //
 // ⚠️  WITH --confirm THIS MUTATES YOUR REAL HOME THEATER and Sonos will
@@ -110,7 +111,8 @@ Future<void> main(List<String> argv) async {
       );
       final diff = diffHtLayout(current: bar, target: swapped);
       print('\n(c) CHANGE: swap LR↔RR. diff.toRemove=${diff.toRemove} '
-          '(expect both surrounds). Removing them, then AddHTSatellite swapped…');
+          '(expect NONE — movers stay bonded and reassign in place). '
+          'Removing them (if any), then AddHTSatellite swapped…');
       await props.removeHtSatellites(barIp, diff.toRemove);
       await _settleLong();
       final r = await _bondVerify(props, topology, barDevice, swapped);


### PR DESCRIPTION
## What & why

Reconfiguring a home theater — e.g. swapping which speakers are fronts vs surrounds — used to `RemoveHTSatellite` **every** satellite whose channel changed, so a speaker that merely **moves** got unbonded first. That briefly dropped the HT to *one speaker per side*, then re-added it, and read as a scary per-attempt retry log. This came from a user report of exactly that flow (One SL + Play:1 fronts/surrounds reshuffled into sorted pairs).

## Findings (hardware A/B/C tested)

Ran three strategies on a real Beam (2×One SL + 2×Play:1 + Sub), a fronts↔surrounds swap, 3 trials each:

| Strategy | Converged | Attempts | Visible in-between |
|---|---|---|---|
| remove **both** movers (old) | 2/3 | 3, 8-fail, 5 | 100% (one per side) |
| remove **one** mover | 3/3 | 5, 4, 5 | one channel empty |
| remove **none** (this PR) | 3/3* | 1, 4, 7 | ~50%, Sonos-side only |

*aggregated 7/9 across all runs. Key takeaways:
- **The retries are Sonos-inherent** — `AddHTSatellite` 800s mid-reshuffle and re-asserts several times no matter what we strip. We can't make a swap "fast".
- Stripping movers only **guarantees** the alarming in-between state; it buys no reliability. A move never drops a speaker from the target map, so `AddHTSatellite` reassigns it in place.

## Change

- **`diffHtLayout`**: `toRemove` now contains only genuine **leaves** (a UUID absent from the target — a dropped sub or a replaced speaker). A moved satellite stays bonded and reassigns in place. `isNoOp` keeps its own full-equality check so a swap (empty `toRemove`) still writes and isn't mistaken for a no-op.
- **Calmer progress**: the bond phase shows one steady *"Applying — Sonos can take up to a minute to settle."* subtitle; the per-attempt retry churn routes to the operation **log** only (new `ApplyProgress.logActive` + a `log` member on the `Phases` record). Reworded *"Remove N changed speakers"* → *"Remove N speakers no longer used"*.

## Verification

- `flutter analyze` + `flutter test` green (182 tests; added swap cases at both the diff and WYSIWYG-flow level).
- Pre-merge review (review subagent + `/code-review` + `/ponytail-review`): no correctness findings; the `isNoOp`-swap trap is correctly avoided.
- **End-to-end on the real Beam**: a fronts L/R swap now applies as a single "Bond 5 speakers" step — no remove step, no missing side — then converges. HT restored to its original layout afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)