### PR TITLE
feat(diagnostics): per-speaker settings in bundle + hardware compatibility doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Added
+- Diagnostics bundle now includes `speaker_settings.json` — a read-only per-speaker snapshot of EQ / volume / mute (RenderingControl), to help debug "configured but silent" reports (e.g. a muted or zero-volume bonded speaker).
+
 ### Changed
 - GitHub Pages landing page now deploys automatically on each release tag (via an LFS-aware Actions workflow) and shows the current app version; the page is generated in CI rather than committed.
 - Internal cleanup: deduplicated shared widgets/helpers and removed dead code; the Sonos engine is now fully decoupled from Flutter (persistence via an injected storage port). No user-facing behaviour change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,11 @@ zone/pair name snapshots through an injected `KeyValueStore` port
 - **Amp as fronts**: a single Sonos Amp drives two passive front speakers, so it
   occupies BOTH front channels in one entry — `AMP:LF,RF` — instead of two
   separate Sonos speakers. Bar still becomes `CC`. (`buildAmpFrontsMap`;
-  detected via `SonosDevice.isAmp`. Confirmed working on hardware.)
+  detected via `SonosDevice.isAmp`.) **Audio is per-soundbar and NOT
+  API-discoverable** — confirmed working on a **Playbase + Connect:Amp**, but
+  **silent on an Arc Ultra + Amp (S16)** despite a clean, correct bond (the Atmos
+  bar appears not to route fronts to a satellite). Track confirmed/failing combos
+  in `docs/COMPATIBILITY.md`; a clean bond ≠ audio.
 - Adding fronts to a setup that already has rears yields 4 satellites — that's the
   natural max; Sonos has no true 7.1 (6 boxes).
 - **Stereo pair** map: `UUID_LEFT:LF,LF;UUID_RIGHT:RF,RF`. Left stays visible; right

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,107 @@
+# Hardware compatibility — unofficial layouts
+
+What real hardware has been confirmed to **work** (or **not work**) for the
+bonding configs Sonority unlocks. Recorded so we don't re-derive it from user
+reports every time.
+
+## The core caveat: a clean bond ≠ audio
+
+The Sonos local API accepts almost any channel map and stores it verbatim — it
+does essentially no validation (see the zone-probe findings in `CLAUDE.md`). But
+whether the **soundbar firmware actually routes audio** to an unofficially-bonded
+speaker is **per-model / per-firmware and is NOT discoverable from the API**. A
+bond can:
+
+- apply with zero SOAP faults,
+- read back with the exact channel map you wrote,
+- be confirmed by the official Sonos app,
+
+…and still produce **no sound**. So "it configured" is not evidence it works —
+only heard audio is. This is why we track confirmed combos here.
+
+> **Privacy:** this file records **model + channel-role only**. No room names,
+> UUIDs, IPs, MACs, serials, households, or any personal detail — none of that is
+> needed to capture a compatibility finding.
+
+Firmware is recorded because audio routing is per-model **and** per-firmware —
+though so far the differentiator has been the *model*, not the firmware (the
+working Beam and the silent Arc Ultra are on near-identical `96.x` builds).
+
+## Dedicated fronts (soundbar becomes center, external speakers take L/R)
+
+Fronts can be either **two discrete speakers** (one `LF`, one `RF`) or **one Amp
+on both** (`AMP:LF,RF`). Both are tracked below.
+
+| Soundbar          | Soundbar fw  | Fronts device        | Result       | Source         |
+|-------------------|--------------|----------------------|--------------|----------------|
+| Beam (Gen 2, S31) | 96.1-78270   | 2× One SL (S22), discrete | ✅ audio | developer (live) |
+| Playbase          | (unknown)    | Connect:Amp (Gen 2)  | ✅ audio     | user-confirmed |
+| Arc Ultra (S45)   | 96.0-78270   | Amp (S16), fw 96.0-78270 | ❌ silent | user-confirmed |
+
+### ✅ Beam (Gen 2, S31) + 2× One SL (discrete fronts) — works
+
+The developer's live, daily-use home theater. Full layout:
+
+- Beam (Gen 2, S31) — center (`CC`)
+- 2× One SL (S22) — dedicated fronts (`LF` / `RF`)
+- 2× Play:1 (S1) — surrounds (`LR` / `RR`)
+- Sub — sub (`SW`)
+
+Confirms **discrete-speaker dedicated fronts work on a Beam**. (The S1-generation
+Play:1s and Sub sit on the older `86.8` firmware track; the Beam/One SL on `96.1`
+— a mixed-firmware HT bonds and plays fine.) This is also the bonding engine's
+primary test rig — `AddHTSatellite` re-assertion, the diff-based apply, one-call
+full-layout rebuild, and remove/rebond are all validated here (see `CLAUDE.md`).
+
+### ✅ Playbase + Sonos Connect:Amp (Gen 2) — works (amp fronts)
+
+- Audio confirmed by the user (front L/R come out of the passive speakers on the Amp).
+- Both devices wired (LAN, Wi-Fi off). Wired vs Wi-Fi made no difference.
+- The Amp drives both fronts as one device: `AMP:LF,RF` (amp-mode, exclusive selection).
+
+### ❌ Arc Ultra (S45) + Sonos Amp (S16) — configures but silent (amp fronts)
+
+The bond applies perfectly and the map reads back correct, but **no sound comes
+from the Amp's passive speakers**. Extensively tested by the user:
+
+- Full 5.1.2 HT (Era 100 surrounds `LR,LTR`/`RR,RTR` + Sub Mini `SW`) with the Amp added as fronts — silent.
+- **Bare bar + Amp fronts only** (`BAR:CC;AMP:LF,RF`, nothing else bonded) — still silent.
+- Tried on **both iPad (iOS) and Android**, and with the Amp on **both LAN and Wi-Fi** — all silent.
+
+Sonority did everything right: clean bond, minimal correct map — the **same map
+shape that works on the Playbase above**. The failure is downstream in Sonos
+firmware.
+
+**Ruled out:** app apply bug · additive-vs-rebuild apply path (bare bar fails
+too) · platform (iPad + Android) · wired vs Wi-Fi · map correctness.
+
+**Remaining suspects (unconfirmed):**
+1. The Arc Ultra (Atmos bar) does not route front L/R to a *satellite* speaker
+   the way older bars (Playbase/Playbar/Beam) do.
+2. The newer Sonos Amp (S16) does not render front-channel content when bonded to
+   an Arc Ultra.
+
+**Pending test that would decide it:** play music **directly on the Amp as a
+standalone room** (ungrouped) in the official Sonos app.
+- Passive speakers play → Amp/wiring is fine; the Arc Ultra isn't routing fronts (suspect #1) — nothing Sonority can fix.
+- Still silent → the Amp's own setup/wiring, unrelated to Sonority.
+
+## Notes / recurring gotchas
+
+- **"Needs attention" + phantom "not connected" products in the official Sonos
+  app are benign.** They appear on *working* setups too (confirmed on the Beam
+  rig). Not a signal that a bond failed.
+- **Unverified community reports are weak evidence.** A r/SonoSequencr post
+  claiming "Arc Ultra + Amp works" is not confirmation — the poster may have hit
+  the same *bond-applies-but-silent* false positive (which two users here hit
+  before verifying audio). Only treat a combo as ✅ once someone reports **heard
+  audio**.
+- **Amp as fronts is one device on both channels** (`AMP:LF,RF`), exclusive
+  selection — not two separate front speakers. The passive speakers wired to the
+  Amp are not network devices and correctly never appear in the app.
+
+## Adding a finding
+
+One row in the table + a short subsection. Record: soundbar model, bonded
+device + channel role, **result (audio heard? yes/no)**, and how it was verified.
+Model + role only — no private info.

--- a/lib/features/diagnostics/diagnostics_bundle.dart
+++ b/lib/features/diagnostics/diagnostics_bundle.dart
@@ -7,6 +7,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../../data/models/sonos_models.dart';
 import '../../data/sonos/diagnostics_log.dart';
 import '../../data/sonos/sonos_repository.dart';
+import '../../data/sonos/speaker_settings.dart';
 import '../widgets/version_badge.dart' show fullVersionLabel;
 import 'diagnostics_platform.dart';
 
@@ -71,6 +72,15 @@ Future<String> buildDiagnosticsZip({
 
   // App-owned persisted state (profiles + pre-group room-name snapshots).
   add('app_state.json', await _appStateJson());
+
+  // Live per-speaker audio settings (RenderingControl reads only — no writes).
+  // Useful for "configured but silent" reports: a muted / zero-volume satellite,
+  // odd sub/surround levels. Best-effort per field (unsupported reads → absent).
+  add(
+    'speaker_settings.json',
+    const JsonEncoder.withIndent('  ')
+        .convert(await readSpeakerSettings(system, SpeakerSettingsClient())),
+  );
 
   if (options.includeNetwork) {
     add('network.txt', await networkInterfacesText());
@@ -147,6 +157,65 @@ Map<String, dynamic> topologyJson(SonosSystem system) => {
       },
   ],
 };
+
+/// Per-speaker RenderingControl read plan for the settings dump, keyed by UUID.
+/// Pure so the role-gating is unit-testable without touching the network. Mirrors
+/// [SonosController.captureSettings]:
+/// - HT satellites reject every EQ read (UPnPError 803), so `audio` is skipped
+///   and only volume/mute is attempted for them.
+/// - The extended EQ bundle (sub/surround/night/speech/height) is only meaningful
+///   on a soundbar, an HT coordinator, or a group/zone coordinator with a bonded
+///   Sub (the sub level/crossover ride the coordinator's `GetEQ`); a plain
+///   speaker answers those GetEQ calls with harmless defaults, so it captures
+///   bass/treble/loudness only.
+Map<String, ({bool audio, bool extendedEq})> settingsReadPlan(
+    SonosSystem system) {
+  final htSatellites = {
+    for (final g in system.groups)
+      for (final m in g.members)
+        for (final s in m.satellites) s.uuid,
+  };
+  // Coordinators that carry the extended EQ: an HT primary, or a group/zone
+  // coordinator with a bonded Sub (`subUuid` reads the group ChannelMapSet) —
+  // matches captureSettings' `entityHtOrSub` gate so a sub-in-zone isn't missed.
+  final extendedCoordinators = {
+    for (final g in system.groups)
+      for (final m in g.members)
+        if (m.isHomeTheater || m.subUuid != null) m.uuid,
+  };
+  return {
+    for (final d in system.devicesByUuid.values)
+      d.uuid: (
+        audio: !htSatellites.contains(d.uuid),
+        extendedEq: d.isSoundbar || extendedCoordinators.contains(d.uuid),
+      ),
+  };
+}
+
+/// Reads a best-effort per-speaker settings snapshot (RenderingControl) for every
+/// reachable speaker, keyed by UUID. Read-only; volume/mute is always attempted
+/// (the most useful signal for a silence report), audio/extended EQ per
+/// [settingsReadPlan].
+Future<Map<String, dynamic>> readSpeakerSettings(
+  SonosSystem system,
+  SpeakerSettingsClient client,
+) async {
+  final plan = settingsReadPlan(system);
+  final out = <String, dynamic>{};
+  for (final d in system.devicesByUuid.values) {
+    final ip = d.ip;
+    if (ip == null || !d.reachable) continue;
+    final p = plan[d.uuid]!;
+    final s = await client.read(ip,
+        audio: p.audio, volume: true, extendedEq: p.extendedEq);
+    out[d.uuid] = {
+      'roomName': d.roomName,
+      'typeLabel': d.typeLabel,
+      'settings': s.toJson(),
+    };
+  }
+  return out;
+}
 
 /// Human-readable mirror of the on-screen technical view — the same string is
 /// shown in the diagnostics sheet and written to `topology.txt`.
@@ -292,6 +361,7 @@ String _readme(
     'raw_topology.xml        — raw GetZoneGroupState from a player',
     'device_descriptions/    — raw device_description.xml per speaker',
     'app_state.json          — the app\'s stored profiles + saved room names',
+    'speaker_settings.json   — per-speaker EQ / volume / mute (RenderingControl, read-only)',
     if (o.includeLogs)
       'logs.txt                — app diagnostics log (SOAP faults, retries, discovery, errors)',
     if (o.includeNetwork)

--- a/test/diagnostics_test.dart
+++ b/test/diagnostics_test.dart
@@ -173,6 +173,89 @@ void main() {
     expect(jsonEncode(out), isNot(contains(r'\"')));
   });
 
+  group('settingsReadPlan role-gating', () {
+    // An HT: Arc Ultra coordinator with an Amp bonded as fronts, plus a
+    // standalone plain speaker in its own group.
+    final htSystem = SonosSystem(
+      groups: const [
+        ZoneGroup(coordinatorUuid: 'BAR', members: [
+          ZoneGroupMember(
+            uuid: 'BAR',
+            zoneName: 'Cinema',
+            location: 'http://192.168.1.20:1400/xml/device_description.xml',
+            htSatChanMapSet: 'BAR:CC;AMP:LF,RF',
+            satellites: [
+              SonosSatellite(
+                uuid: 'AMP',
+                zoneName: 'Cinema',
+                channels: [SonosChannel.leftFront, SonosChannel.rightFront],
+              ),
+            ],
+          ),
+        ]),
+        ZoneGroup(coordinatorUuid: 'ONE', members: [
+          ZoneGroupMember(uuid: 'ONE', zoneName: 'Kitchen'),
+        ]),
+      ],
+      devicesByUuid: {
+        'BAR': const SonosDevice(
+            uuid: 'BAR', roomName: 'Cinema', modelName: 'Sonos Arc Ultra'),
+        'AMP': const SonosDevice(
+            uuid: 'AMP', roomName: 'Cinema', modelName: 'Sonos Amp'),
+        'ONE': const SonosDevice(
+            uuid: 'ONE', roomName: 'Kitchen', modelName: 'Sonos One'),
+      },
+    );
+
+    final plan = settingsReadPlan(htSystem);
+
+    test('soundbar / HT coordinator gets the extended EQ bundle', () {
+      expect(plan['BAR']!.audio, isTrue);
+      expect(plan['BAR']!.extendedEq, isTrue);
+    });
+
+    test('HT satellite skips audio reads (they 803)', () {
+      expect(plan['AMP']!.audio, isFalse);
+      expect(plan['AMP']!.extendedEq, isFalse);
+    });
+
+    test('plain standalone speaker reads audio but not extended EQ', () {
+      expect(plan['ONE']!.audio, isTrue);
+      expect(plan['ONE']!.extendedEq, isFalse);
+    });
+
+    test('zone coordinator with a bonded Sub gets the extended EQ bundle', () {
+      // A zone (ChannelMapSet, no soundbar) with a Sub bonded as SW — the sub
+      // level/crossover ride the coordinator's GetEQ, so it must read extended.
+      final zoneWithSub = SonosSystem(
+        groups: const [
+          ZoneGroup(coordinatorUuid: 'Z1', members: [
+            ZoneGroupMember(
+              uuid: 'Z1',
+              zoneName: 'Loft',
+              location: 'http://192.168.1.30:1400/xml/device_description.xml',
+              channelMapSet: 'Z1:LF,RF;Z2:LF,RF;ZSUB:SW',
+            ),
+            ZoneGroupMember(uuid: 'Z2', zoneName: 'Loft', invisible: true),
+            ZoneGroupMember(uuid: 'ZSUB', zoneName: 'Loft', invisible: true),
+          ]),
+        ],
+        devicesByUuid: {
+          'Z1': const SonosDevice(
+              uuid: 'Z1', roomName: 'Loft', modelName: 'Sonos Era 100'),
+          'Z2': const SonosDevice(
+              uuid: 'Z2', roomName: 'Loft', modelName: 'Sonos Era 100'),
+          'ZSUB': const SonosDevice(
+              uuid: 'ZSUB', roomName: 'Loft', modelName: 'Sonos Sub'),
+        },
+      );
+      final p = settingsReadPlan(zoneWithSub);
+      expect(p['Z1']!.extendedEq, isTrue, reason: 'coordinator carries sub EQ');
+      // A plain zone member without the sub map stays bass/treble/loudness only.
+      expect(p['Z2']!.extendedEq, isFalse);
+    });
+  });
+
   test('DiagnosticsLog is a capped ring buffer, oldest dropped first', () {
     DiagnosticsLog.clear();
     for (var i = 0; i < 600; i++) {


### PR DESCRIPTION
## What

Two things, both driven by an Amp-as-fronts user report (configures cleanly but the Amp is silent):

**1. Diagnostics bundle now captures live per-speaker settings** — a new `speaker_settings.json` with each reachable speaker's `bass/treble/loudness`, the extended EQ bundle, and `volume/mute` (RenderingControl). Volume/mute is always attempted (the key signal for a "configured but silent" report); the extended EQ bundle is role-gated to soundbars, HT coordinators, and group/zone coordinators with a bonded Sub — mirroring `SonosController.captureSettings`. HT satellites skip audio reads (they 803). Fully read-only, best-effort per field (a faulting device never aborts the bundle). Pure `settingsReadPlan()` is unit-tested (4 gating cases incl. sub-in-zone).

**2. `docs/COMPATIBILITY.md`** — tracks which soundbar + fronts hardware combos are confirmed working vs silent, so we stop re-deriving it from user reports. Model / channel-role / firmware only — **no private info** (no UUIDs, IPs, MACs, serials, names). Current entries: Beam + One SL fronts ✅, Playbase + Connect:Amp ✅, Arc Ultra + Amp (S16) ❌ silent despite a clean bond. Core caveat documented up top: a clean bond ≠ audio (firmware routing isn't API-discoverable). Corrected the now-inaccurate blanket "confirmed working" amp-fronts claim in `CLAUDE.md` to point here.

## Review

Pre-merge review done (fresh review subagent + `/code-review` + `/ponytail-review`). No correctness bugs; ponytail verdict "lean, ship". The one substantive finding — extended EQ missing for a sub-bonded zone — is fixed in this branch (+ test).

## Testing

`flutter analyze` clean, `flutter test` green (185 tests, +4 new). Rebased on latest `origin/main` (#53 refactor).