### PR TITLE
feat(l10n): localize the app via Flutter gen-l10n (English-only for now)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ section into the GitHub Release notes regardless of the build suffix
 
 ### Added
 - Diagnostics bundle now includes `speaker_settings.json` — a read-only per-speaker snapshot of EQ / volume / mute (RenderingControl), to help debug "configured but silent" reports (e.g. a muted or zero-volume bonded speaker).
+- Localization groundwork: every user-facing string now runs through Flutter's localization system (`lib/l10n/app_en.arb`), and the app follows the device language. English is the only bundled language for now — a new one is added by dropping in a translation file, no code changes. No visible change yet.
 
 ### Changed
 - GitHub Pages landing page now deploys automatically on each release tag (via an LFS-aware Actions workflow) and shows the current app version; the page is generated in CI rather than committed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,28 @@ zone/pair name snapshots through an injected `KeyValueStore` port
 `lib/data/sonos/` file imports Flutter. CLI tools still build on the pure recipes
 (`front_layout.dart` / `zone_layout.dart`) rather than the orchestrator.
 
+### Localization (i18n)
+All user-facing strings go through Flutter `gen-l10n`. Source of truth:
+`lib/l10n/app_en.arb` (config `l10n.yaml`, generated `lib/l10n/app_localizations*.dart`,
+`generate: true`). **English is the only bundled locale**; add a language by
+dropping in `app_<lang>.arb` + one `supportedLocales` entry — no code changes.
+Adding a new string = add an ARB key (with `@key` placeholder/plural metadata if
+interpolated) then use it.
+- Widgets: `context.l10n.<key>` (extension in `core/l10n.dart`).
+- Context-less code (state/model helpers, e.g. progress step labels): `appL10n()`
+  (resolves the system locale synchronously).
+- **The engine (`lib/data/sonos/`) must stay Flutter-free**, so it never holds a
+  *translated* string. User-facing engine/state failures throw a coded
+  **`SonorityError(SonorityErrorCode, [arg])`** (identity, not prose). Two
+  renderers: `friendlyError()` (engine, English — for CLI tools + the diagnostics
+  bundle, and the fallback) and `localizedError(AppLocalizations, e)`
+  (`lib/state/localized_error.dart` — the UI wording chokepoint; also maps
+  Timeout/SOAP-fault/`OperationCancelled`/`SpeakerUnreachable`, falls back to
+  `friendlyError`). The raw op log + diagnostics bundle stay English by design.
+- Model-layer English getters (`kindLabel`, `groupKindLabel`, `groupChannelShort`)
+  stay English (CLI/pure); the UI maps the enum to `entityKind*` keys at the call
+  site (`_kindLabel` in the controller, `groupKindL10n` in `entity_cards.dart`).
+
 ## Sonos local API — the knowledge that matters
 
 - **Discovery**: SSDP `M-SEARCH` to `239.255.255.250:1900` (ST

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -4,6 +4,10 @@
 	<dict>
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
+		<key>CFBundleLocalizations</key>
+		<array>
+			<string>en</string>
+		</array>
 		<key>CFBundleDisplayName</key>
 		<string>Sonority</string>
 		<key>CFBundleExecutable</key>

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,8 @@
+# Flutter gen-l10n config. Source of truth: lib/l10n/app_en.arb.
+# Generates lib/l10n/app_localizations.dart (AppLocalizations). English-only for
+# now; add a language by dropping in lib/l10n/app_<lang>.arb.
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+output-dir: lib/l10n
+nullable-getter: false

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_sficon/flutter_sficon.dart';
 import 'package:go_router/go_router.dart';
 
+import 'core/l10n.dart';
 import 'core/theme.dart';
 import 'demo/demo_mode.dart';
 import 'features/discovery/discovery_screen.dart';
@@ -112,15 +113,15 @@ class _HomeShell extends StatelessWidget {
           selectedIndex: shell.currentIndex,
           onDestinationSelected: (i) =>
               shell.goBranch(i, initialLocation: i == shell.currentIndex),
-          destinations: const [
+          destinations: [
             NavigationDestination(
-                icon: Icon(Icons.speaker_group_outlined),
-                selectedIcon: Icon(Icons.speaker_group),
-                label: 'System'),
+                icon: const Icon(Icons.speaker_group_outlined),
+                selectedIcon: const Icon(Icons.speaker_group),
+                label: context.l10n.tabSystem),
             NavigationDestination(
-                icon: Icon(Icons.dashboard_customize_outlined),
-                selectedIcon: Icon(Icons.dashboard_customize),
-                label: 'Profiles'),
+                icon: const Icon(Icons.dashboard_customize_outlined),
+                selectedIcon: const Icon(Icons.dashboard_customize),
+                label: context.l10n.tabProfiles),
           ],
         ),
       ),
@@ -294,6 +295,8 @@ class _SonorityAppState extends ConsumerState<SonorityApp> {
               AppTheme.dark(useDynamic ? darkDynamic?.harmonized() : null)
                   .copyWith(platform: platform),
           themeMode: ThemeMode.system,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           routerConfig: _router,
           // The screenshot-only web demo build has no OS chrome, which looks
           // bare — so paint a faux iOS status bar and reserve its height as the

--- a/lib/core/l10n.dart
+++ b/lib/core/l10n.dart
@@ -1,0 +1,25 @@
+import 'dart:ui' show PlatformDispatcher;
+
+import 'package:flutter/widgets.dart';
+
+import '../l10n/app_localizations.dart';
+
+export '../l10n/app_localizations.dart';
+
+/// Terse access to the generated strings from any widget: `context.l10n.foo`.
+extension L10nX on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this);
+}
+
+/// The current strings **without a BuildContext** — for the state layer
+/// (`sonos_controller.dart`) and other context-less code that must produce
+/// user-facing text (progress step labels, error wording). Resolves the system
+/// locale against the supported set (falls back to English) and loads it
+/// synchronously (gen-l10n's `lookupAppLocalizations` is synchronous).
+AppLocalizations appL10n() {
+  final resolved = basicLocaleListResolution(
+    PlatformDispatcher.instance.locales,
+    AppLocalizations.supportedLocales,
+  );
+  return lookupAppLocalizations(resolved);
+}

--- a/lib/data/sonos/friendly_error.dart
+++ b/lib/data/sonos/friendly_error.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'soap_client.dart';
+import 'sonority_error.dart';
 
 /// Turns a raw engine exception into a short, plain-English sentence for the
 /// failed-step text on the apply/bond progress screen. The full technical
@@ -15,6 +16,8 @@ import 'soap_client.dart';
 /// `OperationCancelled` ('Aborted', kept verbatim so an abort reads as neutral,
 /// not a failure) and `SpeakerUnreachable` — both pinned by tests.
 String friendlyError(Object e) {
+  // Our own coded engine/state errors carry their English in `message`.
+  if (e is SonorityError) return e.message;
   if (e is TimeoutException) {
     return 'The speaker didn’t respond in time. It may still be settling — '
         'try again in a moment.';

--- a/lib/data/sonos/identify_service_io.dart
+++ b/lib/data/sonos/identify_service_io.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import '../../core/tone_generator.dart';
 import 'identify_errors.dart';
 import 'soap_client.dart';
+import 'sonority_error.dart';
 
 /// Plays a short chime on a specific speaker so the user can tell which physical
 /// box will be Left vs Right.
@@ -189,7 +190,7 @@ class IdentifyServiceClient {
         if (!a.isLoopback) return a.address;
       }
     }
-    throw Exception('No LAN IP found to serve the chime from.');
+    throw const SonorityError(SonorityErrorCode.noLanIpForChime);
   }
 
   Future<void> dispose() async {

--- a/lib/data/sonos/led_identify.dart
+++ b/lib/data/sonos/led_identify.dart
@@ -1,6 +1,7 @@
 import 'package:xml/xml.dart';
 
 import 'soap_client.dart';
+import 'sonority_error.dart';
 
 /// Identifies a speaker by **blinking its white status LED** — an alternative to
 /// the audio chime ([IdentifyServiceClient]) that needs no in-app HTTP server and so
@@ -109,7 +110,7 @@ class LedIdentifyClient {
     // If not a single toggle landed, the speaker is unreachable — surface it so
     // the UI can tell the user, instead of silently doing nothing.
     if (attempts > 0 && failures == attempts) {
-      throw Exception('Could not reach the speaker to blink its light.');
+      throw const SonorityError(SonorityErrorCode.cannotBlinkLight);
     }
   }
 }

--- a/lib/data/sonos/sonority_error.dart
+++ b/lib/data/sonos/sonority_error.dart
@@ -1,0 +1,107 @@
+/// A user-facing engine/state error carried as **identity, not prose**.
+///
+/// The engine (`lib/data/sonos/`) is pure Dart and must not import the generated
+/// `AppLocalizations` (a Flutter type). So instead of throwing an English
+/// sentence, throw a [SonorityError] with a [code] (+ optional [arg]); the UI/
+/// state layer words it:
+///   - `friendlyError()` (this package, English) — for CLI tools, the
+///     diagnostics bundle, and as the fallback. Also `toString()` here.
+///   - `localizedError()` (`lib/state/localized_error.dart`) — translated via
+///     `AppLocalizations` for on-screen display.
+/// Keep the English in [message] and the localized copy (same keys) in step.
+class SonorityError implements Exception {
+  final SonorityErrorCode code;
+
+  /// Optional single interpolation value — an entity/room label, a channel
+  /// list, or the noun for a remove ("Surrounds"). Meaning depends on [code].
+  final String? arg;
+
+  const SonorityError(this.code, [this.arg]);
+
+  /// English rendering — used by `toString()` (raw logs / CLI) and as the
+  /// English fallback in `friendlyError`.
+  String get message {
+    final a = arg ?? '';
+    switch (code) {
+      case SonorityErrorCode.systemNotFound:
+        return 'Couldn’t find your Sonos system on the network.';
+      case SonorityErrorCode.noDevicesFound:
+        return 'No Sonos devices found. Check Wi-Fi and local network access.';
+      case SonorityErrorCode.descriptionsUnreadable:
+        return 'Found Sonos players but could not read their descriptions.';
+      case SonorityErrorCode.topologyUnreadable:
+        return 'Could not read the Sonos topology from any player.';
+      case SonorityErrorCode.entityNotOnNetwork:
+        return '“$a” isn’t on the network.';
+      case SonorityErrorCode.coordinatorNotOnNetwork:
+        return '“$a” coordinator isn’t on the network.';
+      case SonorityErrorCode.speakerInEntityNotOnNetwork:
+        return 'A speaker in “$a” isn’t on the network.';
+      case SonorityErrorCode.subNotOnNetwork:
+        return 'The Sub for “$a” isn’t on the network.';
+      case SonorityErrorCode.soundbarNotOnNetwork:
+        return 'Soundbar for “$a” isn’t on the network.';
+      case SonorityErrorCode.entityMissingSpeakers:
+        return '“$a” is missing speakers.';
+      case SonorityErrorCode.malformedGroup:
+        return 'Stored group is malformed.';
+      case SonorityErrorCode.malformedHomeTheater:
+        return 'Stored home theater is malformed.';
+      case SonorityErrorCode.didNotForm:
+        return 'Sonos did not form “$a”.';
+      case SonorityErrorCode.didNotCreateGroup:
+        return 'Sonos did not create the group — a speaker may be incompatible.';
+      case SonorityErrorCode.didNotSeparate:
+        return 'Sonos did not separate the group — try again.';
+      case SonorityErrorCode.didNotRemove:
+        return 'Sonos did not remove the $a — try again.';
+      case SonorityErrorCode.groupNeedsTwo:
+        return 'A group needs at least 2 speakers.';
+      case SonorityErrorCode.speakerIpUnknown:
+        return 'Speaker IP unknown; rescan and retry.';
+      case SonorityErrorCode.soundbarIpUnknown:
+        return 'Soundbar IP unknown; rescan and retry.';
+      case SonorityErrorCode.coordinatorIpUnknown:
+        return 'Coordinator IP unknown; rescan and retry.';
+      case SonorityErrorCode.bondingIncomplete:
+        return 'Bonding did not complete — these channels never joined: $a. '
+            'Try again, or finish in the Sonos app.';
+      case SonorityErrorCode.noLanIpForChime:
+        return 'No LAN IP found to serve the chime from.';
+      case SonorityErrorCode.cannotBlinkLight:
+        return 'Could not reach the speaker to blink its light.';
+    }
+  }
+
+  @override
+  String toString() => message;
+}
+
+/// Stable identity for each user-facing engine/state error. Add a case here,
+/// the English in [SonorityError.message], and the matching localized string in
+/// `localizedError` + `app_en.arb` (key `err<Code>`).
+enum SonorityErrorCode {
+  systemNotFound,
+  noDevicesFound,
+  descriptionsUnreadable,
+  topologyUnreadable,
+  entityNotOnNetwork,
+  coordinatorNotOnNetwork,
+  speakerInEntityNotOnNetwork,
+  subNotOnNetwork,
+  soundbarNotOnNetwork,
+  entityMissingSpeakers,
+  malformedGroup,
+  malformedHomeTheater,
+  didNotForm,
+  didNotCreateGroup,
+  didNotSeparate,
+  didNotRemove,
+  groupNeedsTwo,
+  speakerIpUnknown,
+  soundbarIpUnknown,
+  coordinatorIpUnknown,
+  bondingIncomplete,
+  noLanIpForChime,
+  cannotBlinkLight,
+}

--- a/lib/data/sonos/sonos_repository.dart
+++ b/lib/data/sonos/sonos_repository.dart
@@ -12,6 +12,7 @@ import 'diagnostics_log.dart';
 import 'key_value_store.dart';
 import 'room_calibration.dart';
 import 'soap_client.dart';
+import 'sonority_error.dart';
 import 'ssdp_discovery.dart';
 import 'zone_layout.dart';
 import 'zone_topology.dart';
@@ -50,7 +51,7 @@ class SonosRepository {
   Future<SonosSystem> discover() async {
     final locations = await _ssdp.discover();
     if (locations.isEmpty) {
-      throw Exception('No Sonos devices found. Check Wi-Fi and local network access.');
+      throw const SonorityError(SonorityErrorCode.noDevicesFound);
     }
 
     final devices = await Future.wait(
@@ -69,7 +70,7 @@ class SonosRepository {
     );
     final found = devices.whereType<SonosDevice>().toList();
     if (found.isEmpty) {
-      throw Exception('Found Sonos players but could not read their descriptions.');
+      throw const SonorityError(SonorityErrorCode.descriptionsUnreadable);
     }
 
     final devicesByUuid = {for (final d in found) d.uuid: d};
@@ -88,7 +89,8 @@ class SonosRepository {
       }
     }
     if (groups == null) {
-      throw Exception('Could not read the Sonos topology from any player: $lastErr');
+      DiagnosticsLog.add('discovery: topology unreadable from any player: $lastErr');
+      throw const SonorityError(SonorityErrorCode.topologyUnreadable);
     }
     DiagnosticsLog.add(
         'discovery: ${found.length} device(s) described, topology has '
@@ -180,7 +182,9 @@ class SonosRepository {
     CancellationToken? cancel,
   }) async {
     final ip = coordinator.ip;
-    if (ip == null) throw Exception('Coordinator IP unknown; rescan and retry.');
+    if (ip == null) {
+      throw const SonorityError(SonorityErrorCode.coordinatorIpUnknown);
+    }
 
     // Desired channel → set of UUIDs, skipping the CC primary
     // (target.entries.first). A set per channel so dual subs (two SW entries)
@@ -238,8 +242,8 @@ class SonosRepository {
       onNote?.call(
           'attempt $attempt: ${missing.map((c) => c.token).join('/')} not bonded yet');
     }
-    throw Exception('Bonding did not complete — these channels never joined: '
-        '${missing.map((c) => c.token).join(', ')}. Try again, or finish in the Sonos app.');
+    throw SonorityError(SonorityErrorCode.bondingIncomplete,
+        missing.map((c) => c.token).join(', '));
   }
 
   /// Unbonds the given satellite [uuids] from the soundbar at [soundbarIp].
@@ -264,11 +268,11 @@ class SonosRepository {
     SonosDevice? sub,
   }) async {
     if (members.length < 2) {
-      throw Exception('A group needs at least 2 speakers.');
+      throw const SonorityError(SonorityErrorCode.groupNeedsTwo);
     }
     final all = [for (final m in members) m.device, if (sub != null) sub];
     if (all.any((d) => d.ip == null)) {
-      throw Exception('Speaker IP unknown; rescan and retry.');
+      throw const SonorityError(SonorityErrorCode.speakerIpUnknown);
     }
     final attrs = <String, ZoneAttributes>{};
     for (final d in all) {
@@ -302,7 +306,9 @@ class SonosRepository {
   }) async {
     if (members.isEmpty) return;
     final coordIp = members.first.ip;
-    if (coordIp == null) throw Exception('Speaker IP unknown; rescan and retry.');
+    if (coordIp == null) {
+      throw const SonorityError(SonorityErrorCode.speakerIpUnknown);
+    }
     await _deviceProps.separateBondedZones(
         ip: coordIp, channelMapSet: channelMapSet);
     await _restoreZoneNames(members);

--- a/lib/features/diagnostics/diagnostics_sheet.dart
+++ b/lib/features/diagnostics/diagnostics_sheet.dart
@@ -9,6 +9,8 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:file_saver/file_saver.dart';
 import 'package:share_plus/share_plus.dart';
 
+import '../../core/l10n.dart';
+import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/busy_spinner.dart';
 import '../widgets/sheet_scaffold.dart';
@@ -69,24 +71,25 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
     _Action which,
     Future<void> Function(String path) action,
   ) async {
+    final l10n = context.l10n;
     setState(() => _busy = which);
     try {
       final String path;
       try {
         final built = await _collect();
         if (built == null) {
-          _snack('No system to collect — scan first.');
+          _snack(l10n.diagNoSystemToCollect);
           return;
         }
         path = built;
       } catch (e) {
-        _snack('Could not build the diagnostics bundle: $e');
+        _snack(l10n.diagBuildFailed(localizedError(l10n, e)));
         return;
       }
       try {
         await action(path);
       } catch (e) {
-        _snack('Could not complete the action: $e');
+        _snack(l10n.diagActionFailed(localizedError(l10n, e)));
       }
     } finally {
       if (mounted) setState(() => _busy = null);
@@ -94,6 +97,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
   }
 
   Future<void> _save(String path) async {
+    final l10n = context.l10n;
     // file_saver opens a native save dialog on every platform; filePath lets it
     // copy the temp zip to the chosen location without loading it into Dart.
     final saved = await FileSaver.instance.saveAs(
@@ -102,7 +106,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
       fileExtension: 'zip',
       mimeType: MimeType.zip,
     );
-    if (saved != null) _snack('Saved to $saved');
+    if (saved != null) _snack(l10n.diagSavedTo(saved));
   }
 
   /// Spinner on the button whose action is running, else its normal icon.
@@ -113,10 +117,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
     Email(
       subject: 'Sonority diagnostics',
       recipients: const [_devEmail],
-      body:
-          'Describe what went wrong (what you tried, what you expected, '
-          'what happened):\n\n\n'
-          '——— the diagnostics bundle is attached below ———',
+      body: context.l10n.diagEmailBody,
       attachmentPaths: [path],
     ),
   );
@@ -150,9 +151,9 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
     return SheetScaffold(
       fill: true,
       icon: Icons.bug_report_outlined,
-      title: 'Diagnostics',
+      title: context.l10n.diagTitle,
       body: system == null
-          ? const Center(child: Text('No system discovered yet.'))
+          ? Center(child: Text(context.l10n.diagNoSystem))
           : SingleChildScrollView(
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: SizedBox(
@@ -175,10 +176,8 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
           SwitchListTile(
             value: _includeLogs,
             onChanged: _isBusy ? null : (v) => setState(() => _includeLogs = v),
-            title: const Text('Include app logs'),
-            subtitle: const Text(
-              'SOAP faults, bond retries, discovery, errors (logs.txt)',
-            ),
+            title: Text(context.l10n.diagIncludeLogs),
+            subtitle: Text(context.l10n.diagIncludeLogsSubtitle),
             dense: true,
             shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.zero,
@@ -189,10 +188,8 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
             onChanged: _isBusy
                 ? null
                 : (v) => setState(() => _includeNetwork = v),
-            title: const Text('Include phone network info'),
-            subtitle: const Text(
-              "This device's network interface addresses (network.txt)",
-            ),
+            title: Text(context.l10n.diagIncludeNetwork),
+            subtitle: Text(context.l10n.diagIncludeNetworkSubtitle),
             dense: true,
             shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.zero,
@@ -201,8 +198,7 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
             child: Text(
-              'Always included: topology (room names, IPs, MACs, models), raw '
-              'device descriptions, and your saved profiles/room names.',
+              context.l10n.diagAlwaysIncluded,
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -232,10 +228,10 @@ class _DiagnosticsSheetState extends ConsumerState<_DiagnosticsSheet> {
                                 (_emailSupported
                                     ? _Action.email
                                     : _Action.share)
-                            ? 'Collecting…'
+                            ? context.l10n.diagCollecting
                             : _emailSupported
-                            ? 'Email to developer'
-                            : 'Share diagnostics',
+                            ? context.l10n.diagEmailToDeveloper
+                            : context.l10n.diagShareDiagnostics,
                       ),
                     ),
                   ),

--- a/lib/features/discovery/discovery_screen.dart
+++ b/lib/features/discovery/discovery_screen.dart
@@ -3,8 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
+import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../diagnostics/diagnostics_sheet.dart';
 import '../group/group_detail_screen.dart';
@@ -32,7 +34,7 @@ class DiscoveryScreen extends ConsumerWidget {
     final content = state.when(
       loading: () => const Center(child: _Scanning()),
       error: (e, _) => _ErrorView(
-        message: e.toString().replaceFirst('Exception: ', ''),
+        message: localizedError(context.l10n, e),
         onRetry: controller.scan,
       ),
       // discover() throws on an empty network, so data is never null here;
@@ -59,7 +61,7 @@ class DiscoveryScreen extends ConsumerWidget {
       actions: [
         const VersionBadge(),
         IconButton(
-          tooltip: 'Diagnostics',
+          tooltip: context.l10n.discoveryDiagnostics,
           onPressed: () => showDiagnosticsSheet(context),
           icon: const Icon(Icons.bug_report_outlined),
         ),
@@ -67,7 +69,7 @@ class DiscoveryScreen extends ConsumerWidget {
         // uses its own CTA button to scan.
         if (state.value != null)
           IconButton(
-            tooltip: 'Rescan',
+            tooltip: context.l10n.discoveryRescan,
             onPressed: state.isLoading ? null : controller.scan,
             icon: const Icon(Icons.refresh),
           ),
@@ -119,12 +121,9 @@ class _SystemView extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          SectionHeader('Home theaters', icon: Icons.theaters_outlined),
-          if (theaters.isEmpty)
-            const _EmptyHint(
-              'No soundbar found. Dedicated fronts need an Arc, Beam, Ray, '
-              'Playbar or Playbase.',
-            ),
+          SectionHeader(context.l10n.discoveryHomeTheaters,
+              icon: Icons.theaters_outlined),
+          if (theaters.isEmpty) _EmptyHint(context.l10n.discoveryNoSoundbar),
           ...theaters.map((m) => TheaterEntityCard(
                 model: TheaterCardModel.fromMember(system, m),
                 onTap: () => context.push('/theater/${m.uuid}'),
@@ -133,13 +132,13 @@ class _SystemView extends ConsumerWidget {
           // The "+" lives in the header; the flow itself explains if there
           // aren't two free speakers to bond.
           SectionHeader(
-            'Speaker groups',
+            context.l10n.discoverySpeakerGroups,
             icon: Icons.speaker_group_outlined,
             onAdd: () => context.push('/group'),
-            addTooltip: 'Group speakers',
+            addTooltip: context.l10n.discoveryGroupSpeakers,
           ),
           if (groups.isEmpty)
-            const _EmptySectionCard('No speaker groups yet')
+            _EmptySectionCard(context.l10n.discoveryNoGroups)
           else
             ...groups.map((m) => EntityCard(
                   model: EntityCardModel.fromMember(system, m),
@@ -148,7 +147,7 @@ class _SystemView extends ConsumerWidget {
           // Single speaker rooms — hidden entirely when there are none.
           if (singleRooms.isNotEmpty) ...[
             Gap.l,
-            SectionHeader('Single speaker rooms',
+            SectionHeader(context.l10n.discoverySingleRooms,
                 icon: Icons.meeting_room_outlined),
             ...singleRooms.map((m) => EntityCard(
                   model: EntityCardModel.fromMember(system, m),
@@ -161,14 +160,15 @@ class _SystemView extends ConsumerWidget {
           // HT setup flow.
           if (system.bondableSubs.isNotEmpty) ...[
             Gap.l,
-            SectionHeader('Other devices', icon: Icons.devices_other_outlined),
+            SectionHeader(context.l10n.discoveryOtherDevices,
+                icon: Icons.devices_other_outlined),
           ],
           ...system.bondableSubs.map(
             (sub) => Card(
               margin: const EdgeInsets.only(bottom: kCardGap),
               child: ListTile(
                 leading: const Icon(Icons.graphic_eq),
-                title: const Text('Subwoofer'),
+                title: Text(context.l10n.discoverySubwoofer),
                 subtitle: Text(sub.typeLabel),
               ),
             ),
@@ -229,7 +229,7 @@ class _Scanning extends StatelessWidget {
       const CircularProgressIndicator(),
       Gap.l,
       Text(
-        'Scanning your network…',
+        context.l10n.discoveryScanning,
         style: Theme.of(context).textTheme.titleMedium,
       ),
     ],
@@ -252,7 +252,7 @@ class _ErrorView extends StatelessWidget {
           Icon(Icons.wifi_off_rounded, size: 64, color: scheme.error),
           Gap.m,
           Text(
-            'Couldn’t find your system',
+            context.l10n.discoveryErrorTitle,
             textAlign: TextAlign.center,
             style: Theme.of(context).textTheme.titleLarge,
           ),
@@ -268,7 +268,7 @@ class _ErrorView extends StatelessWidget {
           FilledButton.icon(
             onPressed: onRetry,
             icon: const Icon(Icons.refresh),
-            label: const Text('Try again'),
+            label: Text(context.l10n.discoveryTryAgain),
           ),
         ],
       ),

--- a/lib/features/front_surrounds/front_surrounds_flow.dart
+++ b/lib/features/front_surrounds/front_surrounds_flow.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../data/sonos/front_layout.dart' as front_layout;
@@ -123,7 +124,7 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Set up home theater'),
+        title: Text(context.l10n.frontSurroundsTitle),
         bottom: const PreferredSize(
           preferredSize: Size.fromHeight(1),
           child: ScrolledUnderDivider(),
@@ -138,8 +139,8 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
               _controls(context, system, member, soundbar),
           steps: [
             Step(
-              title: const Text('Front speakers'),
-              subtitle: const Text('Optional'),
+              title: Text(context.l10n.frontSurroundsStepFronts),
+              subtitle: Text(context.l10n.frontSurroundsOptional),
               isActive: _step >= 0,
               state: _fronts.isNotEmpty && _frontsValid
                   ? StepState.complete
@@ -147,8 +148,7 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
               content: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Pick two speakers (or a single Amp) for the front '
-                      'left & right, then set which is which.',
+                  Text(context.l10n.frontSurroundsFrontsHint,
                       style: Theme.of(context).textTheme.bodySmall),
                   Gap.s,
                   _ChooseSpeakers(
@@ -168,8 +168,8 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
                     _AssignSides(
                       system: system,
                       selected: _fronts,
-                      leftLabel: 'LEFT',
-                      rightLabel: 'RIGHT',
+                      leftLabel: context.l10n.frontSurroundsLeft,
+                      rightLabel: context.l10n.frontSurroundsRight,
                       onSwap: () => setState(
                           () => _fronts.setAll(0, [_fronts[1], _fronts[0]])),
                       identifyControls: idControls,
@@ -179,14 +179,14 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
               ),
             ),
             Step(
-              title: const Text('Rear surrounds'),
-              subtitle: const Text('Optional'),
+              title: Text(context.l10n.frontSurroundsStepSurrounds),
+              subtitle: Text(context.l10n.frontSurroundsOptional),
               isActive: _step >= 1,
               state: _surrounds.length == 2 ? StepState.complete : StepState.indexed,
               content: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Pick two speakers for the rear left & right surrounds.',
+                  Text(context.l10n.frontSurroundsSurroundsHint,
                       style: Theme.of(context).textTheme.bodySmall),
                   Gap.s,
                   _ChooseSpeakers(
@@ -201,8 +201,8 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
                     _AssignSides(
                       system: system,
                       selected: _surrounds,
-                      leftLabel: 'REAR LEFT',
-                      rightLabel: 'REAR RIGHT',
+                      leftLabel: context.l10n.frontSurroundsRearLeft,
+                      rightLabel: context.l10n.frontSurroundsRearRight,
                       onSwap: () => setState(() =>
                           _surrounds.setAll(0, [_surrounds[1], _surrounds[0]])),
                       identifyControls: idControls,
@@ -212,8 +212,8 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
               ),
             ),
             Step(
-              title: const Text('Subwoofer'),
-              subtitle: const Text('Optional'),
+              title: Text(context.l10n.frontSurroundsStepSub),
+              subtitle: Text(context.l10n.frontSurroundsOptional),
               isActive: _step >= 2,
               state: _subs.isNotEmpty ? StepState.complete : StepState.indexed,
               content: _ChooseSub(
@@ -224,7 +224,7 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
               ),
             ),
             Step(
-              title: const Text('Review & apply'),
+              title: Text(context.l10n.frontSurroundsStepReview),
               isActive: _step >= 3,
               content: _Review(
                   system: system,
@@ -343,7 +343,7 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
           if (_step > 0)
             TextButton(
               onPressed: () => setState(() => _step--),
-              child: const Text('Back'),
+              child: Text(context.l10n.actionBack),
             ),
           Gap.s,
           Expanded(
@@ -351,7 +351,8 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
               onPressed: isLast
                   ? (canApply ? () => _apply(member, soundbar) : null)
                   : (canNext ? () => setState(() => _step++) : null),
-              child: Text(isLast ? 'Apply' : 'Continue'),
+              child: Text(
+                  isLast ? context.l10n.actionApply : context.l10n.actionContinue),
             ),
           ),
         ],
@@ -385,7 +386,7 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
     final router = GoRouter.of(context);
     final outcome = await showBondingProgress(
       context,
-      title: 'Set up home theater',
+      title: context.l10n.frontSurroundsTitle,
       run: () => controller.applyHomeTheaterLayout(
         soundbar: member,
         soundbarDevice: soundbar,
@@ -406,10 +407,9 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
     return confirmDialog(
       context,
       icon: Icons.link_off,
-      title: 'Unbond ${removed.length} speaker${removed.length == 1 ? '' : 's'}?',
-      message: '$types will be removed from this home theater and become '
-          'standalone rooms again. The rest of your layout stays as it is.',
-      confirmLabel: 'Unbond',
+      title: context.l10n.frontSurroundsUnbondTitle(removed.length),
+      message: context.l10n.frontSurroundsUnbondMessage(types),
+      confirmLabel: context.l10n.frontSurroundsUnbond,
     );
   }
 }
@@ -432,10 +432,7 @@ class _ChooseSpeakers extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (candidates.isEmpty) {
-      return const Text(
-        'No free speakers available. They must be standalone (not already part '
-        'of a home theater or stereo pair).',
-      );
+      return Text(context.l10n.frontSurroundsNoFreeSpeakers);
     }
     final hasAmp = allowAmp && candidates.any((d) => d.isAmp);
     return Column(
@@ -443,9 +440,8 @@ class _ChooseSpeakers extends StatelessWidget {
       children: [
         Text(
             hasAmp
-                ? 'Pick two speakers (ideally identical), or a single Sonos Amp '
-                    'that drives both front speakers.'
-                : 'Pick exactly two — ideally an identical pair.',
+                ? context.l10n.frontSurroundsPickWithAmp
+                : context.l10n.frontSurroundsPickExactlyTwo,
             style: Theme.of(context).textTheme.bodySmall),
         Gap.s,
         ...candidates.map((d) {
@@ -457,7 +453,7 @@ class _ChooseSpeakers extends StatelessWidget {
             selected: isSel,
             onChanged: disabled ? null : (_) => onToggle(d),
             subtitle: isAmp
-                ? '${d.typeLabel} — drives both fronts (L + R)'
+                ? context.l10n.frontSurroundsAmpSubtitle(d.typeLabel)
                 : d.typeLabel,
             secondary: identifyControls(d),
           );
@@ -483,14 +479,12 @@ class _ChooseSub extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (subs.isEmpty) {
-      return const Text(
-          'No free subwoofer found. A Sonos Sub must be standalone (not already '
-          'bonded to another home theater).');
+      return Text(context.l10n.frontSurroundsNoFreeSub);
     }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('Pick one or two subwoofers to add as low-frequency channels.',
+        Text(context.l10n.frontSurroundsSubHint,
             style: Theme.of(context).textTheme.bodySmall),
         Gap.s,
         ...subs.map((d) {
@@ -522,9 +516,7 @@ class _AmpWiringNote extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'The ${amp?.modelName ?? 'Amp'} drives both front channels. Wire your '
-          'left & right speakers to its L/R speaker outputs — there\'s nothing '
-          'to assign here.',
+          context.l10n.frontSurroundsAmpWiring(amp?.modelName ?? 'Amp'),
           style: Theme.of(context).textTheme.bodySmall,
         ),
         if (amp != null) ...[
@@ -556,7 +548,7 @@ class _AssignSides extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (selected.length != 2) {
-      return const Text('Choose two speakers first.');
+      return Text(context.l10n.frontSurroundsChooseTwoFirst);
     }
     final left = system.device(selected[0]);
     final right = system.device(selected[1]);
@@ -572,7 +564,7 @@ class _AssignSides extends StatelessWidget {
             IconButton.filledTonal(
               onPressed: onSwap,
               icon: const Icon(Icons.swap_horiz),
-              tooltip: 'Swap sides',
+              tooltip: context.l10n.frontSurroundsSwapSides,
             ),
             Expanded(
                 child: SpeakerSideCard(
@@ -582,7 +574,7 @@ class _AssignSides extends StatelessWidget {
           ],
         ),
         Gap.s,
-        Text('Tap swap if the sides are reversed.',
+        Text(context.l10n.frontSurroundsTapSwap,
             style: Theme.of(context).textTheme.bodySmall),
       ],
     );
@@ -605,7 +597,7 @@ class _Review extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (additions.isEmpty && subCount == 0) {
-      return const Text('Nothing selected yet — choose speakers above.');
+      return Text(context.l10n.frontSurroundsNothingSelected);
     }
     // The diagram shows the DESIRED end state (the current selection), which is
     // pre-seeded from the live layout — so a deselected role correctly shows
@@ -624,12 +616,7 @@ class _Review extends StatelessWidget {
           subCount: subCount,
         ),
         Gap.m,
-        const InfoNote(
-          'The chosen speakers become hidden satellites of the soundbar (which '
-          'stays the center channel). Bonding runs in steps and can take a '
-          'little while; Trueplay may need re-tuning afterward. You can change '
-          'this anytime.',
-        ),
+        InfoNote(context.l10n.frontSurroundsReviewNote),
       ],
     );
   }

--- a/lib/features/group/group_detail_screen.dart
+++ b/lib/features/group/group_detail_screen.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
+import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/bonding_progress_screen.dart';
 import '../widgets/busy_view.dart';
 import '../widgets/confirm_dialog.dart';
 import '../widgets/destructive_button.dart';
 import '../widgets/diagram_labels.dart';
+import '../widgets/entity_cards.dart';
 import '../widgets/identify_controls.dart';
 import '../widgets/rename_dialog.dart';
 import '../widgets/sheet_scaffold.dart';
@@ -29,21 +32,22 @@ class _GroupSheet extends ConsumerWidget {
     final group = system?.memberByUuid(uuid);
 
     if (system == null || group == null || !group.isGroup) {
-      return const SheetScaffold(
-        title: 'Speaker group',
-        body: Padding(padding: EdgeInsets.all(24), child: MissingRoomView()),
+      return SheetScaffold(
+        title: context.l10n.groupSheetTitle,
+        body: const Padding(
+            padding: EdgeInsets.all(24), child: MissingRoomView()),
       );
     }
 
     final device = system.device(group.uuid);
     return SheetScaffold(
       title: group.zoneName,
-      subtitle: groupKindLabel(group.groupKind),
+      subtitle: groupKindL10n(context.l10n, group.groupKind),
       trailing: device == null
           ? null
           : IconButton(
               icon: const Icon(Icons.drive_file_rename_outline),
-              tooltip: 'Rename group',
+              tooltip: context.l10n.groupRenameTooltip,
               onPressed: () => _rename(context, ref, device, group.zoneName),
             ),
       body: Padding(
@@ -52,7 +56,8 @@ class _GroupSheet extends ConsumerWidget {
           // Bonded member → LED only (chiming one plays the whole group).
           children: groupMemberCards(
             group,
-            typeOf: (uuid) => system.device(uuid)?.typeLabel ?? 'Speaker',
+            typeOf: (uuid) =>
+                system.device(uuid)?.typeLabel ?? context.l10n.widgetsSpeaker,
             trailing: (uuid) => speakerIdentifyButton(system.device(uuid)),
           ),
         ),
@@ -61,7 +66,7 @@ class _GroupSheet extends ConsumerWidget {
         padding: const EdgeInsets.fromLTRB(kPageGutter, 8, kPageGutter, 0),
         child: DestructiveButton(
           icon: Icons.link_off,
-          label: 'Separate',
+          label: context.l10n.groupSeparate,
           onPressed: () => _confirmSeparate(context, ref, group),
         ),
       ),
@@ -74,13 +79,15 @@ Future<void> _rename(BuildContext context, WidgetRef ref, SonosDevice device,
   final name = await showRenameDialog(context, current);
   if (name == null || !context.mounted) return;
   final messenger = ScaffoldMessenger.of(context);
+  final l10n = context.l10n;
   try {
     await ref
         .read(sonosControllerProvider.notifier)
         .renameRoom(device: device, name: name);
-    messenger.showSnackBar(SnackBar(content: Text('Renamed to “$name”.')));
+    messenger.showSnackBar(SnackBar(content: Text(l10n.groupRenamedTo(name))));
   } catch (e) {
-    messenger.showSnackBar(SnackBar(content: Text('Failed: $e')));
+    messenger.showSnackBar(SnackBar(
+        content: Text(l10n.groupRenameFailed(localizedError(l10n, e)))));
   }
 }
 
@@ -89,16 +96,15 @@ Future<void> _confirmSeparate(
   final ok = await confirmDialog(
     context,
     icon: Icons.link_off,
-    title: 'Separate group?',
-    message: 'The speakers become standalone rooms again. Their original room '
-        'names will be restored.',
-    confirmLabel: 'Separate',
+    title: context.l10n.groupSeparateConfirmTitle,
+    message: context.l10n.groupSeparateConfirmMessage,
+    confirmLabel: context.l10n.groupSeparate,
   );
   if (!ok || !context.mounted) return;
   final controller = ref.read(sonosControllerProvider.notifier);
   final outcome = await showBondingProgress(
     context,
-    title: 'Separate group',
+    title: context.l10n.groupSeparateProgressTitle,
     run: () => controller.separateGroup(group),
   );
   // The group is gone now — close the sheet.

--- a/lib/features/group/group_flow.dart
+++ b/lib/features/group/group_flow.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
@@ -85,18 +86,17 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
       // header (with its own divider), so a second line under the app bar would
       // double up.
       appBar: AppBar(
-        title: const Text('Group speakers'),
+        title: Text(context.l10n.groupFlowTitle),
         scrolledUnderElevation: 0,
         surfaceTintColor: Colors.transparent,
       ),
       body: SafeArea(
         child: candidates.length < 2
-            ? const Center(
+            ? Center(
                 child: Padding(
-                  padding: EdgeInsets.all(24),
+                  padding: const EdgeInsets.all(24),
                   child: Text(
-                    'Need at least two standalone speakers (not soundbars, subs, '
-                    'amps, or already bonded).',
+                    context.l10n.groupNeedTwoSpeakers,
                     textAlign: TextAlign.center,
                   ),
                 ),
@@ -116,13 +116,16 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
                             padding: const EdgeInsets.symmetric(vertical: 16),
                             textStyle: Theme.of(context).textTheme.titleSmall,
                           ),
-                          segments: const [
+                          segments: [
                             ButtonSegment(
-                                value: _Mode.stereo, label: Text('Stereo')),
+                                value: _Mode.stereo,
+                                label: Text(context.l10n.groupModeStereo)),
                             ButtonSegment(
-                                value: _Mode.zone, label: Text('Zone')),
+                                value: _Mode.zone,
+                                label: Text(context.l10n.groupModeZone)),
                             ButtonSegment(
-                                value: _Mode.custom, label: Text('Custom')),
+                                value: _Mode.custom,
+                                label: Text(context.l10n.groupModeCustom)),
                           ],
                           selected: {_mode},
                           onSelectionChanged: (s) => _onModeChanged(s.first),
@@ -139,7 +142,7 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
                       controlsBuilder: (context, _) => _controls(system),
                       steps: [
                         Step(
-                          title: const Text('Select speakers'),
+                          title: Text(context.l10n.groupStepSelect),
                           isActive: _step >= _stepSpeakers,
                           state: _selected.length >= 2
                               ? StepState.complete
@@ -159,8 +162,8 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
                           ),
                         ),
                         Step(
-                          title: const Text('Add a Sub'),
-                          subtitle: const Text('Optional'),
+                          title: Text(context.l10n.groupStepAddSub),
+                          subtitle: Text(context.l10n.groupOptional),
                           isActive: _step >= _stepSub,
                           state: _subUuid != null
                               ? StepState.complete
@@ -172,8 +175,8 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
                           ),
                         ),
                         Step(
-                          title: const Text('Name'),
-                          subtitle: const Text('Optional'),
+                          title: Text(context.l10n.groupStepName),
+                          subtitle: Text(context.l10n.groupOptional),
                           isActive: _step >= _stepName,
                           content: Padding(
                             // Top room for the floating label (else it clips).
@@ -181,16 +184,16 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
                             child: TextField(
                               controller: _nameController,
                               textCapitalization: TextCapitalization.sentences,
-                              decoration: const InputDecoration(
-                                labelText: 'Group name (optional)',
-                                hintText: 'e.g. Downstairs',
-                                border: OutlineInputBorder(),
+                              decoration: InputDecoration(
+                                labelText: context.l10n.groupNameLabel,
+                                hintText: context.l10n.groupNameHint,
+                                border: const OutlineInputBorder(),
                               ),
                             ),
                           ),
                         ),
                         Step(
-                          title: const Text('Review & create'),
+                          title: Text(context.l10n.groupStepReview),
                           isActive: _step >= _stepReview,
                           content: _ReviewStep(
                             mode: _mode,
@@ -215,11 +218,11 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
     final canAdvance = _step != _stepSpeakers || _selected.length >= 2;
     final label = isLast
         ? switch (_mode) {
-            _Mode.stereo => 'Create stereo pair',
-            _Mode.zone => 'Create zone',
-            _Mode.custom => 'Create custom group',
+            _Mode.stereo => context.l10n.groupCreateStereo,
+            _Mode.zone => context.l10n.groupCreateZone,
+            _Mode.custom => context.l10n.groupCreateCustom,
           }
-        : 'Continue';
+        : context.l10n.actionContinue;
     return Padding(
       padding: const EdgeInsets.only(top: 16),
       child: Row(
@@ -227,7 +230,7 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
           if (_step > 0)
             TextButton(
               onPressed: () => setState(() => _step--),
-              child: const Text('Back'),
+              child: Text(context.l10n.actionBack),
             ),
           Gap.s,
           Expanded(
@@ -258,19 +261,19 @@ class _GroupFlowState extends ConsumerState<GroupFlow> with IdentifyMixin {
     final controller = ref.read(sonosControllerProvider.notifier);
     final messenger = ScaffoldMessenger.of(context);
     final router = GoRouter.of(context);
+    final l10n = context.l10n;
     final outcome = await showBondingProgress(
       context,
-      title: 'Group speakers',
+      title: l10n.groupFlowTitle,
       run: () => controller.createGroup(
           members: members, sub: sub, name: name.isEmpty ? null : name),
     );
     if (outcome == BondingOutcome.success) {
       router.pop();
     } else if (outcome == BondingOutcome.failed) {
-      messenger.showSnackBar(const SnackBar(
-        content: Text('Couldn’t create the group — Sonos may not allow one of '
-            'these speakers. See the log for details.'),
-        duration: Duration(seconds: 6),
+      messenger.showSnackBar(SnackBar(
+        content: Text(l10n.groupCreateFailed),
+        duration: const Duration(seconds: 6),
       ));
     }
   }
@@ -317,14 +320,10 @@ class _SelectStep extends StatelessWidget {
     required this.identifyControls,
   });
 
-  String get _hint => switch (mode) {
-        _Mode.stereo =>
-          'Pick two speakers — one plays left, the other right (swap below). '
-              'Mismatched models are fine.',
-        _Mode.zone =>
-          'Pick 2–16 speakers. They all play full stereo (L+R) as one room.',
-        _Mode.custom =>
-          'Pick 2–16 speakers and set each to Left, Right, or Both.',
+  String _hint(BuildContext context) => switch (mode) {
+        _Mode.stereo => context.l10n.groupHintStereo,
+        _Mode.zone => context.l10n.groupHintZone,
+        _Mode.custom => context.l10n.groupHintCustom,
       };
 
   @override
@@ -333,7 +332,7 @@ class _SelectStep extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(_hint, style: Theme.of(context).textTheme.bodySmall),
+        Text(_hint(context), style: Theme.of(context).textTheme.bodySmall),
         Gap.m,
         ...candidates.map((d) {
           final isSel = selected.contains(d.uuid);
@@ -355,17 +354,17 @@ class _SelectStep extends StatelessWidget {
             children: [
               Expanded(
                   child: SpeakerSideCard(
-                      side: 'LEFT',
+                      side: context.l10n.groupSideLeft,
                       device: system.device(selected[0]),
                       controls: identifyControls(system.device(selected[0])!))),
               IconButton.filledTonal(
                 onPressed: onSwap,
                 icon: const Icon(Icons.swap_horiz),
-                tooltip: 'Swap sides',
+                tooltip: context.l10n.groupSwapSides,
               ),
               Expanded(
                   child: SpeakerSideCard(
-                      side: 'RIGHT',
+                      side: context.l10n.groupSideRight,
                       device: system.device(selected[1]),
                       controls: identifyControls(system.device(selected[1])!))),
             ],
@@ -438,13 +437,16 @@ class _CandidateCard extends StatelessWidget {
                   width: double.infinity,
                   child: SegmentedButton<GroupChannel>(
                     showSelectedIcon: false,
-                    segments: const [
+                    segments: [
                       ButtonSegment(
-                          value: GroupChannel.left, label: Text('Left')),
+                          value: GroupChannel.left,
+                          label: Text(context.l10n.groupChannelLeft)),
                       ButtonSegment(
-                          value: GroupChannel.both, label: Text('Both')),
+                          value: GroupChannel.both,
+                          label: Text(context.l10n.groupChannelBoth)),
                       ButtonSegment(
-                          value: GroupChannel.right, label: Text('Right')),
+                          value: GroupChannel.right,
+                          label: Text(context.l10n.groupChannelRight)),
                     ],
                     selected: {channel},
                     onSelectionChanged: (s) => onChannel(s.first),
@@ -479,12 +481,11 @@ class _SubStep extends StatelessWidget {
       children: [
         if (subs.isEmpty)
           Text(
-            'No standalone Sub available. A Sub bonded to a home theater must be '
-            'removed there first.',
+            context.l10n.groupNoSub,
             style: muted,
           )
         else ...[
-          Text('Optionally add a Sub to the group.', style: muted),
+          Text(context.l10n.groupAddSubHint, style: muted),
           Gap.s,
           ...subs.map((s) => Card(
                 margin: const EdgeInsets.only(bottom: 8),
@@ -492,7 +493,7 @@ class _SubStep extends StatelessWidget {
                   value: selected == s.uuid,
                   onChanged: (v) => onChanged((v ?? false) ? s.uuid : null),
                   controlAffinity: ListTileControlAffinity.leading,
-                  title: const Text('Subwoofer'),
+                  title: Text(context.l10n.groupSubwoofer),
                   subtitle: Text(s.typeLabel),
                   secondary: const Icon(Icons.graphic_eq),
                 ),
@@ -527,14 +528,22 @@ class _ReviewStep extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final muted = theme.mutedText;
+    final l10n = context.l10n;
     final kind = switch (mode) {
-      _Mode.stereo => 'Stereo pair',
-      _Mode.zone => 'Zone (${selected.length} speakers)',
-      _Mode.custom => 'Custom group (${selected.length} speakers)',
+      _Mode.stereo => l10n.groupKindStereo,
+      _Mode.zone => l10n.groupKindZone(selected.length),
+      _Mode.custom => l10n.groupKindCustom(selected.length),
     };
     final lines = [
       for (final r in _resolveChannels(mode, selected, channels))
-        '${_room(r.uuid)} — ${groupChannelLabel(r.channel)}',
+        l10n.groupReviewMemberLine(
+          _room(r.uuid),
+          switch (r.channel) {
+            GroupChannel.left => l10n.groupChannelLeft,
+            GroupChannel.right => l10n.groupChannelRight,
+            GroupChannel.both => l10n.groupChannelBoth,
+          },
+        ),
     ];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -542,7 +551,7 @@ class _ReviewStep extends StatelessWidget {
         Text(kind, style: theme.textTheme.titleMedium),
         if (name.isNotEmpty) ...[
           Gap.s,
-          Text('Name: $name', style: muted),
+          Text(l10n.groupReviewName(name), style: muted),
         ],
         Gap.s,
         ...lines.map((l) => Padding(
@@ -550,13 +559,13 @@ class _ReviewStep extends StatelessWidget {
               child: Text(l, style: muted),
             )),
         if (subUuid != null)
-          Text('Sub: ${system.device(subUuid!)?.typeLabel ?? 'Subwoofer'}',
+          Text(
+              l10n.groupReviewSub(
+                  system.device(subUuid!)?.typeLabel ?? l10n.groupSubwoofer),
               style: muted),
         Gap.m,
         Text(
-          'Bonded speakers play as one room. Larger or mixed-model groups can '
-          'drop out briefly — play something to confirm it works for you. '
-          'Original room names are restored when you separate the group.',
+          l10n.groupReviewNote,
           style: muted,
         ),
       ],

--- a/lib/features/home_theater/home_theater_screen.dart
+++ b/lib/features/home_theater/home_theater_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
+import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../../state/trueplay_controller.dart';
 import '../widgets/bonding_progress_screen.dart';
@@ -49,24 +51,22 @@ class HomeTheaterScreen extends ConsumerWidget {
     }
 
     return AppScaffold(
-      title: member?.zoneName ?? 'Home theater',
-      subtitle: member == null ? null : 'Home theater',
+      title: member?.zoneName ?? context.l10n.htHomeTheater,
+      subtitle: member == null ? null : context.l10n.htHomeTheater,
       onRefresh: refreshAll,
       actions: [
         if (member != null && device != null)
           IconButton(
             icon: const Icon(Icons.drive_file_rename_outline),
-            tooltip: 'Rename room',
+            tooltip: context.l10n.htRenameRoomTooltip,
             onPressed: () => _rename(context, ref, device, member.zoneName),
           ),
         RefreshIconButton(onRefresh: refreshAll),
       ],
       body: state.isLoading
-          ? const BusyView(
-              title: 'Updating your home theater…',
-              subtitle:
-                  'This can take up to ~20 seconds while Sonos reconfigures '
-                  'and re-reads the layout.',
+          ? BusyView(
+              title: context.l10n.htUpdatingTitle,
+              subtitle: context.l10n.htUpdatingSubtitle,
             )
           : (member == null || device == null)
           ? const MissingRoomView()
@@ -98,13 +98,15 @@ class HomeTheaterScreen extends ConsumerWidget {
     final name = await showRenameDialog(context, current);
     if (name == null || !context.mounted) return;
     final messenger = ScaffoldMessenger.of(context);
+    final l10n = context.l10n;
     try {
       await ref
           .read(sonosControllerProvider.notifier)
           .renameRoom(device: device, name: name);
-      messenger.showSnackBar(SnackBar(content: Text('Renamed to “$name”.')));
+      messenger.showSnackBar(SnackBar(content: Text(l10n.htRenamedTo(name))));
     } catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('Failed: $e')));
+      messenger.showSnackBar(SnackBar(
+          content: Text(l10n.htRenameFailed(localizedError(l10n, e)))));
     }
   }
 
@@ -117,16 +119,16 @@ class HomeTheaterScreen extends ConsumerWidget {
     String label, {
     bool separateAll = false,
   }) async {
+    final l10n = context.l10n;
     final ok = await confirmDialog(
       context,
       icon: Icons.link_off,
-      title: separateAll ? 'Separate home theater?' : 'Remove $label?',
-      message: separateAll
-          ? 'All extra speakers will be un-bonded and become standalone rooms '
-              'again, leaving just the soundbar.'
-          : 'These speakers will be un-bonded and become standalone rooms '
-              'again. The rest of your home theater stays as it is.',
-      confirmLabel: separateAll ? 'Separate' : 'Remove',
+      title: separateAll
+          ? l10n.htSeparateConfirmTitle
+          : l10n.htRemoveConfirmTitle(label),
+      message:
+          separateAll ? l10n.htSeparateMessage : l10n.htRemoveMessage,
+      confirmLabel: separateAll ? l10n.htSeparate : l10n.actionRemove,
     );
     if (!ok || !context.mounted) return;
 
@@ -134,7 +136,9 @@ class HomeTheaterScreen extends ConsumerWidget {
     // No success toast — the progress screen already showed the outcome.
     await showBondingProgress(
       context,
-      title: separateAll ? 'Separate home theater' : 'Remove $label',
+      title: separateAll
+          ? l10n.htSeparateProgressTitle
+          : l10n.htRemoveProgressTitle(label),
       run: () => controller.removeHtRoles(
         soundbar: member,
         soundbarDevice: device,
@@ -153,17 +157,17 @@ class _Group {
   const _Group(this.label, this.icon, this.channels);
 }
 
-const _htGroups = [
-  _Group('Fronts', Icons.speaker, {
-    SonosChannel.leftFront,
-    SonosChannel.rightFront,
-  }),
-  _Group('Surrounds', Icons.surround_sound, {
-    SonosChannel.leftRear,
-    SonosChannel.rightRear,
-  }),
-  _Group('Subwoofer', Icons.graphic_eq, {SonosChannel.sub}),
-];
+List<_Group> _htGroupsFor(AppLocalizations l10n) => [
+      _Group(l10n.htGroupFronts, Icons.speaker, {
+        SonosChannel.leftFront,
+        SonosChannel.rightFront,
+      }),
+      _Group(l10n.htGroupSurrounds, Icons.surround_sound, {
+        SonosChannel.leftRear,
+        SonosChannel.rightRear,
+      }),
+      _Group(l10n.htGroupSubwoofer, Icons.graphic_eq, {SonosChannel.sub}),
+    ];
 
 class _Content extends StatelessWidget {
   final SonosSystem system;
@@ -184,13 +188,13 @@ class _Content extends StatelessWidget {
   /// Speaker model per bonded speaker in a group (e.g. "Play:1, Play:1") — the
   /// room name just echoes the HT name, so the model is the useful detail. One
   /// entry per distinct device (an Amp driving both fronts shows once).
-  List<String> _models(Set<SonosChannel> channels) {
+  List<String> _models(Set<SonosChannel> channels, String fallback) {
     final seen = <String>{};
     final out = <String>[];
     for (final c in channels) {
       for (final uuid in member.uuidsForChannel(c)) {
         if (!seen.add(uuid)) continue;
-        out.add(system.device(uuid)?.typeLabel ?? 'Speaker');
+        out.add(system.device(uuid)?.typeLabel ?? fallback);
       }
     }
     return out;
@@ -199,8 +203,9 @@ class _Content extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = context.l10n;
     final present = [
-      for (final g in _htGroups)
+      for (final g in _htGroupsFor(l10n))
         if (g.channels.any((c) => hasChannel(member, c))) g,
     ];
     // Edge-to-edge list so the Trueplay settings section can be full-bleed
@@ -222,21 +227,20 @@ class _Content extends StatelessWidget {
                 // glyph (Icons.tune) is reserved for the audio/Trueplay surfaces
                 // so a layout action never looks like EQ (which we don't do).
                 icon: const Icon(Icons.settings),
-                label: const Text('Configure home theater'),
+                label: Text(l10n.htConfigure),
               ),
               Gap.l,
-              const SectionHeader('Bonded speakers'),
+              SectionHeader(l10n.htBondedSpeakers),
               if (present.isEmpty)
                 Text(
-                  'Just the soundbar — no fronts, surrounds or sub bonded yet. '
-                  'Tap “Configure home theater” to add some.',
+                  l10n.htNoBonded,
                   style: theme.mutedText,
                 )
               else
                 for (final g in present) ...[
                   _GroupCard(
                     group: g,
-                    models: _models(g.channels),
+                    models: _models(g.channels, l10n.htSpeakerFallback),
                     onRemove: () => onRemoveGroup(g.channels, g.label),
                   ),
                   Gap.s,
@@ -254,12 +258,7 @@ class _Content extends StatelessWidget {
               if (member.hasDedicatedFronts) ...[
                 Gap.s,
                 Text(
-                  'Trueplay can only be measured from the Sonos app on iOS — '
-                  'tune the home theater, and the fronts separately as a stereo '
-                  'pair. Heads-up: Sonos often clears a tuning when speakers are '
-                  'bonded/unbonded, so you may see “Not tuned” after changing the '
-                  'layout and have to redo it. Sonority only toggles a stored '
-                  'tuning.',
+                  l10n.htTrueplayNote,
                   style: theme.mutedText,
                 ),
               ],
@@ -267,10 +266,10 @@ class _Content extends StatelessWidget {
                 Gap.l,
                 DestructiveButton(
                   icon: Icons.link_off,
-                  label: 'Separate',
+                  label: l10n.htSeparate,
                   onPressed: () => onRemoveGroup(
                     {for (final g in present) ...g.channels},
-                    'all extra speakers',
+                    l10n.htAllExtraSpeakers,
                     separateAll: true,
                   ),
                 ),
@@ -301,11 +300,11 @@ class _GroupCard extends StatelessWidget {
       child: ListTile(
         leading: Icon(group.icon, color: theme.colorScheme.primary),
         title: Text(group.label),
-        subtitle: Text(models.isEmpty ? 'Bonded' : models.join(', ')),
+        subtitle: Text(models.isEmpty ? context.l10n.htBonded : models.join(', ')),
         trailing: TextButton(
           onPressed: onRemove,
           style: TextButton.styleFrom(foregroundColor: theme.colorScheme.error),
-          child: const Text('Remove'),
+          child: Text(context.l10n.actionRemove),
         ),
       ),
     );

--- a/lib/features/profiles/profile.dart
+++ b/lib/features/profiles/profile.dart
@@ -1,3 +1,4 @@
+import '../../core/l10n.dart';
 import '../../data/models/sonos_models.dart';
 import '../../data/sonos/speaker_settings.dart';
 
@@ -68,14 +69,19 @@ class EntitySnapshot {
   /// A short human label for the create checklist + profile tiles.
   String get label => names[primaryUuid] ?? primaryUuid;
 
-  String get kindLabel => switch (kind) {
-        EntityKind.homeTheater => 'Home theater',
-        EntityKind.single => 'Speaker',
-        // Reuse the group labels so the strings live in one place.
-        EntityKind.stereoPair => groupKindLabel(GroupKind.stereoPair),
-        EntityKind.zone => groupKindLabel(GroupKind.zone),
-        EntityKind.custom => groupKindLabel(GroupKind.custom),
-      };
+  // Context-less (this getter is read from widgets), so it resolves strings via
+  // the shared [appL10n] helper. Reuses the app-wide entity-kind keys — the same
+  // labels the state layer's progress steps use.
+  String get kindLabel {
+    final l10n = appL10n();
+    return switch (kind) {
+      EntityKind.homeTheater => l10n.entityKindHomeTheater,
+      EntityKind.stereoPair => l10n.entityKindStereoPair,
+      EntityKind.zone => l10n.entityKindZone,
+      EntityKind.custom => l10n.entityKindCustom,
+      EntityKind.single => l10n.entityKindSpeaker,
+    };
+  }
 
   /// Every UUID this entity bonds — used for pre-flight resolution + conflict
   /// detection. For an HT that's the coordinator + all satellites; for a pair

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
@@ -67,7 +68,7 @@ class _State extends ConsumerState<ProfileCreateScreen> {
   /// A helpful default that isn't already taken ("My setup", then "My setup 2",
   /// …) so New profile doesn't open on a name-collision error.
   String _defaultName(List<Profile> profiles) {
-    const base = 'My setup';
+    final base = context.l10n.profileDefaultName;
     if (!isProfileNameTaken(profiles, base)) return base;
     for (var i = 2;; i++) {
       final candidate = '$base $i';
@@ -95,13 +96,15 @@ class _State extends ConsumerState<ProfileCreateScreen> {
 
     if (system == null) {
       return Scaffold(
-        appBar: AppBar(title: Text(isResnapshot ? 'Re-snapshot' : 'New profile')),
-        body: const Center(
+        appBar: AppBar(
+            title: Text(isResnapshot
+                ? context.l10n.profileResnapshot
+                : context.l10n.profileNew)),
+        body: Center(
           child: Padding(
-            padding: EdgeInsets.all(32),
+            padding: const EdgeInsets.all(32),
             child: Text(
-              'Scan your system first (System tab), then create a '
-              'profile from it.',
+              context.l10n.profileScanFirstCreate,
               textAlign: TextAlign.center,
             ),
           ),
@@ -120,13 +123,15 @@ class _State extends ConsumerState<ProfileCreateScreen> {
     final canSave = name.isNotEmpty && !taken && anyIncluded && !_saving;
 
     return AppScaffold(
-      title: isResnapshot ? 'Re-snapshot' : 'New profile',
+      title: isResnapshot
+          ? context.l10n.profileResnapshot
+          : context.l10n.profileNew,
       bottomOverlay: _BottomButtonBar(
         label: _saving
-            ? 'Reading settings…'
+            ? context.l10n.profileReadingSettings
             : isResnapshot
-                ? 'Use snapshot'
-                : 'Create profile',
+                ? context.l10n.profileUseSnapshot
+                : context.l10n.profileCreate,
         onPressed: canSave ? () => _save(name, existing) : null,
       ),
       body: ListView(
@@ -135,10 +140,7 @@ class _State extends ConsumerState<ProfileCreateScreen> {
           if (isResnapshot) ...[
             // Non-destructive: nothing is written until the user saves on the
             // profile screen, so this is a light note, not a warning.
-            const InfoNote(
-              'Recapture your current setup, then review and save it '
-              'on the profile screen.',
-            ),
+            InfoNote(context.l10n.profileResnapshotNote),
             Gap.l,
           ] else
             // Name + appearance are edited on the profile screen for an existing
@@ -161,18 +163,12 @@ class _State extends ConsumerState<ProfileCreateScreen> {
           // re-snapshot the profile already exists and the detail screen owns
           // the review.
           if (!isResnapshot) ...[
-            const InfoNote(
-              'Applying a profile later rebuilds these speakers into this '
-              'layout. Any speaker that’s part of a different setup at that '
-              'time is removed from it first — which can dissolve another '
-              'stereo pair or zone and free its other speakers.',
-            ),
+            InfoNote(context.l10n.profileApplyPrimer),
             Gap.l,
           ],
-          const SectionHeader(
-            'Include',
-            helper: 'Pick which of your current home theaters, pairs and '
-                'rooms to capture in this profile.',
+          SectionHeader(
+            context.l10n.profileIncludeHeader,
+            helper: context.l10n.profileIncludeHelper,
           ),
           for (final e in _entities) ...[
             _SelectableEntityCard(
@@ -184,10 +180,9 @@ class _State extends ConsumerState<ProfileCreateScreen> {
             Gap.s,
           ],
           Gap.l,
-          const SectionHeader(
-            'Speaker settings',
-            helper: 'Optionally snapshot each speaker’s current settings and '
-                'restore them when this profile is applied.',
+          SectionHeader(
+            context.l10n.profileSpeakerSettingsHeader,
+            helper: context.l10n.profileSpeakerSettingsHelper,
           ),
           Card(
             margin: EdgeInsets.zero,
@@ -203,10 +198,8 @@ class _State extends ConsumerState<ProfileCreateScreen> {
                       borderRadius:
                           BorderRadius.vertical(top: Radius.circular(12))),
                   secondary: const Icon(Icons.tune),
-                  title: const Text('Save audio settings'),
-                  subtitle: const Text(
-                      'EQ, night sound, speech enhancement, sub & surround '
-                      'levels, lip sync & more'),
+                  title: Text(context.l10n.profileSaveAudio),
+                  subtitle: Text(context.l10n.profileSaveAudioSubtitle),
                 ),
                 const Divider(height: 1),
                 SwitchListTile(
@@ -216,9 +209,8 @@ class _State extends ConsumerState<ProfileCreateScreen> {
                       borderRadius:
                           BorderRadius.vertical(bottom: Radius.circular(12))),
                   secondary: const Icon(Icons.volume_up),
-                  title: const Text('Save volume'),
-                  subtitle: const Text(
-                      'Applying the profile will change how loud each speaker plays'),
+                  title: Text(context.l10n.profileSaveVolume),
+                  subtitle: Text(context.l10n.profileSaveVolumeSubtitle),
                 ),
               ],
             ),

--- a/lib/features/profiles/profile_detail_screen.dart
+++ b/lib/features/profiles/profile_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../state/sonos_controller.dart';
@@ -72,10 +73,10 @@ class _State extends ConsumerState<ProfileDetailScreen> {
         !taken;
 
     return AppScaffold(
-      title: 'Profile',
+      title: context.l10n.profileTitle,
       actions: [
         IconButton(
-          tooltip: 'Re-snapshot from current setup',
+          tooltip: context.l10n.profileResnapshotTooltip,
           onPressed: system == null ? null : () => _resnapshot(profile),
           icon: const Icon(Icons.cameraswitch),
         ),
@@ -86,7 +87,7 @@ class _State extends ConsumerState<ProfileDetailScreen> {
           ? FloatingActionButton.extended(
               onPressed: () => _save(profile, name),
               icon: const Icon(Icons.check),
-              label: const Text('Save'),
+              label: Text(context.l10n.actionSave),
             )
           : null,
       body: ListView(
@@ -104,12 +105,11 @@ class _State extends ConsumerState<ProfileDetailScreen> {
             }),
           ),
           Gap.l,
-          const SectionHeader('Included'),
+          SectionHeader(context.l10n.profileIncludedHeader),
           Text(
             entitiesChanged
-                ? 'Recaptured from your current setup — press Save to keep it.'
-                : 'Captured when the profile was created. Use the re-snapshot '
-                    'button (top right) to recapture from your current setup.',
+                ? context.l10n.profileRecapturedNote
+                : context.l10n.profileCapturedNote,
             style: theme.textTheme.bodySmall?.copyWith(
               color: entitiesChanged
                   ? theme.colorScheme.primary
@@ -149,7 +149,8 @@ class _State extends ConsumerState<ProfileDetailScreen> {
     // Stay on the page: clearing pending + the provider update make `changed`
     // false, so the Save FAB hides itself.
     setState(() => _pendingEntities = null);
-    messenger.showSnackBar(const SnackBar(content: Text('Profile saved')));
+    messenger.showSnackBar(
+        SnackBar(content: Text(context.l10n.profileSaved)));
   }
 }
 
@@ -161,6 +162,7 @@ Widget _entityCard(
   return EntityCard(
     model: EntityCardModel.fromSnapshot(system, e.toMember()),
     onTap: () => showEntitySheet(context, e, system),
-    footer: settingsBadges(audio: e.hasAudioSettings, volume: e.hasVolume),
+    footer: settingsBadges(context,
+        audio: e.hasAudioSettings, volume: e.hasVolume),
   );
 }

--- a/lib/features/profiles/profile_entity_detail_screen.dart
+++ b/lib/features/profiles/profile_entity_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../data/sonos/channel_map.dart';
@@ -29,7 +30,9 @@ class _EntitySheet extends StatelessWidget {
     // Prefer the live device type, fall back to the captured room name, then a
     // generic label (same fallback the entity cards use).
     String typeOf(String uuid) =>
-        system?.device(uuid)?.typeLabel ?? e.names[uuid] ?? 'Speaker';
+        system?.device(uuid)?.typeLabel ??
+        e.names[uuid] ??
+        context.l10n.entityKindSpeaker;
 
     return SheetScaffold(
       title: e.label,
@@ -96,7 +99,7 @@ Widget _savedSettings(
       Padding(
         padding: const EdgeInsets.fromLTRB(kPageGutter, 28, kPageGutter, 28),
         child: Text(
-          'No speaker settings saved in this profile.',
+          context.l10n.profileNoSettingsSaved,
           textAlign: TextAlign.center,
           style: muted,
         ),
@@ -108,7 +111,7 @@ Widget _savedSettings(
       if (i > 0) const Divider(height: 1),
       _SettingsBlock(
         title: typeOf(withSettings[i]),
-        role: _roleLabel(e, withSettings[i]),
+        role: _roleLabel(context.l10n, e, withSettings[i]),
         rows: e.settings[withSettings[i]]!.describe(),
       ),
     ],
@@ -116,7 +119,9 @@ Widget _savedSettings(
 }
 
 /// Short role of [uuid] within the entity, for the settings-card subtitle.
-String? _roleLabel(EntitySnapshot e, String uuid) {
+/// "Sub" is left untranslated — it's Sonos' product/channel token (like the
+/// L/R group-channel shorts).
+String? _roleLabel(AppLocalizations l10n, EntitySnapshot e, String uuid) {
   if (e.mapSet == null) return null;
   switch (e.kind) {
     case EntityKind.single:
@@ -129,7 +134,7 @@ String? _roleLabel(EntitySnapshot e, String uuid) {
       final ch = m.groupChannels[uuid];
       return ch == null ? null : groupChannelShort(ch);
     case EntityKind.homeTheater:
-      if (uuid == e.primaryUuid) return 'Soundbar';
+      if (uuid == e.primaryUuid) return l10n.profileRoleSoundbar;
       final m = e.toMember();
       final channels = m.channelAssignments.entries
           .where((a) => a.value == uuid)
@@ -138,9 +143,10 @@ String? _roleLabel(EntitySnapshot e, String uuid) {
       final parts = <String>[
         if (channels.contains(SonosChannel.leftFront) ||
             channels.contains(SonosChannel.rightFront))
-          'Front',
-        if (channels.contains(SonosChannel.leftRear)) 'Surround L',
-        if (channels.contains(SonosChannel.rightRear)) 'Surround R',
+          l10n.profileRoleFront,
+        if (channels.contains(SonosChannel.leftRear)) l10n.profileRoleSurroundL,
+        if (channels.contains(SonosChannel.rightRear))
+          l10n.profileRoleSurroundR,
         if (channels.contains(SonosChannel.sub)) 'Sub',
       ];
       return parts.isEmpty ? null : parts.join(' · ');

--- a/lib/features/profiles/profile_ui.dart
+++ b/lib/features/profiles/profile_ui.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_sficon/flutter_sficon.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import 'profile.dart';
 
@@ -219,9 +220,9 @@ class ProfileNameField extends StatelessWidget {
             onChanged: (_) => onChanged(),
             textCapitalization: TextCapitalization.sentences,
             decoration: InputDecoration(
-              labelText: 'Profile name',
+              labelText: context.l10n.profileNameLabel,
               border: const OutlineInputBorder(),
-              errorText: nameTaken ? 'A profile with this name exists' : null,
+              errorText: nameTaken ? context.l10n.profileNameTaken : null,
               visualDensity: VisualDensity.standard,
             ),
           ),
@@ -296,12 +297,12 @@ class ProfileCard extends StatelessWidget {
                     Text(profile.name, style: theme.textTheme.titleMedium),
                     const SizedBox(height: 4),
                     Text(
-                      summary.isEmpty ? 'No entities' : summary,
+                      summary.isEmpty ? context.l10n.profileNoEntities : summary,
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       style: theme.mutedText,
                     ),
-                    if (settingsBadges(
+                    if (settingsBadges(context,
                             audio: profile.hasAudioSettings,
                             volume: profile.hasVolume)
                         case final badges?) ...[
@@ -323,14 +324,19 @@ class ProfileCard extends StatelessWidget {
 /// The captured-settings chips ("Audio settings" / "Volume"), or null when
 /// neither is set. Shared by the profile tile (aggregate) and the per-entity
 /// cards on the detail screen.
-Widget? settingsBadges({required bool audio, required bool volume}) {
+Widget? settingsBadges(BuildContext context,
+    {required bool audio, required bool volume}) {
   if (!audio && !volume) return null;
   return Wrap(
     spacing: 6,
     runSpacing: 6,
     children: [
-      if (audio) const SettingsBadge(icon: Icons.tune, label: 'Audio settings'),
-      if (volume) const SettingsBadge(icon: Icons.volume_up, label: 'Volume'),
+      if (audio)
+        SettingsBadge(
+            icon: Icons.tune, label: context.l10n.profileBadgeAudio),
+      if (volume)
+        SettingsBadge(
+            icon: Icons.volume_up, label: context.l10n.profileBadgeVolume),
     ],
   );
 }
@@ -377,7 +383,7 @@ Future<(String, int)?> showAppearanceDialog(BuildContext context,
     context: context,
     builder: (ctx) => StatefulBuilder(
       builder: (ctx, setLocal) => AlertDialog(
-        title: const Text('Appearance'),
+        title: Text(context.l10n.profileAppearance),
         content: SingleChildScrollView(
           child: _AppearancePicker(
             iconId: icon,
@@ -389,10 +395,10 @@ Future<(String, int)?> showAppearanceDialog(BuildContext context,
         actions: [
           TextButton(
               onPressed: () => Navigator.pop(ctx),
-              child: const Text('Cancel')),
+              child: Text(context.l10n.actionCancel)),
           TextButton(
               onPressed: () => Navigator.pop(ctx, (icon, col)),
-              child: const Text('Done')),
+              child: Text(context.l10n.actionDone)),
         ],
       ),
     ),

--- a/lib/features/profiles/profile_widget.dart
+++ b/lib/features/profiles/profile_widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:home_widget/home_widget.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import 'profile.dart';
 import 'profile_store.dart';
@@ -195,6 +196,8 @@ class WidgetConfigApp extends StatelessWidget {
         theme: AppTheme.light(null),
         darkTheme: AppTheme.dark(null),
         themeMode: ThemeMode.system,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
         home: const _WidgetConfigScreen(),
       );
 }
@@ -244,14 +247,14 @@ class _WidgetConfigScreenState extends State<_WidgetConfigScreen> {
   Widget build(BuildContext context) {
     final list = _ordered;
     return Scaffold(
-      appBar: AppBar(title: const Text('Pick profiles')),
+      appBar: AppBar(title: Text(context.l10n.profileWidgetPickTitle)),
       body: list == null
           ? const Center(child: CircularProgressIndicator())
           : list.isEmpty
-              ? const Center(
+              ? Center(
                   child: Padding(
-                    padding: EdgeInsets.all(32),
-                    child: Text('No profiles yet — create one in Sonority first.',
+                    padding: const EdgeInsets.all(32),
+                    child: Text(context.l10n.profileWidgetEmpty,
                         textAlign: TextAlign.center),
                   ),
                 )
@@ -261,12 +264,9 @@ class _WidgetConfigScreenState extends State<_WidgetConfigScreen> {
                       child: ListView(
                         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
                         children: [
-                          const Padding(
-                            padding: EdgeInsets.fromLTRB(4, 8, 4, 12),
-                            child: Text(
-                              'Pick the profiles to show. Reorder them in the '
-                              'Profiles tab.',
-                            ),
+                          Padding(
+                            padding: const EdgeInsets.fromLTRB(4, 8, 4, 12),
+                            child: Text(context.l10n.profileWidgetPickHelper),
                           ),
                           for (final p in list)
                             Padding(
@@ -292,8 +292,9 @@ class _WidgetConfigScreenState extends State<_WidgetConfigScreen> {
                         child: FilledButton(
                           onPressed: _checked.isEmpty ? null : _confirm,
                           child: Text(_checked.isEmpty
-                              ? 'Select at least one'
-                              : 'Add ${_checked.length} to widget'),
+                              ? context.l10n.profileWidgetSelectAtLeastOne
+                              : context.l10n
+                                  .profileWidgetAddCount(_checked.length)),
                         ),
                       ),
                     ),

--- a/lib/features/profiles/profiles_screen.dart
+++ b/lib/features/profiles/profiles_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
+import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/bonding_progress_screen.dart';
 import '../widgets/app_scaffold.dart';
@@ -22,7 +24,9 @@ class ProfilesScreen extends ConsumerWidget {
 
     final body = profiles.when(
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('Couldn’t load profiles: $e')),
+      error: (e, _) => Center(
+          child: Text(
+              context.l10n.profileLoadError(localizedError(context.l10n, e)))),
       data: (list) => list.isEmpty
           ? const _EmptyState()
           : ReorderableListView.builder(
@@ -59,17 +63,20 @@ class ProfilesScreen extends ConsumerWidget {
                           IconButton.filled(
                             onPressed: () =>
                                 applyProfileInteractive(context, ref, p),
-                            tooltip: 'Apply',
+                            tooltip: context.l10n.actionApply,
                             icon: const Icon(Icons.play_arrow),
                           ),
                           PopupMenuButton<String>(
                             onSelected: (v) => v == 'edit'
                                 ? context.go('/profiles/edit/${p.id}')
                                 : _confirmDelete(context, ref, p),
-                            itemBuilder: (_) => const [
-                              PopupMenuItem(value: 'edit', child: Text('Edit')),
+                            itemBuilder: (_) => [
                               PopupMenuItem(
-                                  value: 'delete', child: Text('Delete')),
+                                  value: 'edit',
+                                  child: Text(context.l10n.profileEdit)),
+                              PopupMenuItem(
+                                  value: 'delete',
+                                  child: Text(context.l10n.actionDelete)),
                             ],
                           ),
                         ],
@@ -82,17 +89,17 @@ class ProfilesScreen extends ConsumerWidget {
     );
 
     return AppScaffold(
-      title: 'Profiles',
+      title: context.l10n.tabProfiles,
       floatingActionButton: FloatingActionButton.extended(
         onPressed: hasSystem
             ? () => context.go('/profiles/new')
             : () => ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Scan your system first (System tab).'),
+                SnackBar(
+                  content: Text(context.l10n.profileScanFirst),
                 ),
               ),
         icon: const Icon(Icons.add),
-        label: const Text('New profile'),
+        label: Text(context.l10n.profileNew),
       ),
       body: body,
     );
@@ -105,9 +112,9 @@ class ProfilesScreen extends ConsumerWidget {
   ) async {
     final ok = await confirmDialog(
       context,
-      title: 'Delete “${p.name}”?',
-      message: 'This removes the saved profile. Your speakers are not changed.',
-      confirmLabel: 'Delete',
+      title: context.l10n.profileDeleteConfirm(p.name),
+      message: context.l10n.profileDeleteMessage,
+      confirmLabel: context.l10n.actionDelete,
     );
     if (ok) await ref.read(profilesProvider.notifier).remove(p.id);
   }
@@ -122,7 +129,7 @@ Future<void> applyProfileInteractive(
   final system = ref.read(sonosControllerProvider).value;
   if (system == null) {
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Scan your system first (System tab).')),
+      SnackBar(content: Text(context.l10n.profileScanFirst)),
     );
     return;
   }
@@ -144,7 +151,7 @@ Future<void> applyProfileInteractive(
   // No success toast — the progress screen already shows the outcome.
   await showBondingProgress(
     context,
-    title: 'Applying “${profile.name}”',
+    title: context.l10n.profileApplying(profile.name),
     run: () => ctrl.applyProfile(profile, skip: skip),
   );
 }
@@ -159,7 +166,7 @@ Future<void> applyProfileFromLaunch(
   final ctrl = ref.read(sonosControllerProvider.notifier);
   await showBondingProgress(
     context,
-    title: 'Applying “${profile.name}”',
+    title: context.l10n.profileApplying(profile.name),
     run: () => ctrl.scanAndApplyProfile(
       profile,
       confirmIssues: (issues) async {
@@ -192,12 +199,11 @@ class _EmptyState extends StatelessWidget {
               color: theme.colorScheme.primary,
             ),
             Gap.m,
-            Text('No profiles yet', style: theme.textTheme.titleLarge),
+            Text(context.l10n.profileEmptyTitle,
+                style: theme.textTheme.titleLarge),
             Gap.s,
             Text(
-              'A profile snapshots your current home theaters, stereo pairs and '
-              'rooms so you can rebuild them in one tap — handy after moving '
-              'speakers away. Tap “New profile” to capture your setup now.',
+              context.l10n.profileEmptyBody,
               textAlign: TextAlign.center,
               style: theme.textTheme.bodyMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
@@ -222,16 +228,14 @@ class _ApplyConfirmDialog extends StatelessWidget {
     final applicable = issues.where((i) => !i.blocked).toList();
 
     return AlertDialog(
-      title: Text('Apply “${profile.name}”?'),
+      title: Text(context.l10n.profileApplyConfirmTitle(profile.name)),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              'This re-bonds speakers on your live system and may take a while '
-              '(each step waits for Sonos to settle). Trueplay may need '
-              're-tuning afterward.',
+              context.l10n.profileApplyConfirmBody,
               style: theme.textTheme.bodySmall,
             ),
             Gap.m,
@@ -248,19 +252,20 @@ class _ApplyConfirmDialog extends StatelessWidget {
                 title: Text('${i.entity.kindLabel}: ${i.entity.label}'),
                 subtitle: i.blocked
                     ? Text(
-                        'Missing: ${i.missing.toSet().join(', ')} — will be skipped',
+                        context.l10n.profileIssueMissing(
+                            i.missing.toSet().join(', ')),
                         style: TextStyle(color: theme.colorScheme.error),
                       )
                     : i.conflicts.isNotEmpty
-                    ? Text('Will free: ${i.conflicts.toSet().join(', ')}')
+                    ? Text(context.l10n
+                        .profileIssueFree(i.conflicts.toSet().join(', ')))
                     : null,
               ),
             if (applicable.isEmpty)
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text(
-                  'Nothing can be applied — all entities are missing '
-                  'speakers.',
+                  context.l10n.profileNothingApplicable,
                   style: TextStyle(color: theme.colorScheme.error),
                 ),
               )
@@ -268,8 +273,8 @@ class _ApplyConfirmDialog extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(top: 8),
                 child: Text(
-                  'Will apply ${applicable.length} of ${issues.length} '
-                  'entities; ${blocked.length} skipped.',
+                  context.l10n.profileApplySummary(
+                      applicable.length, issues.length, blocked.length),
                   style: theme.textTheme.bodySmall,
                 ),
               ),
@@ -279,13 +284,13 @@ class _ApplyConfirmDialog extends StatelessWidget {
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context, false),
-          child: const Text('Cancel'),
+          child: Text(context.l10n.actionCancel),
         ),
         TextButton(
           onPressed: applicable.isEmpty
               ? null
               : () => Navigator.pop(context, true),
-          child: const Text('Apply'),
+          child: Text(context.l10n.actionApply),
         ),
       ],
     );

--- a/lib/features/room/room_screen.dart
+++ b/lib/features/room/room_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
+import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/busy_view.dart';
 import '../widgets/identify_controls.dart';
@@ -27,9 +29,10 @@ class _RoomSheet extends ConsumerWidget {
     final member = system?.memberByUuid(uuid);
 
     if (member == null) {
-      return const SheetScaffold(
-        title: 'Room',
-        body: Padding(padding: EdgeInsets.all(24), child: MissingRoomView()),
+      return SheetScaffold(
+        title: context.l10n.roomTitle,
+        body: const Padding(
+            padding: EdgeInsets.all(24), child: MissingRoomView()),
       );
     }
 
@@ -39,12 +42,12 @@ class _RoomSheet extends ConsumerWidget {
 
     return SheetScaffold(
       title: member.zoneName,
-      subtitle: 'Room',
+      subtitle: context.l10n.roomTitle,
       trailing: device == null
           ? null
           : IconButton(
               icon: const Icon(Icons.drive_file_rename_outline),
-              tooltip: 'Rename room',
+              tooltip: context.l10n.roomRenameTooltip,
               onPressed: () => _rename(context, ref, device, member.zoneName),
             ),
       body: Column(
@@ -75,12 +78,14 @@ Future<void> _rename(BuildContext context, WidgetRef ref, SonosDevice device,
   final name = await showRenameDialog(context, current);
   if (name == null || !context.mounted) return;
   final messenger = ScaffoldMessenger.of(context);
+  final l10n = context.l10n;
   try {
     await ref
         .read(sonosControllerProvider.notifier)
         .renameRoom(device: device, name: name);
-    messenger.showSnackBar(SnackBar(content: Text('Renamed to “$name”.')));
+    messenger.showSnackBar(SnackBar(content: Text(l10n.roomRenamedTo(name))));
   } catch (e) {
-    messenger.showSnackBar(SnackBar(content: Text('Failed: $e')));
+    messenger.showSnackBar(
+        SnackBar(content: Text(l10n.roomRenameFailed(localizedError(l10n, e)))));
   }
 }

--- a/lib/features/widgets/apply_progress_view.dart
+++ b/lib/features/widgets/apply_progress_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/sonos/apply_progress.dart';
 import 'busy_spinner.dart';
@@ -44,9 +45,8 @@ class ApplyProgressView extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(kPageGutter, 8, kPageGutter, 0),
           child: Text(
             failed
-                ? 'Something went wrong — see the step below.'
-                : 'Bonding can take ~15–20s per step while Sonos applies and '
-                    're-reads the layout.',
+                ? context.l10n.widgetsSomethingWentWrong
+                : context.l10n.widgetsBondingTakesTime,
             style: theme.mutedText,
           ),
         ),
@@ -167,7 +167,7 @@ class _TimelineRow extends StatelessWidget {
                   if (step.isFailed && !hasFailedChild)
                     Padding(
                       padding: const EdgeInsets.only(top: 2),
-                      child: Text(step.detail ?? 'Failed.',
+                      child: Text(step.detail ?? context.l10n.widgetsStepFailed,
                           style: theme.textTheme.bodyMedium
                               ?.copyWith(color: scheme.error)),
                     )
@@ -179,7 +179,7 @@ class _TimelineRow extends StatelessWidget {
                           const BusySpinner(size: 14),
                           Gap.s,
                           Expanded(
-                            child: Text(step.detail ?? 'Working…',
+                            child: Text(step.detail ?? context.l10n.widgetsStepWorking,
                                 style: theme.textTheme.bodyMedium?.copyWith(
                                     color: scheme.onSurfaceVariant)),
                           ),

--- a/lib/features/widgets/bondable_speaker_tile.dart
+++ b/lib/features/widgets/bondable_speaker_tile.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import '../../data/models/sonos_models.dart';
-
-/// Shown wherever an unreachable speaker ([SonosDevice.reachable] == false)
-/// surfaces — we have it from the topology but couldn't read its description.
-const unreachableSpeakerHint =
-    'Couldn’t read this speaker’s details — check it’s powered on and on the '
-    'same network.';
 
 /// A selectable speaker row used by the "pick speakers" lists (dedicated-fronts
 /// and stereo-pair flows).
@@ -48,7 +43,7 @@ class BondableSpeakerTile extends StatelessWidget {
         onChanged: null,
         title: Text(device.roomName),
         subtitle: Text(
-          unreachableSpeakerHint,
+          context.l10n.widgetsUnreachableSpeakerHint,
           style: TextStyle(color: scheme.error),
         ),
         controlAffinity: ListTileControlAffinity.leading,

--- a/lib/features/widgets/bonding_progress_screen.dart
+++ b/lib/features/widgets/bonding_progress_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/sonos/cancellation.dart';
 import '../../state/sonos_controller.dart';
@@ -113,7 +114,7 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
     await Clipboard.setData(ClipboardData(text: log));
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Logs copied to clipboard.')));
+          SnackBar(content: Text(context.l10n.bondingLogsCopied)));
     }
   }
 
@@ -133,12 +134,14 @@ class _BondingProgressScreenState extends ConsumerState<BondingProgressScreen> {
           title: Text(widget.title),
           actions: [
             IconButton(
-              tooltip: 'Copy logs',
+              tooltip: context.l10n.bondingCopyLogs,
               onPressed: _copyLogs,
               icon: const Icon(Icons.copy_all),
             ),
             IconButton(
-              tooltip: _showLogs ? 'Show steps' : 'Show raw log',
+              tooltip: _showLogs
+                  ? context.l10n.bondingShowSteps
+                  : context.l10n.bondingShowRawLog,
               onPressed: () => setState(() => _showLogs = !_showLogs),
               icon: Icon(_showLogs
                   ? Icons.view_timeline_outlined
@@ -197,7 +200,7 @@ class _RawLogViewState extends ConsumerState<_RawLogView> {
     });
     if (lines.isEmpty) {
       return Center(
-        child: Text('No log output yet.', style: theme.mutedText),
+        child: Text(context.l10n.bondingNoLogOutput, style: theme.mutedText),
       );
     }
     return Scrollbar(
@@ -242,7 +245,8 @@ class _BottomBar extends StatelessWidget {
         onPressed: aborting ? null : onAbort,
         style: FilledButton.styleFrom(
             backgroundColor: scheme.error, foregroundColor: scheme.onError),
-        child: Text(aborting ? 'Aborting…' : 'Abort'),
+        child: Text(
+            aborting ? context.l10n.actionAborting : context.l10n.actionAbort),
       );
     } else {
       // Color Done by result: green on success, red/error on failure (or abort).
@@ -256,7 +260,7 @@ class _BottomBar extends StatelessWidget {
               style: FilledButton.styleFrom(
                   backgroundColor: doneColor,
                   foregroundColor: failed ? scheme.onError : Colors.white),
-              child: const Text('Done'),
+              child: Text(context.l10n.actionDone),
             ),
           ),
           if (failed) ...[
@@ -265,7 +269,7 @@ class _BottomBar extends StatelessWidget {
               child: FilledButton.icon(
                 onPressed: onRetry,
                 icon: const Icon(Icons.refresh),
-                label: const Text('Retry'),
+                label: Text(context.l10n.actionRetry),
               ),
             ),
           ],

--- a/lib/features/widgets/busy_view.dart
+++ b/lib/features/widgets/busy_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 
 /// A friendly full-screen busy state with a title + explanation, so long
@@ -61,11 +62,11 @@ class MissingRoomView extends StatelessWidget {
             children: [
               const Icon(Icons.help_outline, size: 56),
               Gap.m,
-              const Text('This room is no longer available. Rescan to refresh.'),
+              Text(context.l10n.widgetsRoomNoLongerAvailable),
               Gap.l,
               FilledButton(
                 onPressed: () => context.go('/'),
-                child: const Text('Back to scan'),
+                child: Text(context.l10n.widgetsBackToScan),
               ),
             ],
           ),

--- a/lib/features/widgets/confirm_dialog.dart
+++ b/lib/features/widgets/confirm_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
+
 /// Shared yes/no confirmation dialog. Returns true only if the user taps the
 /// confirm action (false on cancel or dismiss). [destructive] tints the confirm
 /// label with the error color; both actions are `TextButton`s so they stay
@@ -10,7 +12,7 @@ Future<bool> confirmDialog(
   required String title,
   required String message,
   required String confirmLabel,
-  String cancelLabel = 'Cancel',
+  String? cancelLabel,
   IconData? icon,
   bool destructive = true,
 }) async {
@@ -23,7 +25,7 @@ Future<bool> confirmDialog(
       actions: [
         TextButton(
             onPressed: () => Navigator.pop(ctx, false),
-            child: Text(cancelLabel)),
+            child: Text(cancelLabel ?? ctx.l10n.actionCancel)),
         TextButton(
           onPressed: () => Navigator.pop(ctx, true),
           style: destructive

--- a/lib/features/widgets/diagram_labels.dart
+++ b/lib/features/widgets/diagram_labels.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import 'member_channel_card.dart';
@@ -17,7 +18,7 @@ String? typeForChannel(
     {Map<String, String>? names}) {
   final uuid = member.channelAssignments[channel];
   if (uuid == null) return null;
-  return system?.device(uuid)?.typeLabel ?? names?[uuid] ?? 'Speaker';
+  return system?.device(uuid)?.typeLabel ?? names?[uuid] ?? appL10n().widgetsSpeaker;
 }
 
 /// Whether a speaker is currently bonded to [channel].

--- a/lib/features/widgets/entity_cards.dart
+++ b/lib/features/widgets/entity_cards.dart
@@ -1,11 +1,20 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
-import 'bondable_speaker_tile.dart';
 import 'diagram_labels.dart';
 import 'entity_icons.dart';
 import 'pill_chip.dart';
+
+/// Localized label for a group's [GroupKind] (card subtitles). The engine's
+/// [groupKindLabel] stays English for CLI tools / logs.
+String groupKindL10n(AppLocalizations l10n, GroupKind k) => switch (k) {
+      GroupKind.stereoPair => l10n.entityKindStereoPair,
+      GroupKind.zone => l10n.entityKindZone,
+      GroupKind.custom => l10n.entityKindCustom,
+      GroupKind.none => l10n.entityKindGroup,
+    };
 
 // -----------------------------------------------------------------------------
 // View models
@@ -41,7 +50,7 @@ class TheaterCardModel {
   factory TheaterCardModel.fromMember(SonosSystem system, ZoneGroupMember m) =>
       TheaterCardModel(
         title: m.zoneName,
-        soundbarLabel: system.device(m.uuid)?.modelName ?? 'Soundbar',
+        soundbarLabel: system.device(m.uuid)?.modelName ?? appL10n().widgetsSoundbar,
         hasFronts: hasChannel(m, SonosChannel.leftFront) ||
             hasChannel(m, SonosChannel.rightFront),
         hasSurrounds: hasChannel(m, SonosChannel.leftRear) ||
@@ -81,16 +90,17 @@ class EntityCardModel {
 
   static EntityCardModel _build(SonosSystem? system, ZoneGroupMember m,
       {required bool reachable}) {
+    final l10n = appL10n();
     if (m.isHomeTheater) {
-      final type = system?.device(m.uuid)?.typeLabel ?? 'Soundbar';
+      final type = system?.device(m.uuid)?.typeLabel ?? l10n.widgetsSoundbar;
       final features = [
         if (hasChannel(m, SonosChannel.leftFront) ||
             hasChannel(m, SonosChannel.rightFront))
-          'Fronts',
+          l10n.widgetsFronts,
         if (hasChannel(m, SonosChannel.leftRear) ||
             hasChannel(m, SonosChannel.rightRear))
-          'Surrounds',
-        if (hasChannel(m, SonosChannel.sub)) 'Subwoofer',
+          l10n.widgetsSurrounds,
+        if (hasChannel(m, SonosChannel.sub)) l10n.widgetsSubwoofer,
       ];
       return EntityCardModel(
         icon: Icons.surround_sound,
@@ -104,9 +114,9 @@ class EntityCardModel {
         title: m.zoneName,
         // No per-speaker type list — tap through for speaker details.
         subtitle: [
-          groupKindLabel(m.groupKind),
-          '${m.groupChannels.length} speakers',
-          if (m.subUuid != null) 'Sub',
+          groupKindL10n(l10n, m.groupKind),
+          l10n.widgetsNSpeakers(m.groupChannels.length),
+          if (m.subUuid != null) l10n.widgetsSub,
         ].join(' · '),
       );
     }
@@ -116,7 +126,7 @@ class EntityCardModel {
       // The device may not be on the LAN (a profile snapshots a config that
       // isn't necessarily live), so fall back to a generic label rather than an
       // empty subtitle.
-      subtitle: system?.device(m.uuid)?.typeLabel ?? 'Standalone speaker',
+      subtitle: system?.device(m.uuid)?.typeLabel ?? l10n.widgetsStandaloneSpeaker,
       reachable: reachable,
     );
   }
@@ -206,7 +216,8 @@ class EntityCard extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final unreachable = !model.reachable;
     final tap = unreachable ? null : onTap;
-    final text = unreachable ? unreachableSpeakerHint : model.subtitle;
+    final text =
+        unreachable ? context.l10n.widgetsUnreachableSpeakerHint : model.subtitle;
     return Card(
       margin: const EdgeInsets.only(bottom: kCardGap),
       child: ListTile(
@@ -249,22 +260,28 @@ class _GroupChips extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
+    final l10n = context.l10n;
     final chips = <Widget>[
       if (hasFronts)
-        PillChip(icon: Icons.speaker, text: 'Fronts', color: scheme.primary),
+        PillChip(
+            icon: Icons.speaker,
+            text: l10n.widgetsFronts,
+            color: scheme.primary),
       if (hasSurrounds)
         PillChip(
             icon: Icons.surround_sound,
-            text: 'Surrounds',
+            text: l10n.widgetsSurrounds,
             color: scheme.primary),
       if (hasSub)
         PillChip(
-            icon: Icons.graphic_eq, text: 'Subwoofer', color: scheme.primary),
+            icon: Icons.graphic_eq,
+            text: l10n.widgetsSubwoofer,
+            color: scheme.primary),
     ];
     if (chips.isEmpty) {
       chips.add(PillChip(
         icon: Icons.info_outline,
-        text: 'No extra speakers',
+        text: l10n.widgetsNoExtraSpeakers,
         color: scheme.onSurfaceVariant,
       ));
     }

--- a/lib/features/widgets/identify_controls.dart
+++ b/lib/features/widgets/identify_controls.dart
@@ -2,8 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/l10n.dart';
 import '../../data/models/sonos_models.dart';
 import '../../data/sonos/identify_service.dart';
+import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import 'busy_spinner.dart';
 
@@ -27,7 +29,7 @@ class IdentifyButtons extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         IconButton(
-          tooltip: 'Blink the light',
+          tooltip: context.l10n.widgetsBlinkLightTooltip,
           onPressed: busy ? null : onBlink,
           icon: busy
               ? const BusySpinner()
@@ -35,7 +37,7 @@ class IdentifyButtons extends StatelessWidget {
         ),
         if (onChime != null)
           IconButton(
-            tooltip: 'Play a test chime',
+            tooltip: context.l10n.widgetsChimeTooltip,
             onPressed: busy ? null : onChime,
             icon: const Icon(Icons.volume_up_outlined),
           ),
@@ -68,13 +70,13 @@ mixin IdentifyMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
   /// Blinks a speaker's status LED so the user can tell which physical box it
   /// is. The default identify action — silent and works on every platform.
   Future<void> identify(SonosDevice device) =>
-      _run(device, '💡 Blinking the light on ${device.roomName}…', () async {
+      _run(device, context.l10n.widgetsBlinkingLight(device.roomName), () async {
         await ref.read(ledIdentifyProvider).blink(device.ip!);
       });
 
   /// Plays an audio chime (mobile only) as an audible alternative to the blink.
   Future<void> playChime(SonosDevice device) =>
-      _run(device, '🔊 Playing a chime on ${device.roomName}…', () async {
+      _run(device, context.l10n.widgetsPlayingChime(device.roomName), () async {
         await ref.read(identifyServiceProvider).chirp(device.ip!);
       });
 
@@ -97,9 +99,10 @@ mixin IdentifyMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
     Future<void> Function() action,
   ) async {
     final messenger = ScaffoldMessenger.of(context);
+    final l10n = context.l10n;
     if (device.ip == null) {
-      messenger.showSnackBar(
-          SnackBar(content: Text('No address for ${device.roomName}.')));
+      messenger.showSnackBar(SnackBar(
+          content: Text(l10n.widgetsNoAddressFor(device.roomName))));
       return;
     }
     setState(() => _identifyingUuid = device.uuid);
@@ -110,11 +113,13 @@ mixin IdentifyMixin<T extends ConsumerStatefulWidget> on ConsumerState<T> {
     try {
       await action();
     } on SpeakerUnreachable catch (e) {
-      messenger.showSnackBar(
-          SnackBar(content: Text('$e'), duration: const Duration(seconds: 6)));
+      messenger.showSnackBar(SnackBar(
+          content: Text(localizedError(l10n, e)),
+          duration: const Duration(seconds: 6)));
     } catch (e) {
       messenger.showSnackBar(SnackBar(
-          content: Text('Couldn’t identify ${device.roomName}: $e')));
+          content: Text(l10n.widgetsCouldntIdentify(
+              device.roomName, localizedError(l10n, e)))));
     } finally {
       if (mounted) setState(() => _identifyingUuid = null);
     }

--- a/lib/features/widgets/refresh_icon_button.dart
+++ b/lib/features/widgets/refresh_icon_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import 'busy_spinner.dart';
 
 /// An app-bar refresh button that shows a spinner while its async [onRefresh]
@@ -35,7 +36,7 @@ class _RefreshIconButtonState extends State<RefreshIconButton> {
       );
     }
     return IconButton(
-      tooltip: 'Refresh',
+      tooltip: context.l10n.widgetsRefresh,
       onPressed: _run,
       icon: const Icon(Icons.refresh),
     );

--- a/lib/features/widgets/rename_dialog.dart
+++ b/lib/features/widgets/rename_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
+
 /// Prompts for a new room name, pre-filled with [current]. Returns the trimmed
 /// new name, or null if cancelled / unchanged. Shared by the room and
 /// home-theater detail pages.
@@ -8,20 +10,21 @@ Future<String?> showRenameDialog(BuildContext context, String current) async {
   final result = await showDialog<String>(
     context: context,
     builder: (ctx) => AlertDialog(
-      title: const Text('Rename room'),
+      title: Text(ctx.l10n.widgetsRenameRoomTitle),
       content: TextField(
         controller: controller,
         autofocus: true,
         textCapitalization: TextCapitalization.sentences,
-        decoration: const InputDecoration(labelText: 'Room name'),
+        decoration: InputDecoration(labelText: ctx.l10n.widgetsRoomNameLabel),
         onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
       ),
       actions: [
         TextButton(
-            onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
+            onPressed: () => Navigator.pop(ctx),
+            child: Text(ctx.l10n.actionCancel)),
         TextButton(
             onPressed: () => Navigator.pop(ctx, controller.text.trim()),
-            child: const Text('Save')),
+            child: Text(ctx.l10n.actionSave)),
       ],
     ),
   );

--- a/lib/features/widgets/sheet_scaffold.dart
+++ b/lib/features/widgets/sheet_scaffold.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import 'app_scaffold.dart' show ScrolledUnderDivider;
 
@@ -61,7 +62,7 @@ class _SheetHeader extends StatelessWidget {
           if (trailing != null) trailing!,
           IconButton(
             icon: const Icon(Icons.close),
-            tooltip: 'Close',
+            tooltip: context.l10n.actionClose,
             onPressed: () => Navigator.of(context).pop(),
           ),
         ],

--- a/lib/features/widgets/speaker_diagram.dart
+++ b/lib/features/widgets/speaker_diagram.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 
 /// A simple top-down room diagram showing the soundbar and the currently
@@ -52,7 +53,7 @@ class SpeakerDiagram extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 6),
-            Text(soundbarLabel ?? 'TV / Soundbar',
+            Text(soundbarLabel ?? context.l10n.widgetsTvSoundbar,
                 style: Theme.of(context)
                     .textTheme
                     .labelSmall

--- a/lib/features/widgets/trueplay_control.dart
+++ b/lib/features/widgets/trueplay_control.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import '../../data/sonos/room_calibration.dart';
@@ -74,20 +75,23 @@ class _TrueplayControlState extends ConsumerState<TrueplayControl> {
     // tuned, instead of getting stuck looking "partially on / 3/5".
     final isOn = enabledCount > 0;
 
+    final l10n = context.l10n;
     final String subtitle;
     if (busy && known.isEmpty) {
-      subtitle = 'Checking…';
+      subtitle = l10n.widgetsTrueplayChecking;
     } else if (tunedCount == 0) {
-      subtitle = 'Not tuned — run Trueplay once in the Sonos app (iOS).';
+      subtitle = l10n.widgetsTrueplayNotTuned;
     } else if (withIp.length == 1) {
       // Single speaker — the x/y counter adds nothing.
-      subtitle = isOn ? 'Active' : 'Tuned · off';
+      subtitle = isOn ? l10n.widgetsTrueplayActive : l10n.widgetsTrueplayTunedOff;
     } else {
       // Multi-speaker (HT / pair): always show the active counter, plus tuned
       // coverage when some bonded speakers have no stored tuning at all.
-      final parts = <String>['$enabledCount/${withIp.length} active'];
+      final parts = <String>[
+        l10n.widgetsTrueplayActiveCount(enabledCount, withIp.length)
+      ];
       if (tunedCount < withIp.length) {
-        parts.add('$tunedCount/${withIp.length} tuned');
+        parts.add(l10n.widgetsTrueplayTunedCount(tunedCount, withIp.length));
       }
       subtitle = parts.join(' · ');
     }

--- a/lib/features/widgets/version_badge.dart
+++ b/lib/features/widgets/version_badge.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../core/l10n.dart';
 import '../../core/theme.dart';
 import 'sheet_scaffold.dart';
 
@@ -77,7 +78,7 @@ Future<void> showVersionSheet(BuildContext context, PackageInfo info) {
     context,
     SheetScaffold(
       fill: true,
-      title: 'Changelog',
+      title: context.l10n.widgetsChangelog,
       trailing: _VersionPill(fullVersionLabel(info)),
       body: FutureBuilder<String>(
         future: rootBundle.loadString('CHANGELOG.md'),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,716 @@
+{
+  "@@locale": "en",
+  "tabSystem": "System",
+  "tabProfiles": "Profiles",
+  "actionCancel": "Cancel",
+  "actionDone": "Done",
+  "actionDelete": "Delete",
+  "actionRemove": "Remove",
+  "actionRename": "Rename",
+  "actionApply": "Apply",
+  "actionRetry": "Retry",
+  "actionAdd": "Add",
+  "actionSave": "Save",
+  "actionClose": "Close",
+  "actionBack": "Back",
+  "actionNext": "Next",
+  "actionContinue": "Continue",
+  "actionOk": "OK",
+  "actionAbort": "Abort",
+  "actionAborting": "Aborting…",
+  "bondingCopyLogs": "Copy logs",
+  "bondingShowSteps": "Show steps",
+  "bondingShowRawLog": "Show raw log",
+  "bondingLogsCopied": "Logs copied to clipboard.",
+  "bondingNoLogOutput": "No log output yet.",
+  "errSystemNotFound": "Couldn’t find your Sonos system on the network.",
+  "errNoDevicesFound": "No Sonos devices found. Check Wi-Fi and local network access.",
+  "errDescriptionsUnreadable": "Found Sonos players but could not read their descriptions.",
+  "errTopologyUnreadable": "Could not read the Sonos topology from any player.",
+  "errEntityNotOnNetwork": "“{name}” isn’t on the network.",
+  "@errEntityNotOnNetwork": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "errCoordinatorNotOnNetwork": "“{name}” coordinator isn’t on the network.",
+  "@errCoordinatorNotOnNetwork": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "errSpeakerInEntityNotOnNetwork": "A speaker in “{name}” isn’t on the network.",
+  "@errSpeakerInEntityNotOnNetwork": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "errSubNotOnNetwork": "The Sub for “{name}” isn’t on the network.",
+  "@errSubNotOnNetwork": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "errSoundbarNotOnNetwork": "Soundbar for “{name}” isn’t on the network.",
+  "@errSoundbarNotOnNetwork": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "errEntityMissingSpeakers": "“{name}” is missing speakers.",
+  "@errEntityMissingSpeakers": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "errMalformedGroup": "Stored group is malformed.",
+  "errMalformedHomeTheater": "Stored home theater is malformed.",
+  "errDidNotForm": "Sonos did not form “{name}”.",
+  "@errDidNotForm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "errDidNotCreateGroup": "Sonos did not create the group — a speaker may be incompatible.",
+  "errDidNotSeparate": "Sonos did not separate the group — try again.",
+  "errDidNotRemove": "Sonos did not remove the {label} — try again.",
+  "@errDidNotRemove": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "errGroupNeedsTwo": "A group needs at least 2 speakers.",
+  "errSpeakerIpUnknown": "Speaker IP unknown; rescan and retry.",
+  "errSoundbarIpUnknown": "Soundbar IP unknown; rescan and retry.",
+  "errCoordinatorIpUnknown": "Coordinator IP unknown; rescan and retry.",
+  "errBondingIncomplete": "Bonding did not complete — these channels never joined: {channels}. Try again, or finish in the Sonos app.",
+  "@errBondingIncomplete": {
+    "placeholders": {
+      "channels": {
+        "type": "String"
+      }
+    }
+  },
+  "errNoLanIpForChime": "No LAN IP found to serve the chime from.",
+  "errCannotBlinkLight": "Could not reach the speaker to blink its light.",
+  "errTimeout": "The speaker didn’t respond in time. It may still be settling — try again in a moment.",
+  "errSonosBusy": "Sonos is busy rearranging speakers right now. Wait a moment and try again.",
+  "errUnsupportedCombo": "Sonos wouldn’t bond these speakers this way (unsupported combination).",
+  "errInvalidRequest": "Sonos rejected the request as invalid.",
+  "errSonosCode": "Sonos reported an error (code {code}). See the raw log for details.",
+  "@errSonosCode": {
+    "placeholders": {
+      "code": {
+        "type": "String"
+      }
+    }
+  },
+  "errSonosGeneric": "Sonos reported an error. See the raw log for details.",
+  "errAborted": "Aborted",
+  "errChimeUnreachable": "The speaker could not reach your phone to play the sound. Make sure your phone and speakers are on the same Wi‑Fi network. (Android emulators can’t reach speakers on your LAN — use a real device.)",
+  "entityKindHomeTheater": "Home theater",
+  "entityKindStereoPair": "Stereo pair",
+  "entityKindZone": "Zone",
+  "entityKindCustom": "Custom group",
+  "entityKindSpeaker": "Speaker",
+  "entityKindGroup": "Group",
+  "stepSetUpHomeTheater": "Set up home theater",
+  "stepScanNetwork": "Scan network for Sonos system",
+  "stepBondSpeakers": "Bond speakers",
+  "stepBondNSpeakers": "{count, plural, one{Bond {count} speaker} other{Bond {count} speakers}}",
+  "@stepBondNSpeakers": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "stepBondNSpeakersWithSub": "{count, plural, one{Bond {count} speaker + sub} other{Bond {count} speakers + sub}}",
+  "@stepBondNSpeakersWithSub": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "stepRemoveUnused": "{count, plural, one{Remove {count} speaker no longer used} other{Remove {count} speakers no longer used}}",
+  "@stepRemoveUnused": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "stepUnbondN": "{count, plural, one{Unbond {count} speaker} other{Unbond {count} speakers}}",
+  "@stepUnbondN": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "stepCreateGroupN": "{count, plural, one{Create group ({count} speaker)} other{Create group ({count} speakers)}}",
+  "@stepCreateGroupN": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "stepRemoveLabel": "Remove {label}",
+  "@stepRemoveLabel": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "stepSpeakers": "speakers",
+  "stepRestoreRoomName": "Restore room name",
+  "stepRestoreSettings": "Restore settings",
+  "stepNameGroup": "Name the group",
+  "stepSeparateGroup": "Separate group",
+  "stepSeparateRestore": "Separate + restore room names",
+  "stepDetach": "Detach from playback group",
+  "stepFreeFromBond": "Free from its current bond",
+  "stepFreeConflicting": "Free conflicting speakers",
+  "stepFreeing": "Freeing {name}",
+  "@stepFreeing": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "stepWaitForSettle": "Wait for Sonos to settle",
+  "stepWaitingSettle": "waiting for Sonos to settle",
+  "stepWaitForConfirm": "Wait for Sonos to confirm",
+  "stepWaitingConfirm": "waiting for Sonos to confirm",
+  "stepApplyingSettle": "Applying — Sonos can take up to a minute to settle.",
+  "stepNameUnchanged": "name unchanged — nothing to do",
+  "stepAlreadyFormed": "already formed — nothing to do",
+  "stepLayoutUnchanged": "layout unchanged — nothing to do",
+  "stepSkippedMissing": "skipped — {names} not on the network",
+  "@stepSkippedMissing": {
+    "placeholders": {
+      "names": {
+        "type": "String"
+      }
+    }
+  },
+  "stepSkippingSettingsOffline": "Skipping settings — not on the network",
+  "stepRestoring": "Restoring {what} — {type}",
+  "@stepRestoring": {
+    "placeholders": {
+      "what": {
+        "type": "String"
+      },
+      "type": {
+        "type": "String"
+      }
+    }
+  },
+  "stepAudioSettings": "audio settings",
+  "stepVolume": "volume",
+  "stepSettingsFailed": "{count, plural, one{{count} setting for {type} could not be applied} other{{count} settings for {type} could not be applied}}",
+  "@stepSettingsFailed": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "type": {
+        "type": "String"
+      }
+    }
+  },
+  "widgetsSomethingWentWrong": "Something went wrong — see the step below.",
+  "widgetsBondingTakesTime": "Bonding can take ~15–20s per step while Sonos applies and re-reads the layout.",
+  "widgetsStepFailed": "Failed.",
+  "widgetsStepWorking": "Working…",
+  "widgetsUnreachableSpeakerHint": "Couldn’t read this speaker’s details — check it’s powered on and on the same network.",
+  "widgetsSoundbar": "Soundbar",
+  "widgetsFronts": "Fronts",
+  "widgetsSurrounds": "Surrounds",
+  "widgetsSubwoofer": "Subwoofer",
+  "widgetsSub": "Sub",
+  "widgetsStandaloneSpeaker": "Standalone speaker",
+  "widgetsNoExtraSpeakers": "No extra speakers",
+  "widgetsNSpeakers": "{count, plural, one{{count} speaker} other{{count} speakers}}",
+  "@widgetsNSpeakers": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "widgetsRoomNoLongerAvailable": "This room is no longer available. Rescan to refresh.",
+  "widgetsBackToScan": "Back to scan",
+  "widgetsSpeaker": "Speaker",
+  "widgetsBlinkLightTooltip": "Blink the light",
+  "widgetsChimeTooltip": "Play a test chime",
+  "widgetsBlinkingLight": "💡 Blinking the light on {room}…",
+  "@widgetsBlinkingLight": {
+    "placeholders": {
+      "room": {
+        "type": "String"
+      }
+    }
+  },
+  "widgetsPlayingChime": "🔊 Playing a chime on {room}…",
+  "@widgetsPlayingChime": {
+    "placeholders": {
+      "room": {
+        "type": "String"
+      }
+    }
+  },
+  "widgetsNoAddressFor": "No address for {room}.",
+  "@widgetsNoAddressFor": {
+    "placeholders": {
+      "room": {
+        "type": "String"
+      }
+    }
+  },
+  "widgetsCouldntIdentify": "Couldn’t identify {room}: {error}",
+  "@widgetsCouldntIdentify": {
+    "placeholders": {
+      "room": {
+        "type": "String"
+      },
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "widgetsRefresh": "Refresh",
+  "widgetsRenameRoomTitle": "Rename room",
+  "widgetsRoomNameLabel": "Room name",
+  "widgetsTvSoundbar": "TV / Soundbar",
+  "widgetsTrueplayChecking": "Checking…",
+  "widgetsTrueplayNotTuned": "Not tuned — run Trueplay once in the Sonos app (iOS).",
+  "widgetsTrueplayActive": "Active",
+  "widgetsTrueplayTunedOff": "Tuned · off",
+  "widgetsTrueplayActiveCount": "{enabled}/{total} active",
+  "@widgetsTrueplayActiveCount": {
+    "placeholders": {
+      "enabled": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "widgetsTrueplayTunedCount": "{tuned}/{total} tuned",
+  "@widgetsTrueplayTunedCount": {
+    "placeholders": {
+      "tuned": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "widgetsChangelog": "Changelog",
+  "profileLoadError": "Couldn’t load profiles: {error}",
+  "@profileLoadError": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "profileEdit": "Edit",
+  "profileScanFirst": "Scan your system first (System tab).",
+  "profileNew": "New profile",
+  "profileDeleteConfirm": "Delete “{name}”?",
+  "@profileDeleteConfirm": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "profileDeleteMessage": "This removes the saved profile. Your speakers are not changed.",
+  "profileApplying": "Applying “{name}”",
+  "@profileApplying": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "profileEmptyTitle": "No profiles yet",
+  "profileEmptyBody": "A profile snapshots your current home theaters, stereo pairs and rooms so you can rebuild them in one tap — handy after moving speakers away. Tap “New profile” to capture your setup now.",
+  "profileApplyConfirmTitle": "Apply “{name}”?",
+  "@profileApplyConfirmTitle": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "profileApplyConfirmBody": "This re-bonds speakers on your live system and may take a while (each step waits for Sonos to settle). Trueplay may need re-tuning afterward.",
+  "profileIssueMissing": "Missing: {speakers} — will be skipped",
+  "@profileIssueMissing": {
+    "placeholders": {
+      "speakers": {
+        "type": "String"
+      }
+    }
+  },
+  "profileIssueFree": "Will free: {speakers}",
+  "@profileIssueFree": {
+    "placeholders": {
+      "speakers": {
+        "type": "String"
+      }
+    }
+  },
+  "profileNothingApplicable": "Nothing can be applied — all entities are missing speakers.",
+  "profileApplySummary": "Will apply {applicable} of {total} entities; {skipped} skipped.",
+  "@profileApplySummary": {
+    "placeholders": {
+      "applicable": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      },
+      "skipped": {
+        "type": "int"
+      }
+    }
+  },
+  "profileResnapshot": "Re-snapshot",
+  "profileScanFirstCreate": "Scan your system first (System tab), then create a profile from it.",
+  "profileReadingSettings": "Reading settings…",
+  "profileUseSnapshot": "Use snapshot",
+  "profileCreate": "Create profile",
+  "profileResnapshotNote": "Recapture your current setup, then review and save it on the profile screen.",
+  "profileApplyPrimer": "Applying a profile later rebuilds these speakers into this layout. Any speaker that’s part of a different setup at that time is removed from it first — which can dissolve another stereo pair or zone and free its other speakers.",
+  "profileIncludeHeader": "Include",
+  "profileIncludeHelper": "Pick which of your current home theaters, pairs and rooms to capture in this profile.",
+  "profileSpeakerSettingsHeader": "Speaker settings",
+  "profileSpeakerSettingsHelper": "Optionally snapshot each speaker’s current settings and restore them when this profile is applied.",
+  "profileSaveAudio": "Save audio settings",
+  "profileSaveAudioSubtitle": "EQ, night sound, speech enhancement, sub & surround levels, lip sync & more",
+  "profileSaveVolume": "Save volume",
+  "profileSaveVolumeSubtitle": "Applying the profile will change how loud each speaker plays",
+  "profileDefaultName": "My setup",
+  "profileTitle": "Profile",
+  "profileResnapshotTooltip": "Re-snapshot from current setup",
+  "profileIncludedHeader": "Included",
+  "profileRecapturedNote": "Recaptured from your current setup — press Save to keep it.",
+  "profileCapturedNote": "Captured when the profile was created. Use the re-snapshot button (top right) to recapture from your current setup.",
+  "profileSaved": "Profile saved",
+  "profileNoSettingsSaved": "No speaker settings saved in this profile.",
+  "profileRoleSoundbar": "Soundbar",
+  "profileRoleFront": "Front",
+  "profileRoleSurroundL": "Surround L",
+  "profileRoleSurroundR": "Surround R",
+  "profileNameLabel": "Profile name",
+  "profileNameTaken": "A profile with this name exists",
+  "profileNoEntities": "No entities",
+  "profileBadgeAudio": "Audio settings",
+  "profileBadgeVolume": "Volume",
+  "profileAppearance": "Appearance",
+  "profileWidgetPickTitle": "Pick profiles",
+  "profileWidgetEmpty": "No profiles yet — create one in Sonority first.",
+  "profileWidgetPickHelper": "Pick the profiles to show. Reorder them in the Profiles tab.",
+  "profileWidgetSelectAtLeastOne": "Select at least one",
+  "profileWidgetAddCount": "Add {count} to widget",
+  "@profileWidgetAddCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "discoveryDiagnostics": "Diagnostics",
+  "discoveryRescan": "Rescan",
+  "discoveryHomeTheaters": "Home theaters",
+  "discoveryNoSoundbar": "No soundbar found. Dedicated fronts need an Arc, Beam, Ray, Playbar or Playbase.",
+  "discoverySpeakerGroups": "Speaker groups",
+  "discoveryGroupSpeakers": "Group speakers",
+  "discoveryNoGroups": "No speaker groups yet",
+  "discoverySingleRooms": "Single speaker rooms",
+  "discoveryOtherDevices": "Other devices",
+  "discoverySubwoofer": "Subwoofer",
+  "discoveryScanning": "Scanning your network…",
+  "discoveryErrorTitle": "Couldn’t find your system",
+  "discoveryTryAgain": "Try again",
+  "roomTitle": "Room",
+  "roomRenameTooltip": "Rename room",
+  "roomRenamedTo": "Renamed to “{name}”.",
+  "@roomRenamedTo": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "roomRenameFailed": "Failed: {error}",
+  "@roomRenameFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "groupSheetTitle": "Speaker group",
+  "groupRenameTooltip": "Rename group",
+  "groupSeparate": "Separate",
+  "groupRenamedTo": "Renamed to “{name}”.",
+  "@groupRenamedTo": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "groupRenameFailed": "Failed: {error}",
+  "@groupRenameFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "groupSeparateConfirmTitle": "Separate group?",
+  "groupSeparateConfirmMessage": "The speakers become standalone rooms again. Their original room names will be restored.",
+  "groupSeparateProgressTitle": "Separate group",
+  "groupFlowTitle": "Group speakers",
+  "groupNeedTwoSpeakers": "Need at least two standalone speakers (not soundbars, subs, amps, or already bonded).",
+  "groupModeStereo": "Stereo",
+  "groupModeZone": "Zone",
+  "groupModeCustom": "Custom",
+  "groupStepSelect": "Select speakers",
+  "groupStepAddSub": "Add a Sub",
+  "groupOptional": "Optional",
+  "groupStepName": "Name",
+  "groupNameLabel": "Group name (optional)",
+  "groupNameHint": "e.g. Downstairs",
+  "groupStepReview": "Review & create",
+  "groupCreateStereo": "Create stereo pair",
+  "groupCreateZone": "Create zone",
+  "groupCreateCustom": "Create custom group",
+  "groupCreateFailed": "Couldn’t create the group — Sonos may not allow one of these speakers. See the log for details.",
+  "groupHintStereo": "Pick two speakers — one plays left, the other right (swap below). Mismatched models are fine.",
+  "groupHintZone": "Pick 2–16 speakers. They all play full stereo (L+R) as one room.",
+  "groupHintCustom": "Pick 2–16 speakers and set each to Left, Right, or Both.",
+  "groupSideLeft": "LEFT",
+  "groupSideRight": "RIGHT",
+  "groupSwapSides": "Swap sides",
+  "groupChannelLeft": "Left",
+  "groupChannelBoth": "Both",
+  "groupChannelRight": "Right",
+  "groupNoSub": "No standalone Sub available. A Sub bonded to a home theater must be removed there first.",
+  "groupAddSubHint": "Optionally add a Sub to the group.",
+  "groupSubwoofer": "Subwoofer",
+  "groupKindStereo": "Stereo pair",
+  "groupKindZone": "{count, plural, one{Zone ({count} speaker)} other{Zone ({count} speakers)}}",
+  "@groupKindZone": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "groupKindCustom": "{count, plural, one{Custom group ({count} speaker)} other{Custom group ({count} speakers)}}",
+  "@groupKindCustom": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "groupReviewMemberLine": "{room} — {channel}",
+  "@groupReviewMemberLine": {
+    "placeholders": {
+      "room": {
+        "type": "String"
+      },
+      "channel": {
+        "type": "String"
+      }
+    }
+  },
+  "groupReviewName": "Name: {name}",
+  "@groupReviewName": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "groupReviewSub": "Sub: {type}",
+  "@groupReviewSub": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      }
+    }
+  },
+  "groupReviewNote": "Bonded speakers play as one room. Larger or mixed-model groups can drop out briefly — play something to confirm it works for you. Original room names are restored when you separate the group.",
+  "htHomeTheater": "Home theater",
+  "htRenameRoomTooltip": "Rename room",
+  "htUpdatingTitle": "Updating your home theater…",
+  "htUpdatingSubtitle": "This can take up to ~20 seconds while Sonos reconfigures and re-reads the layout.",
+  "htRenamedTo": "Renamed to “{name}”.",
+  "@htRenamedTo": {
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "htRenameFailed": "Failed: {error}",
+  "@htRenameFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "htSeparateConfirmTitle": "Separate home theater?",
+  "htRemoveConfirmTitle": "Remove {label}?",
+  "@htRemoveConfirmTitle": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "htSeparateMessage": "All extra speakers will be un-bonded and become standalone rooms again, leaving just the soundbar.",
+  "htRemoveMessage": "These speakers will be un-bonded and become standalone rooms again. The rest of your home theater stays as it is.",
+  "htSeparate": "Separate",
+  "htSeparateProgressTitle": "Separate home theater",
+  "htRemoveProgressTitle": "Remove {label}",
+  "@htRemoveProgressTitle": {
+    "placeholders": {
+      "label": {
+        "type": "String"
+      }
+    }
+  },
+  "htGroupFronts": "Fronts",
+  "htGroupSurrounds": "Surrounds",
+  "htGroupSubwoofer": "Subwoofer",
+  "htConfigure": "Configure home theater",
+  "htBondedSpeakers": "Bonded speakers",
+  "htNoBonded": "Just the soundbar — no fronts, surrounds or sub bonded yet. Tap “Configure home theater” to add some.",
+  "htSpeakerFallback": "Speaker",
+  "htTrueplayNote": "Trueplay can only be measured from the Sonos app on iOS — tune the home theater, and the fronts separately as a stereo pair. Heads-up: Sonos often clears a tuning when speakers are bonded/unbonded, so you may see “Not tuned” after changing the layout and have to redo it. Sonority only toggles a stored tuning.",
+  "htAllExtraSpeakers": "all extra speakers",
+  "htBonded": "Bonded",
+  "frontSurroundsTitle": "Set up home theater",
+  "frontSurroundsStepFronts": "Front speakers",
+  "frontSurroundsOptional": "Optional",
+  "frontSurroundsFrontsHint": "Pick two speakers (or a single Amp) for the front left & right, then set which is which.",
+  "frontSurroundsLeft": "LEFT",
+  "frontSurroundsRight": "RIGHT",
+  "frontSurroundsStepSurrounds": "Rear surrounds",
+  "frontSurroundsSurroundsHint": "Pick two speakers for the rear left & right surrounds.",
+  "frontSurroundsRearLeft": "REAR LEFT",
+  "frontSurroundsRearRight": "REAR RIGHT",
+  "frontSurroundsStepSub": "Subwoofer",
+  "frontSurroundsStepReview": "Review & apply",
+  "frontSurroundsUnbondTitle": "{count, plural, one{Unbond {count} speaker?} other{Unbond {count} speakers?}}",
+  "@frontSurroundsUnbondTitle": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "frontSurroundsUnbondMessage": "{types} will be removed from this home theater and become standalone rooms again. The rest of your layout stays as it is.",
+  "@frontSurroundsUnbondMessage": {
+    "placeholders": {
+      "types": {
+        "type": "String"
+      }
+    }
+  },
+  "frontSurroundsUnbond": "Unbond",
+  "frontSurroundsNoFreeSpeakers": "No free speakers available. They must be standalone (not already part of a home theater or stereo pair).",
+  "frontSurroundsPickWithAmp": "Pick two speakers (ideally identical), or a single Sonos Amp that drives both front speakers.",
+  "frontSurroundsPickExactlyTwo": "Pick exactly two — ideally an identical pair.",
+  "frontSurroundsAmpSubtitle": "{type} — drives both fronts (L + R)",
+  "@frontSurroundsAmpSubtitle": {
+    "placeholders": {
+      "type": {
+        "type": "String"
+      }
+    }
+  },
+  "frontSurroundsNoFreeSub": "No free subwoofer found. A Sonos Sub must be standalone (not already bonded to another home theater).",
+  "frontSurroundsSubHint": "Pick one or two subwoofers to add as low-frequency channels.",
+  "frontSurroundsAmpWiring": "The {amp} drives both front channels. Wire your left & right speakers to its L/R speaker outputs — there’s nothing to assign here.",
+  "@frontSurroundsAmpWiring": {
+    "placeholders": {
+      "amp": {
+        "type": "String"
+      }
+    }
+  },
+  "frontSurroundsChooseTwoFirst": "Choose two speakers first.",
+  "frontSurroundsSwapSides": "Swap sides",
+  "frontSurroundsTapSwap": "Tap swap if the sides are reversed.",
+  "frontSurroundsNothingSelected": "Nothing selected yet — choose speakers above.",
+  "frontSurroundsReviewNote": "The chosen speakers become hidden satellites of the soundbar (which stays the center channel). Bonding runs in steps and can take a little while; Trueplay may need re-tuning afterward. You can change this anytime.",
+  "diagNoSystemToCollect": "No system to collect — scan first.",
+  "diagBuildFailed": "Could not build the diagnostics bundle: {error}",
+  "@diagBuildFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "diagActionFailed": "Could not complete the action: {error}",
+  "@diagActionFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "diagSavedTo": "Saved to {path}",
+  "@diagSavedTo": {
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+  "diagTitle": "Diagnostics",
+  "diagNoSystem": "No system discovered yet.",
+  "diagIncludeLogs": "Include app logs",
+  "diagIncludeLogsSubtitle": "SOAP faults, bond retries, discovery, errors (logs.txt)",
+  "diagIncludeNetwork": "Include phone network info",
+  "diagIncludeNetworkSubtitle": "This device’s network interface addresses (network.txt)",
+  "diagAlwaysIncluded": "Always included: topology (room names, IPs, MACs, models), raw device descriptions, and your saved profiles/room names.",
+  "diagCollecting": "Collecting…",
+  "diagEmailToDeveloper": "Email to developer",
+  "diagShareDiagnostics": "Share diagnostics",
+  "diagEmailBody": "Describe what went wrong (what you tried, what you expected, what happened):\n\n\n——— the diagnostics bundle is attached below ———"
+}

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,1952 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_en.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
+
+  /// No description provided for @tabSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'System'**
+  String get tabSystem;
+
+  /// No description provided for @tabProfiles.
+  ///
+  /// In en, this message translates to:
+  /// **'Profiles'**
+  String get tabProfiles;
+
+  /// No description provided for @actionCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get actionCancel;
+
+  /// No description provided for @actionDone.
+  ///
+  /// In en, this message translates to:
+  /// **'Done'**
+  String get actionDone;
+
+  /// No description provided for @actionDelete.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get actionDelete;
+
+  /// No description provided for @actionRemove.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove'**
+  String get actionRemove;
+
+  /// No description provided for @actionRename.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename'**
+  String get actionRename;
+
+  /// No description provided for @actionApply.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply'**
+  String get actionApply;
+
+  /// No description provided for @actionRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get actionRetry;
+
+  /// No description provided for @actionAdd.
+  ///
+  /// In en, this message translates to:
+  /// **'Add'**
+  String get actionAdd;
+
+  /// No description provided for @actionSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get actionSave;
+
+  /// No description provided for @actionClose.
+  ///
+  /// In en, this message translates to:
+  /// **'Close'**
+  String get actionClose;
+
+  /// No description provided for @actionBack.
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get actionBack;
+
+  /// No description provided for @actionNext.
+  ///
+  /// In en, this message translates to:
+  /// **'Next'**
+  String get actionNext;
+
+  /// No description provided for @actionContinue.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get actionContinue;
+
+  /// No description provided for @actionOk.
+  ///
+  /// In en, this message translates to:
+  /// **'OK'**
+  String get actionOk;
+
+  /// No description provided for @actionAbort.
+  ///
+  /// In en, this message translates to:
+  /// **'Abort'**
+  String get actionAbort;
+
+  /// No description provided for @actionAborting.
+  ///
+  /// In en, this message translates to:
+  /// **'Aborting…'**
+  String get actionAborting;
+
+  /// No description provided for @bondingCopyLogs.
+  ///
+  /// In en, this message translates to:
+  /// **'Copy logs'**
+  String get bondingCopyLogs;
+
+  /// No description provided for @bondingShowSteps.
+  ///
+  /// In en, this message translates to:
+  /// **'Show steps'**
+  String get bondingShowSteps;
+
+  /// No description provided for @bondingShowRawLog.
+  ///
+  /// In en, this message translates to:
+  /// **'Show raw log'**
+  String get bondingShowRawLog;
+
+  /// No description provided for @bondingLogsCopied.
+  ///
+  /// In en, this message translates to:
+  /// **'Logs copied to clipboard.'**
+  String get bondingLogsCopied;
+
+  /// No description provided for @bondingNoLogOutput.
+  ///
+  /// In en, this message translates to:
+  /// **'No log output yet.'**
+  String get bondingNoLogOutput;
+
+  /// No description provided for @errSystemNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t find your Sonos system on the network.'**
+  String get errSystemNotFound;
+
+  /// No description provided for @errNoDevicesFound.
+  ///
+  /// In en, this message translates to:
+  /// **'No Sonos devices found. Check Wi-Fi and local network access.'**
+  String get errNoDevicesFound;
+
+  /// No description provided for @errDescriptionsUnreadable.
+  ///
+  /// In en, this message translates to:
+  /// **'Found Sonos players but could not read their descriptions.'**
+  String get errDescriptionsUnreadable;
+
+  /// No description provided for @errTopologyUnreadable.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not read the Sonos topology from any player.'**
+  String get errTopologyUnreadable;
+
+  /// No description provided for @errEntityNotOnNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'“{name}” isn’t on the network.'**
+  String errEntityNotOnNetwork(String name);
+
+  /// No description provided for @errCoordinatorNotOnNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'“{name}” coordinator isn’t on the network.'**
+  String errCoordinatorNotOnNetwork(String name);
+
+  /// No description provided for @errSpeakerInEntityNotOnNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'A speaker in “{name}” isn’t on the network.'**
+  String errSpeakerInEntityNotOnNetwork(String name);
+
+  /// No description provided for @errSubNotOnNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'The Sub for “{name}” isn’t on the network.'**
+  String errSubNotOnNetwork(String name);
+
+  /// No description provided for @errSoundbarNotOnNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'Soundbar for “{name}” isn’t on the network.'**
+  String errSoundbarNotOnNetwork(String name);
+
+  /// No description provided for @errEntityMissingSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'“{name}” is missing speakers.'**
+  String errEntityMissingSpeakers(String name);
+
+  /// No description provided for @errMalformedGroup.
+  ///
+  /// In en, this message translates to:
+  /// **'Stored group is malformed.'**
+  String get errMalformedGroup;
+
+  /// No description provided for @errMalformedHomeTheater.
+  ///
+  /// In en, this message translates to:
+  /// **'Stored home theater is malformed.'**
+  String get errMalformedHomeTheater;
+
+  /// No description provided for @errDidNotForm.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos did not form “{name}”.'**
+  String errDidNotForm(String name);
+
+  /// No description provided for @errDidNotCreateGroup.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos did not create the group — a speaker may be incompatible.'**
+  String get errDidNotCreateGroup;
+
+  /// No description provided for @errDidNotSeparate.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos did not separate the group — try again.'**
+  String get errDidNotSeparate;
+
+  /// No description provided for @errDidNotRemove.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos did not remove the {label} — try again.'**
+  String errDidNotRemove(String label);
+
+  /// No description provided for @errGroupNeedsTwo.
+  ///
+  /// In en, this message translates to:
+  /// **'A group needs at least 2 speakers.'**
+  String get errGroupNeedsTwo;
+
+  /// No description provided for @errSpeakerIpUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker IP unknown; rescan and retry.'**
+  String get errSpeakerIpUnknown;
+
+  /// No description provided for @errSoundbarIpUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Soundbar IP unknown; rescan and retry.'**
+  String get errSoundbarIpUnknown;
+
+  /// No description provided for @errCoordinatorIpUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Coordinator IP unknown; rescan and retry.'**
+  String get errCoordinatorIpUnknown;
+
+  /// No description provided for @errBondingIncomplete.
+  ///
+  /// In en, this message translates to:
+  /// **'Bonding did not complete — these channels never joined: {channels}. Try again, or finish in the Sonos app.'**
+  String errBondingIncomplete(String channels);
+
+  /// No description provided for @errNoLanIpForChime.
+  ///
+  /// In en, this message translates to:
+  /// **'No LAN IP found to serve the chime from.'**
+  String get errNoLanIpForChime;
+
+  /// No description provided for @errCannotBlinkLight.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not reach the speaker to blink its light.'**
+  String get errCannotBlinkLight;
+
+  /// No description provided for @errTimeout.
+  ///
+  /// In en, this message translates to:
+  /// **'The speaker didn’t respond in time. It may still be settling — try again in a moment.'**
+  String get errTimeout;
+
+  /// No description provided for @errSonosBusy.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos is busy rearranging speakers right now. Wait a moment and try again.'**
+  String get errSonosBusy;
+
+  /// No description provided for @errUnsupportedCombo.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos wouldn’t bond these speakers this way (unsupported combination).'**
+  String get errUnsupportedCombo;
+
+  /// No description provided for @errInvalidRequest.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos rejected the request as invalid.'**
+  String get errInvalidRequest;
+
+  /// No description provided for @errSonosCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos reported an error (code {code}). See the raw log for details.'**
+  String errSonosCode(String code);
+
+  /// No description provided for @errSonosGeneric.
+  ///
+  /// In en, this message translates to:
+  /// **'Sonos reported an error. See the raw log for details.'**
+  String get errSonosGeneric;
+
+  /// No description provided for @errAborted.
+  ///
+  /// In en, this message translates to:
+  /// **'Aborted'**
+  String get errAborted;
+
+  /// No description provided for @errChimeUnreachable.
+  ///
+  /// In en, this message translates to:
+  /// **'The speaker could not reach your phone to play the sound. Make sure your phone and speakers are on the same Wi‑Fi network. (Android emulators can’t reach speakers on your LAN — use a real device.)'**
+  String get errChimeUnreachable;
+
+  /// No description provided for @entityKindHomeTheater.
+  ///
+  /// In en, this message translates to:
+  /// **'Home theater'**
+  String get entityKindHomeTheater;
+
+  /// No description provided for @entityKindStereoPair.
+  ///
+  /// In en, this message translates to:
+  /// **'Stereo pair'**
+  String get entityKindStereoPair;
+
+  /// No description provided for @entityKindZone.
+  ///
+  /// In en, this message translates to:
+  /// **'Zone'**
+  String get entityKindZone;
+
+  /// No description provided for @entityKindCustom.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom group'**
+  String get entityKindCustom;
+
+  /// No description provided for @entityKindSpeaker.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker'**
+  String get entityKindSpeaker;
+
+  /// No description provided for @entityKindGroup.
+  ///
+  /// In en, this message translates to:
+  /// **'Group'**
+  String get entityKindGroup;
+
+  /// No description provided for @stepSetUpHomeTheater.
+  ///
+  /// In en, this message translates to:
+  /// **'Set up home theater'**
+  String get stepSetUpHomeTheater;
+
+  /// No description provided for @stepScanNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan network for Sonos system'**
+  String get stepScanNetwork;
+
+  /// No description provided for @stepBondSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'Bond speakers'**
+  String get stepBondSpeakers;
+
+  /// No description provided for @stepBondNSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Bond {count} speaker} other{Bond {count} speakers}}'**
+  String stepBondNSpeakers(int count);
+
+  /// No description provided for @stepBondNSpeakersWithSub.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Bond {count} speaker + sub} other{Bond {count} speakers + sub}}'**
+  String stepBondNSpeakersWithSub(int count);
+
+  /// No description provided for @stepRemoveUnused.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Remove {count} speaker no longer used} other{Remove {count} speakers no longer used}}'**
+  String stepRemoveUnused(int count);
+
+  /// No description provided for @stepUnbondN.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Unbond {count} speaker} other{Unbond {count} speakers}}'**
+  String stepUnbondN(int count);
+
+  /// No description provided for @stepCreateGroupN.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Create group ({count} speaker)} other{Create group ({count} speakers)}}'**
+  String stepCreateGroupN(int count);
+
+  /// No description provided for @stepRemoveLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove {label}'**
+  String stepRemoveLabel(String label);
+
+  /// No description provided for @stepSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'speakers'**
+  String get stepSpeakers;
+
+  /// No description provided for @stepRestoreRoomName.
+  ///
+  /// In en, this message translates to:
+  /// **'Restore room name'**
+  String get stepRestoreRoomName;
+
+  /// No description provided for @stepRestoreSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Restore settings'**
+  String get stepRestoreSettings;
+
+  /// No description provided for @stepNameGroup.
+  ///
+  /// In en, this message translates to:
+  /// **'Name the group'**
+  String get stepNameGroup;
+
+  /// No description provided for @stepSeparateGroup.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate group'**
+  String get stepSeparateGroup;
+
+  /// No description provided for @stepSeparateRestore.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate + restore room names'**
+  String get stepSeparateRestore;
+
+  /// No description provided for @stepDetach.
+  ///
+  /// In en, this message translates to:
+  /// **'Detach from playback group'**
+  String get stepDetach;
+
+  /// No description provided for @stepFreeFromBond.
+  ///
+  /// In en, this message translates to:
+  /// **'Free from its current bond'**
+  String get stepFreeFromBond;
+
+  /// No description provided for @stepFreeConflicting.
+  ///
+  /// In en, this message translates to:
+  /// **'Free conflicting speakers'**
+  String get stepFreeConflicting;
+
+  /// No description provided for @stepFreeing.
+  ///
+  /// In en, this message translates to:
+  /// **'Freeing {name}'**
+  String stepFreeing(String name);
+
+  /// No description provided for @stepWaitForSettle.
+  ///
+  /// In en, this message translates to:
+  /// **'Wait for Sonos to settle'**
+  String get stepWaitForSettle;
+
+  /// No description provided for @stepWaitingSettle.
+  ///
+  /// In en, this message translates to:
+  /// **'waiting for Sonos to settle'**
+  String get stepWaitingSettle;
+
+  /// No description provided for @stepWaitForConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Wait for Sonos to confirm'**
+  String get stepWaitForConfirm;
+
+  /// No description provided for @stepWaitingConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'waiting for Sonos to confirm'**
+  String get stepWaitingConfirm;
+
+  /// No description provided for @stepApplyingSettle.
+  ///
+  /// In en, this message translates to:
+  /// **'Applying — Sonos can take up to a minute to settle.'**
+  String get stepApplyingSettle;
+
+  /// No description provided for @stepNameUnchanged.
+  ///
+  /// In en, this message translates to:
+  /// **'name unchanged — nothing to do'**
+  String get stepNameUnchanged;
+
+  /// No description provided for @stepAlreadyFormed.
+  ///
+  /// In en, this message translates to:
+  /// **'already formed — nothing to do'**
+  String get stepAlreadyFormed;
+
+  /// No description provided for @stepLayoutUnchanged.
+  ///
+  /// In en, this message translates to:
+  /// **'layout unchanged — nothing to do'**
+  String get stepLayoutUnchanged;
+
+  /// No description provided for @stepSkippedMissing.
+  ///
+  /// In en, this message translates to:
+  /// **'skipped — {names} not on the network'**
+  String stepSkippedMissing(String names);
+
+  /// No description provided for @stepSkippingSettingsOffline.
+  ///
+  /// In en, this message translates to:
+  /// **'Skipping settings — not on the network'**
+  String get stepSkippingSettingsOffline;
+
+  /// No description provided for @stepRestoring.
+  ///
+  /// In en, this message translates to:
+  /// **'Restoring {what} — {type}'**
+  String stepRestoring(String what, String type);
+
+  /// No description provided for @stepAudioSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'audio settings'**
+  String get stepAudioSettings;
+
+  /// No description provided for @stepVolume.
+  ///
+  /// In en, this message translates to:
+  /// **'volume'**
+  String get stepVolume;
+
+  /// No description provided for @stepSettingsFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{{count} setting for {type} could not be applied} other{{count} settings for {type} could not be applied}}'**
+  String stepSettingsFailed(int count, String type);
+
+  /// No description provided for @widgetsSomethingWentWrong.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong — see the step below.'**
+  String get widgetsSomethingWentWrong;
+
+  /// No description provided for @widgetsBondingTakesTime.
+  ///
+  /// In en, this message translates to:
+  /// **'Bonding can take ~15–20s per step while Sonos applies and re-reads the layout.'**
+  String get widgetsBondingTakesTime;
+
+  /// No description provided for @widgetsStepFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed.'**
+  String get widgetsStepFailed;
+
+  /// No description provided for @widgetsStepWorking.
+  ///
+  /// In en, this message translates to:
+  /// **'Working…'**
+  String get widgetsStepWorking;
+
+  /// No description provided for @widgetsUnreachableSpeakerHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t read this speaker’s details — check it’s powered on and on the same network.'**
+  String get widgetsUnreachableSpeakerHint;
+
+  /// No description provided for @widgetsSoundbar.
+  ///
+  /// In en, this message translates to:
+  /// **'Soundbar'**
+  String get widgetsSoundbar;
+
+  /// No description provided for @widgetsFronts.
+  ///
+  /// In en, this message translates to:
+  /// **'Fronts'**
+  String get widgetsFronts;
+
+  /// No description provided for @widgetsSurrounds.
+  ///
+  /// In en, this message translates to:
+  /// **'Surrounds'**
+  String get widgetsSurrounds;
+
+  /// No description provided for @widgetsSubwoofer.
+  ///
+  /// In en, this message translates to:
+  /// **'Subwoofer'**
+  String get widgetsSubwoofer;
+
+  /// No description provided for @widgetsSub.
+  ///
+  /// In en, this message translates to:
+  /// **'Sub'**
+  String get widgetsSub;
+
+  /// No description provided for @widgetsStandaloneSpeaker.
+  ///
+  /// In en, this message translates to:
+  /// **'Standalone speaker'**
+  String get widgetsStandaloneSpeaker;
+
+  /// No description provided for @widgetsNoExtraSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'No extra speakers'**
+  String get widgetsNoExtraSpeakers;
+
+  /// No description provided for @widgetsNSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{{count} speaker} other{{count} speakers}}'**
+  String widgetsNSpeakers(int count);
+
+  /// No description provided for @widgetsRoomNoLongerAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'This room is no longer available. Rescan to refresh.'**
+  String get widgetsRoomNoLongerAvailable;
+
+  /// No description provided for @widgetsBackToScan.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to scan'**
+  String get widgetsBackToScan;
+
+  /// No description provided for @widgetsSpeaker.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker'**
+  String get widgetsSpeaker;
+
+  /// No description provided for @widgetsBlinkLightTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Blink the light'**
+  String get widgetsBlinkLightTooltip;
+
+  /// No description provided for @widgetsChimeTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Play a test chime'**
+  String get widgetsChimeTooltip;
+
+  /// No description provided for @widgetsBlinkingLight.
+  ///
+  /// In en, this message translates to:
+  /// **'💡 Blinking the light on {room}…'**
+  String widgetsBlinkingLight(String room);
+
+  /// No description provided for @widgetsPlayingChime.
+  ///
+  /// In en, this message translates to:
+  /// **'🔊 Playing a chime on {room}…'**
+  String widgetsPlayingChime(String room);
+
+  /// No description provided for @widgetsNoAddressFor.
+  ///
+  /// In en, this message translates to:
+  /// **'No address for {room}.'**
+  String widgetsNoAddressFor(String room);
+
+  /// No description provided for @widgetsCouldntIdentify.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t identify {room}: {error}'**
+  String widgetsCouldntIdentify(String room, String error);
+
+  /// No description provided for @widgetsRefresh.
+  ///
+  /// In en, this message translates to:
+  /// **'Refresh'**
+  String get widgetsRefresh;
+
+  /// No description provided for @widgetsRenameRoomTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename room'**
+  String get widgetsRenameRoomTitle;
+
+  /// No description provided for @widgetsRoomNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Room name'**
+  String get widgetsRoomNameLabel;
+
+  /// No description provided for @widgetsTvSoundbar.
+  ///
+  /// In en, this message translates to:
+  /// **'TV / Soundbar'**
+  String get widgetsTvSoundbar;
+
+  /// No description provided for @widgetsTrueplayChecking.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking…'**
+  String get widgetsTrueplayChecking;
+
+  /// No description provided for @widgetsTrueplayNotTuned.
+  ///
+  /// In en, this message translates to:
+  /// **'Not tuned — run Trueplay once in the Sonos app (iOS).'**
+  String get widgetsTrueplayNotTuned;
+
+  /// No description provided for @widgetsTrueplayActive.
+  ///
+  /// In en, this message translates to:
+  /// **'Active'**
+  String get widgetsTrueplayActive;
+
+  /// No description provided for @widgetsTrueplayTunedOff.
+  ///
+  /// In en, this message translates to:
+  /// **'Tuned · off'**
+  String get widgetsTrueplayTunedOff;
+
+  /// No description provided for @widgetsTrueplayActiveCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{enabled}/{total} active'**
+  String widgetsTrueplayActiveCount(int enabled, int total);
+
+  /// No description provided for @widgetsTrueplayTunedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{tuned}/{total} tuned'**
+  String widgetsTrueplayTunedCount(int tuned, int total);
+
+  /// No description provided for @widgetsChangelog.
+  ///
+  /// In en, this message translates to:
+  /// **'Changelog'**
+  String get widgetsChangelog;
+
+  /// No description provided for @profileLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t load profiles: {error}'**
+  String profileLoadError(String error);
+
+  /// No description provided for @profileEdit.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit'**
+  String get profileEdit;
+
+  /// No description provided for @profileScanFirst.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan your system first (System tab).'**
+  String get profileScanFirst;
+
+  /// No description provided for @profileNew.
+  ///
+  /// In en, this message translates to:
+  /// **'New profile'**
+  String get profileNew;
+
+  /// No description provided for @profileDeleteConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete “{name}”?'**
+  String profileDeleteConfirm(String name);
+
+  /// No description provided for @profileDeleteMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This removes the saved profile. Your speakers are not changed.'**
+  String get profileDeleteMessage;
+
+  /// No description provided for @profileApplying.
+  ///
+  /// In en, this message translates to:
+  /// **'Applying “{name}”'**
+  String profileApplying(String name);
+
+  /// No description provided for @profileEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No profiles yet'**
+  String get profileEmptyTitle;
+
+  /// No description provided for @profileEmptyBody.
+  ///
+  /// In en, this message translates to:
+  /// **'A profile snapshots your current home theaters, stereo pairs and rooms so you can rebuild them in one tap — handy after moving speakers away. Tap “New profile” to capture your setup now.'**
+  String get profileEmptyBody;
+
+  /// No description provided for @profileApplyConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply “{name}”?'**
+  String profileApplyConfirmTitle(String name);
+
+  /// No description provided for @profileApplyConfirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This re-bonds speakers on your live system and may take a while (each step waits for Sonos to settle). Trueplay may need re-tuning afterward.'**
+  String get profileApplyConfirmBody;
+
+  /// No description provided for @profileIssueMissing.
+  ///
+  /// In en, this message translates to:
+  /// **'Missing: {speakers} — will be skipped'**
+  String profileIssueMissing(String speakers);
+
+  /// No description provided for @profileIssueFree.
+  ///
+  /// In en, this message translates to:
+  /// **'Will free: {speakers}'**
+  String profileIssueFree(String speakers);
+
+  /// No description provided for @profileNothingApplicable.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing can be applied — all entities are missing speakers.'**
+  String get profileNothingApplicable;
+
+  /// No description provided for @profileApplySummary.
+  ///
+  /// In en, this message translates to:
+  /// **'Will apply {applicable} of {total} entities; {skipped} skipped.'**
+  String profileApplySummary(int applicable, int total, int skipped);
+
+  /// No description provided for @profileResnapshot.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-snapshot'**
+  String get profileResnapshot;
+
+  /// No description provided for @profileScanFirstCreate.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan your system first (System tab), then create a profile from it.'**
+  String get profileScanFirstCreate;
+
+  /// No description provided for @profileReadingSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Reading settings…'**
+  String get profileReadingSettings;
+
+  /// No description provided for @profileUseSnapshot.
+  ///
+  /// In en, this message translates to:
+  /// **'Use snapshot'**
+  String get profileUseSnapshot;
+
+  /// No description provided for @profileCreate.
+  ///
+  /// In en, this message translates to:
+  /// **'Create profile'**
+  String get profileCreate;
+
+  /// No description provided for @profileResnapshotNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Recapture your current setup, then review and save it on the profile screen.'**
+  String get profileResnapshotNote;
+
+  /// No description provided for @profileApplyPrimer.
+  ///
+  /// In en, this message translates to:
+  /// **'Applying a profile later rebuilds these speakers into this layout. Any speaker that’s part of a different setup at that time is removed from it first — which can dissolve another stereo pair or zone and free its other speakers.'**
+  String get profileApplyPrimer;
+
+  /// No description provided for @profileIncludeHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Include'**
+  String get profileIncludeHeader;
+
+  /// No description provided for @profileIncludeHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick which of your current home theaters, pairs and rooms to capture in this profile.'**
+  String get profileIncludeHelper;
+
+  /// No description provided for @profileSpeakerSettingsHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker settings'**
+  String get profileSpeakerSettingsHeader;
+
+  /// No description provided for @profileSpeakerSettingsHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'Optionally snapshot each speaker’s current settings and restore them when this profile is applied.'**
+  String get profileSpeakerSettingsHelper;
+
+  /// No description provided for @profileSaveAudio.
+  ///
+  /// In en, this message translates to:
+  /// **'Save audio settings'**
+  String get profileSaveAudio;
+
+  /// No description provided for @profileSaveAudioSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'EQ, night sound, speech enhancement, sub & surround levels, lip sync & more'**
+  String get profileSaveAudioSubtitle;
+
+  /// No description provided for @profileSaveVolume.
+  ///
+  /// In en, this message translates to:
+  /// **'Save volume'**
+  String get profileSaveVolume;
+
+  /// No description provided for @profileSaveVolumeSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Applying the profile will change how loud each speaker plays'**
+  String get profileSaveVolumeSubtitle;
+
+  /// No description provided for @profileDefaultName.
+  ///
+  /// In en, this message translates to:
+  /// **'My setup'**
+  String get profileDefaultName;
+
+  /// No description provided for @profileTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Profile'**
+  String get profileTitle;
+
+  /// No description provided for @profileResnapshotTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Re-snapshot from current setup'**
+  String get profileResnapshotTooltip;
+
+  /// No description provided for @profileIncludedHeader.
+  ///
+  /// In en, this message translates to:
+  /// **'Included'**
+  String get profileIncludedHeader;
+
+  /// No description provided for @profileRecapturedNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Recaptured from your current setup — press Save to keep it.'**
+  String get profileRecapturedNote;
+
+  /// No description provided for @profileCapturedNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Captured when the profile was created. Use the re-snapshot button (top right) to recapture from your current setup.'**
+  String get profileCapturedNote;
+
+  /// No description provided for @profileSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'Profile saved'**
+  String get profileSaved;
+
+  /// No description provided for @profileNoSettingsSaved.
+  ///
+  /// In en, this message translates to:
+  /// **'No speaker settings saved in this profile.'**
+  String get profileNoSettingsSaved;
+
+  /// No description provided for @profileRoleSoundbar.
+  ///
+  /// In en, this message translates to:
+  /// **'Soundbar'**
+  String get profileRoleSoundbar;
+
+  /// No description provided for @profileRoleFront.
+  ///
+  /// In en, this message translates to:
+  /// **'Front'**
+  String get profileRoleFront;
+
+  /// No description provided for @profileRoleSurroundL.
+  ///
+  /// In en, this message translates to:
+  /// **'Surround L'**
+  String get profileRoleSurroundL;
+
+  /// No description provided for @profileRoleSurroundR.
+  ///
+  /// In en, this message translates to:
+  /// **'Surround R'**
+  String get profileRoleSurroundR;
+
+  /// No description provided for @profileNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Profile name'**
+  String get profileNameLabel;
+
+  /// No description provided for @profileNameTaken.
+  ///
+  /// In en, this message translates to:
+  /// **'A profile with this name exists'**
+  String get profileNameTaken;
+
+  /// No description provided for @profileNoEntities.
+  ///
+  /// In en, this message translates to:
+  /// **'No entities'**
+  String get profileNoEntities;
+
+  /// No description provided for @profileBadgeAudio.
+  ///
+  /// In en, this message translates to:
+  /// **'Audio settings'**
+  String get profileBadgeAudio;
+
+  /// No description provided for @profileBadgeVolume.
+  ///
+  /// In en, this message translates to:
+  /// **'Volume'**
+  String get profileBadgeVolume;
+
+  /// No description provided for @profileAppearance.
+  ///
+  /// In en, this message translates to:
+  /// **'Appearance'**
+  String get profileAppearance;
+
+  /// No description provided for @profileWidgetPickTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick profiles'**
+  String get profileWidgetPickTitle;
+
+  /// No description provided for @profileWidgetEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No profiles yet — create one in Sonority first.'**
+  String get profileWidgetEmpty;
+
+  /// No description provided for @profileWidgetPickHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick the profiles to show. Reorder them in the Profiles tab.'**
+  String get profileWidgetPickHelper;
+
+  /// No description provided for @profileWidgetSelectAtLeastOne.
+  ///
+  /// In en, this message translates to:
+  /// **'Select at least one'**
+  String get profileWidgetSelectAtLeastOne;
+
+  /// No description provided for @profileWidgetAddCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Add {count} to widget'**
+  String profileWidgetAddCount(int count);
+
+  /// No description provided for @discoveryDiagnostics.
+  ///
+  /// In en, this message translates to:
+  /// **'Diagnostics'**
+  String get discoveryDiagnostics;
+
+  /// No description provided for @discoveryRescan.
+  ///
+  /// In en, this message translates to:
+  /// **'Rescan'**
+  String get discoveryRescan;
+
+  /// No description provided for @discoveryHomeTheaters.
+  ///
+  /// In en, this message translates to:
+  /// **'Home theaters'**
+  String get discoveryHomeTheaters;
+
+  /// No description provided for @discoveryNoSoundbar.
+  ///
+  /// In en, this message translates to:
+  /// **'No soundbar found. Dedicated fronts need an Arc, Beam, Ray, Playbar or Playbase.'**
+  String get discoveryNoSoundbar;
+
+  /// No description provided for @discoverySpeakerGroups.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker groups'**
+  String get discoverySpeakerGroups;
+
+  /// No description provided for @discoveryGroupSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'Group speakers'**
+  String get discoveryGroupSpeakers;
+
+  /// No description provided for @discoveryNoGroups.
+  ///
+  /// In en, this message translates to:
+  /// **'No speaker groups yet'**
+  String get discoveryNoGroups;
+
+  /// No description provided for @discoverySingleRooms.
+  ///
+  /// In en, this message translates to:
+  /// **'Single speaker rooms'**
+  String get discoverySingleRooms;
+
+  /// No description provided for @discoveryOtherDevices.
+  ///
+  /// In en, this message translates to:
+  /// **'Other devices'**
+  String get discoveryOtherDevices;
+
+  /// No description provided for @discoverySubwoofer.
+  ///
+  /// In en, this message translates to:
+  /// **'Subwoofer'**
+  String get discoverySubwoofer;
+
+  /// No description provided for @discoveryScanning.
+  ///
+  /// In en, this message translates to:
+  /// **'Scanning your network…'**
+  String get discoveryScanning;
+
+  /// No description provided for @discoveryErrorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t find your system'**
+  String get discoveryErrorTitle;
+
+  /// No description provided for @discoveryTryAgain.
+  ///
+  /// In en, this message translates to:
+  /// **'Try again'**
+  String get discoveryTryAgain;
+
+  /// No description provided for @roomTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Room'**
+  String get roomTitle;
+
+  /// No description provided for @roomRenameTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename room'**
+  String get roomRenameTooltip;
+
+  /// No description provided for @roomRenamedTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Renamed to “{name}”.'**
+  String roomRenamedTo(String name);
+
+  /// No description provided for @roomRenameFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed: {error}'**
+  String roomRenameFailed(String error);
+
+  /// No description provided for @groupSheetTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker group'**
+  String get groupSheetTitle;
+
+  /// No description provided for @groupRenameTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename group'**
+  String get groupRenameTooltip;
+
+  /// No description provided for @groupSeparate.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate'**
+  String get groupSeparate;
+
+  /// No description provided for @groupRenamedTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Renamed to “{name}”.'**
+  String groupRenamedTo(String name);
+
+  /// No description provided for @groupRenameFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed: {error}'**
+  String groupRenameFailed(String error);
+
+  /// No description provided for @groupSeparateConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate group?'**
+  String get groupSeparateConfirmTitle;
+
+  /// No description provided for @groupSeparateConfirmMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'The speakers become standalone rooms again. Their original room names will be restored.'**
+  String get groupSeparateConfirmMessage;
+
+  /// No description provided for @groupSeparateProgressTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate group'**
+  String get groupSeparateProgressTitle;
+
+  /// No description provided for @groupFlowTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Group speakers'**
+  String get groupFlowTitle;
+
+  /// No description provided for @groupNeedTwoSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'Need at least two standalone speakers (not soundbars, subs, amps, or already bonded).'**
+  String get groupNeedTwoSpeakers;
+
+  /// No description provided for @groupModeStereo.
+  ///
+  /// In en, this message translates to:
+  /// **'Stereo'**
+  String get groupModeStereo;
+
+  /// No description provided for @groupModeZone.
+  ///
+  /// In en, this message translates to:
+  /// **'Zone'**
+  String get groupModeZone;
+
+  /// No description provided for @groupModeCustom.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom'**
+  String get groupModeCustom;
+
+  /// No description provided for @groupStepSelect.
+  ///
+  /// In en, this message translates to:
+  /// **'Select speakers'**
+  String get groupStepSelect;
+
+  /// No description provided for @groupStepAddSub.
+  ///
+  /// In en, this message translates to:
+  /// **'Add a Sub'**
+  String get groupStepAddSub;
+
+  /// No description provided for @groupOptional.
+  ///
+  /// In en, this message translates to:
+  /// **'Optional'**
+  String get groupOptional;
+
+  /// No description provided for @groupStepName.
+  ///
+  /// In en, this message translates to:
+  /// **'Name'**
+  String get groupStepName;
+
+  /// No description provided for @groupNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Group name (optional)'**
+  String get groupNameLabel;
+
+  /// No description provided for @groupNameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. Downstairs'**
+  String get groupNameHint;
+
+  /// No description provided for @groupStepReview.
+  ///
+  /// In en, this message translates to:
+  /// **'Review & create'**
+  String get groupStepReview;
+
+  /// No description provided for @groupCreateStereo.
+  ///
+  /// In en, this message translates to:
+  /// **'Create stereo pair'**
+  String get groupCreateStereo;
+
+  /// No description provided for @groupCreateZone.
+  ///
+  /// In en, this message translates to:
+  /// **'Create zone'**
+  String get groupCreateZone;
+
+  /// No description provided for @groupCreateCustom.
+  ///
+  /// In en, this message translates to:
+  /// **'Create custom group'**
+  String get groupCreateCustom;
+
+  /// No description provided for @groupCreateFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn’t create the group — Sonos may not allow one of these speakers. See the log for details.'**
+  String get groupCreateFailed;
+
+  /// No description provided for @groupHintStereo.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick two speakers — one plays left, the other right (swap below). Mismatched models are fine.'**
+  String get groupHintStereo;
+
+  /// No description provided for @groupHintZone.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick 2–16 speakers. They all play full stereo (L+R) as one room.'**
+  String get groupHintZone;
+
+  /// No description provided for @groupHintCustom.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick 2–16 speakers and set each to Left, Right, or Both.'**
+  String get groupHintCustom;
+
+  /// No description provided for @groupSideLeft.
+  ///
+  /// In en, this message translates to:
+  /// **'LEFT'**
+  String get groupSideLeft;
+
+  /// No description provided for @groupSideRight.
+  ///
+  /// In en, this message translates to:
+  /// **'RIGHT'**
+  String get groupSideRight;
+
+  /// No description provided for @groupSwapSides.
+  ///
+  /// In en, this message translates to:
+  /// **'Swap sides'**
+  String get groupSwapSides;
+
+  /// No description provided for @groupChannelLeft.
+  ///
+  /// In en, this message translates to:
+  /// **'Left'**
+  String get groupChannelLeft;
+
+  /// No description provided for @groupChannelBoth.
+  ///
+  /// In en, this message translates to:
+  /// **'Both'**
+  String get groupChannelBoth;
+
+  /// No description provided for @groupChannelRight.
+  ///
+  /// In en, this message translates to:
+  /// **'Right'**
+  String get groupChannelRight;
+
+  /// No description provided for @groupNoSub.
+  ///
+  /// In en, this message translates to:
+  /// **'No standalone Sub available. A Sub bonded to a home theater must be removed there first.'**
+  String get groupNoSub;
+
+  /// No description provided for @groupAddSubHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Optionally add a Sub to the group.'**
+  String get groupAddSubHint;
+
+  /// No description provided for @groupSubwoofer.
+  ///
+  /// In en, this message translates to:
+  /// **'Subwoofer'**
+  String get groupSubwoofer;
+
+  /// No description provided for @groupKindStereo.
+  ///
+  /// In en, this message translates to:
+  /// **'Stereo pair'**
+  String get groupKindStereo;
+
+  /// No description provided for @groupKindZone.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Zone ({count} speaker)} other{Zone ({count} speakers)}}'**
+  String groupKindZone(int count);
+
+  /// No description provided for @groupKindCustom.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Custom group ({count} speaker)} other{Custom group ({count} speakers)}}'**
+  String groupKindCustom(int count);
+
+  /// No description provided for @groupReviewMemberLine.
+  ///
+  /// In en, this message translates to:
+  /// **'{room} — {channel}'**
+  String groupReviewMemberLine(String room, String channel);
+
+  /// No description provided for @groupReviewName.
+  ///
+  /// In en, this message translates to:
+  /// **'Name: {name}'**
+  String groupReviewName(String name);
+
+  /// No description provided for @groupReviewSub.
+  ///
+  /// In en, this message translates to:
+  /// **'Sub: {type}'**
+  String groupReviewSub(String type);
+
+  /// No description provided for @groupReviewNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Bonded speakers play as one room. Larger or mixed-model groups can drop out briefly — play something to confirm it works for you. Original room names are restored when you separate the group.'**
+  String get groupReviewNote;
+
+  /// No description provided for @htHomeTheater.
+  ///
+  /// In en, this message translates to:
+  /// **'Home theater'**
+  String get htHomeTheater;
+
+  /// No description provided for @htRenameRoomTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename room'**
+  String get htRenameRoomTooltip;
+
+  /// No description provided for @htUpdatingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Updating your home theater…'**
+  String get htUpdatingTitle;
+
+  /// No description provided for @htUpdatingSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'This can take up to ~20 seconds while Sonos reconfigures and re-reads the layout.'**
+  String get htUpdatingSubtitle;
+
+  /// No description provided for @htRenamedTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Renamed to “{name}”.'**
+  String htRenamedTo(String name);
+
+  /// No description provided for @htRenameFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed: {error}'**
+  String htRenameFailed(String error);
+
+  /// No description provided for @htSeparateConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate home theater?'**
+  String get htSeparateConfirmTitle;
+
+  /// No description provided for @htRemoveConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove {label}?'**
+  String htRemoveConfirmTitle(String label);
+
+  /// No description provided for @htSeparateMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'All extra speakers will be un-bonded and become standalone rooms again, leaving just the soundbar.'**
+  String get htSeparateMessage;
+
+  /// No description provided for @htRemoveMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'These speakers will be un-bonded and become standalone rooms again. The rest of your home theater stays as it is.'**
+  String get htRemoveMessage;
+
+  /// No description provided for @htSeparate.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate'**
+  String get htSeparate;
+
+  /// No description provided for @htSeparateProgressTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Separate home theater'**
+  String get htSeparateProgressTitle;
+
+  /// No description provided for @htRemoveProgressTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove {label}'**
+  String htRemoveProgressTitle(String label);
+
+  /// No description provided for @htGroupFronts.
+  ///
+  /// In en, this message translates to:
+  /// **'Fronts'**
+  String get htGroupFronts;
+
+  /// No description provided for @htGroupSurrounds.
+  ///
+  /// In en, this message translates to:
+  /// **'Surrounds'**
+  String get htGroupSurrounds;
+
+  /// No description provided for @htGroupSubwoofer.
+  ///
+  /// In en, this message translates to:
+  /// **'Subwoofer'**
+  String get htGroupSubwoofer;
+
+  /// No description provided for @htConfigure.
+  ///
+  /// In en, this message translates to:
+  /// **'Configure home theater'**
+  String get htConfigure;
+
+  /// No description provided for @htBondedSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'Bonded speakers'**
+  String get htBondedSpeakers;
+
+  /// No description provided for @htNoBonded.
+  ///
+  /// In en, this message translates to:
+  /// **'Just the soundbar — no fronts, surrounds or sub bonded yet. Tap “Configure home theater” to add some.'**
+  String get htNoBonded;
+
+  /// No description provided for @htSpeakerFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'Speaker'**
+  String get htSpeakerFallback;
+
+  /// No description provided for @htTrueplayNote.
+  ///
+  /// In en, this message translates to:
+  /// **'Trueplay can only be measured from the Sonos app on iOS — tune the home theater, and the fronts separately as a stereo pair. Heads-up: Sonos often clears a tuning when speakers are bonded/unbonded, so you may see “Not tuned” after changing the layout and have to redo it. Sonority only toggles a stored tuning.'**
+  String get htTrueplayNote;
+
+  /// No description provided for @htAllExtraSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'all extra speakers'**
+  String get htAllExtraSpeakers;
+
+  /// No description provided for @htBonded.
+  ///
+  /// In en, this message translates to:
+  /// **'Bonded'**
+  String get htBonded;
+
+  /// No description provided for @frontSurroundsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Set up home theater'**
+  String get frontSurroundsTitle;
+
+  /// No description provided for @frontSurroundsStepFronts.
+  ///
+  /// In en, this message translates to:
+  /// **'Front speakers'**
+  String get frontSurroundsStepFronts;
+
+  /// No description provided for @frontSurroundsOptional.
+  ///
+  /// In en, this message translates to:
+  /// **'Optional'**
+  String get frontSurroundsOptional;
+
+  /// No description provided for @frontSurroundsFrontsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick two speakers (or a single Amp) for the front left & right, then set which is which.'**
+  String get frontSurroundsFrontsHint;
+
+  /// No description provided for @frontSurroundsLeft.
+  ///
+  /// In en, this message translates to:
+  /// **'LEFT'**
+  String get frontSurroundsLeft;
+
+  /// No description provided for @frontSurroundsRight.
+  ///
+  /// In en, this message translates to:
+  /// **'RIGHT'**
+  String get frontSurroundsRight;
+
+  /// No description provided for @frontSurroundsStepSurrounds.
+  ///
+  /// In en, this message translates to:
+  /// **'Rear surrounds'**
+  String get frontSurroundsStepSurrounds;
+
+  /// No description provided for @frontSurroundsSurroundsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick two speakers for the rear left & right surrounds.'**
+  String get frontSurroundsSurroundsHint;
+
+  /// No description provided for @frontSurroundsRearLeft.
+  ///
+  /// In en, this message translates to:
+  /// **'REAR LEFT'**
+  String get frontSurroundsRearLeft;
+
+  /// No description provided for @frontSurroundsRearRight.
+  ///
+  /// In en, this message translates to:
+  /// **'REAR RIGHT'**
+  String get frontSurroundsRearRight;
+
+  /// No description provided for @frontSurroundsStepSub.
+  ///
+  /// In en, this message translates to:
+  /// **'Subwoofer'**
+  String get frontSurroundsStepSub;
+
+  /// No description provided for @frontSurroundsStepReview.
+  ///
+  /// In en, this message translates to:
+  /// **'Review & apply'**
+  String get frontSurroundsStepReview;
+
+  /// No description provided for @frontSurroundsUnbondTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{Unbond {count} speaker?} other{Unbond {count} speakers?}}'**
+  String frontSurroundsUnbondTitle(int count);
+
+  /// No description provided for @frontSurroundsUnbondMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'{types} will be removed from this home theater and become standalone rooms again. The rest of your layout stays as it is.'**
+  String frontSurroundsUnbondMessage(String types);
+
+  /// No description provided for @frontSurroundsUnbond.
+  ///
+  /// In en, this message translates to:
+  /// **'Unbond'**
+  String get frontSurroundsUnbond;
+
+  /// No description provided for @frontSurroundsNoFreeSpeakers.
+  ///
+  /// In en, this message translates to:
+  /// **'No free speakers available. They must be standalone (not already part of a home theater or stereo pair).'**
+  String get frontSurroundsNoFreeSpeakers;
+
+  /// No description provided for @frontSurroundsPickWithAmp.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick two speakers (ideally identical), or a single Sonos Amp that drives both front speakers.'**
+  String get frontSurroundsPickWithAmp;
+
+  /// No description provided for @frontSurroundsPickExactlyTwo.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick exactly two — ideally an identical pair.'**
+  String get frontSurroundsPickExactlyTwo;
+
+  /// No description provided for @frontSurroundsAmpSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'{type} — drives both fronts (L + R)'**
+  String frontSurroundsAmpSubtitle(String type);
+
+  /// No description provided for @frontSurroundsNoFreeSub.
+  ///
+  /// In en, this message translates to:
+  /// **'No free subwoofer found. A Sonos Sub must be standalone (not already bonded to another home theater).'**
+  String get frontSurroundsNoFreeSub;
+
+  /// No description provided for @frontSurroundsSubHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick one or two subwoofers to add as low-frequency channels.'**
+  String get frontSurroundsSubHint;
+
+  /// No description provided for @frontSurroundsAmpWiring.
+  ///
+  /// In en, this message translates to:
+  /// **'The {amp} drives both front channels. Wire your left & right speakers to its L/R speaker outputs — there’s nothing to assign here.'**
+  String frontSurroundsAmpWiring(String amp);
+
+  /// No description provided for @frontSurroundsChooseTwoFirst.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose two speakers first.'**
+  String get frontSurroundsChooseTwoFirst;
+
+  /// No description provided for @frontSurroundsSwapSides.
+  ///
+  /// In en, this message translates to:
+  /// **'Swap sides'**
+  String get frontSurroundsSwapSides;
+
+  /// No description provided for @frontSurroundsTapSwap.
+  ///
+  /// In en, this message translates to:
+  /// **'Tap swap if the sides are reversed.'**
+  String get frontSurroundsTapSwap;
+
+  /// No description provided for @frontSurroundsNothingSelected.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing selected yet — choose speakers above.'**
+  String get frontSurroundsNothingSelected;
+
+  /// No description provided for @frontSurroundsReviewNote.
+  ///
+  /// In en, this message translates to:
+  /// **'The chosen speakers become hidden satellites of the soundbar (which stays the center channel). Bonding runs in steps and can take a little while; Trueplay may need re-tuning afterward. You can change this anytime.'**
+  String get frontSurroundsReviewNote;
+
+  /// No description provided for @diagNoSystemToCollect.
+  ///
+  /// In en, this message translates to:
+  /// **'No system to collect — scan first.'**
+  String get diagNoSystemToCollect;
+
+  /// No description provided for @diagBuildFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not build the diagnostics bundle: {error}'**
+  String diagBuildFailed(String error);
+
+  /// No description provided for @diagActionFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not complete the action: {error}'**
+  String diagActionFailed(String error);
+
+  /// No description provided for @diagSavedTo.
+  ///
+  /// In en, this message translates to:
+  /// **'Saved to {path}'**
+  String diagSavedTo(String path);
+
+  /// No description provided for @diagTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Diagnostics'**
+  String get diagTitle;
+
+  /// No description provided for @diagNoSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'No system discovered yet.'**
+  String get diagNoSystem;
+
+  /// No description provided for @diagIncludeLogs.
+  ///
+  /// In en, this message translates to:
+  /// **'Include app logs'**
+  String get diagIncludeLogs;
+
+  /// No description provided for @diagIncludeLogsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'SOAP faults, bond retries, discovery, errors (logs.txt)'**
+  String get diagIncludeLogsSubtitle;
+
+  /// No description provided for @diagIncludeNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'Include phone network info'**
+  String get diagIncludeNetwork;
+
+  /// No description provided for @diagIncludeNetworkSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'This device’s network interface addresses (network.txt)'**
+  String get diagIncludeNetworkSubtitle;
+
+  /// No description provided for @diagAlwaysIncluded.
+  ///
+  /// In en, this message translates to:
+  /// **'Always included: topology (room names, IPs, MACs, models), raw device descriptions, and your saved profiles/room names.'**
+  String get diagAlwaysIncluded;
+
+  /// No description provided for @diagCollecting.
+  ///
+  /// In en, this message translates to:
+  /// **'Collecting…'**
+  String get diagCollecting;
+
+  /// No description provided for @diagEmailToDeveloper.
+  ///
+  /// In en, this message translates to:
+  /// **'Email to developer'**
+  String get diagEmailToDeveloper;
+
+  /// No description provided for @diagShareDiagnostics.
+  ///
+  /// In en, this message translates to:
+  /// **'Share diagnostics'**
+  String get diagShareDiagnostics;
+
+  /// No description provided for @diagEmailBody.
+  ///
+  /// In en, this message translates to:
+  /// **'Describe what went wrong (what you tried, what you expected, what happened):\n\n\n——— the diagnostics bundle is attached below ———'**
+  String get diagEmailBody;
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['en'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
+}

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1,0 +1,1155 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for English (`en`).
+class AppLocalizationsEn extends AppLocalizations {
+  AppLocalizationsEn([String locale = 'en']) : super(locale);
+
+  @override
+  String get tabSystem => 'System';
+
+  @override
+  String get tabProfiles => 'Profiles';
+
+  @override
+  String get actionCancel => 'Cancel';
+
+  @override
+  String get actionDone => 'Done';
+
+  @override
+  String get actionDelete => 'Delete';
+
+  @override
+  String get actionRemove => 'Remove';
+
+  @override
+  String get actionRename => 'Rename';
+
+  @override
+  String get actionApply => 'Apply';
+
+  @override
+  String get actionRetry => 'Retry';
+
+  @override
+  String get actionAdd => 'Add';
+
+  @override
+  String get actionSave => 'Save';
+
+  @override
+  String get actionClose => 'Close';
+
+  @override
+  String get actionBack => 'Back';
+
+  @override
+  String get actionNext => 'Next';
+
+  @override
+  String get actionContinue => 'Continue';
+
+  @override
+  String get actionOk => 'OK';
+
+  @override
+  String get actionAbort => 'Abort';
+
+  @override
+  String get actionAborting => 'Aborting…';
+
+  @override
+  String get bondingCopyLogs => 'Copy logs';
+
+  @override
+  String get bondingShowSteps => 'Show steps';
+
+  @override
+  String get bondingShowRawLog => 'Show raw log';
+
+  @override
+  String get bondingLogsCopied => 'Logs copied to clipboard.';
+
+  @override
+  String get bondingNoLogOutput => 'No log output yet.';
+
+  @override
+  String get errSystemNotFound =>
+      'Couldn’t find your Sonos system on the network.';
+
+  @override
+  String get errNoDevicesFound =>
+      'No Sonos devices found. Check Wi-Fi and local network access.';
+
+  @override
+  String get errDescriptionsUnreadable =>
+      'Found Sonos players but could not read their descriptions.';
+
+  @override
+  String get errTopologyUnreadable =>
+      'Could not read the Sonos topology from any player.';
+
+  @override
+  String errEntityNotOnNetwork(String name) {
+    return '“$name” isn’t on the network.';
+  }
+
+  @override
+  String errCoordinatorNotOnNetwork(String name) {
+    return '“$name” coordinator isn’t on the network.';
+  }
+
+  @override
+  String errSpeakerInEntityNotOnNetwork(String name) {
+    return 'A speaker in “$name” isn’t on the network.';
+  }
+
+  @override
+  String errSubNotOnNetwork(String name) {
+    return 'The Sub for “$name” isn’t on the network.';
+  }
+
+  @override
+  String errSoundbarNotOnNetwork(String name) {
+    return 'Soundbar for “$name” isn’t on the network.';
+  }
+
+  @override
+  String errEntityMissingSpeakers(String name) {
+    return '“$name” is missing speakers.';
+  }
+
+  @override
+  String get errMalformedGroup => 'Stored group is malformed.';
+
+  @override
+  String get errMalformedHomeTheater => 'Stored home theater is malformed.';
+
+  @override
+  String errDidNotForm(String name) {
+    return 'Sonos did not form “$name”.';
+  }
+
+  @override
+  String get errDidNotCreateGroup =>
+      'Sonos did not create the group — a speaker may be incompatible.';
+
+  @override
+  String get errDidNotSeparate =>
+      'Sonos did not separate the group — try again.';
+
+  @override
+  String errDidNotRemove(String label) {
+    return 'Sonos did not remove the $label — try again.';
+  }
+
+  @override
+  String get errGroupNeedsTwo => 'A group needs at least 2 speakers.';
+
+  @override
+  String get errSpeakerIpUnknown => 'Speaker IP unknown; rescan and retry.';
+
+  @override
+  String get errSoundbarIpUnknown => 'Soundbar IP unknown; rescan and retry.';
+
+  @override
+  String get errCoordinatorIpUnknown =>
+      'Coordinator IP unknown; rescan and retry.';
+
+  @override
+  String errBondingIncomplete(String channels) {
+    return 'Bonding did not complete — these channels never joined: $channels. Try again, or finish in the Sonos app.';
+  }
+
+  @override
+  String get errNoLanIpForChime => 'No LAN IP found to serve the chime from.';
+
+  @override
+  String get errCannotBlinkLight =>
+      'Could not reach the speaker to blink its light.';
+
+  @override
+  String get errTimeout =>
+      'The speaker didn’t respond in time. It may still be settling — try again in a moment.';
+
+  @override
+  String get errSonosBusy =>
+      'Sonos is busy rearranging speakers right now. Wait a moment and try again.';
+
+  @override
+  String get errUnsupportedCombo =>
+      'Sonos wouldn’t bond these speakers this way (unsupported combination).';
+
+  @override
+  String get errInvalidRequest => 'Sonos rejected the request as invalid.';
+
+  @override
+  String errSonosCode(String code) {
+    return 'Sonos reported an error (code $code). See the raw log for details.';
+  }
+
+  @override
+  String get errSonosGeneric =>
+      'Sonos reported an error. See the raw log for details.';
+
+  @override
+  String get errAborted => 'Aborted';
+
+  @override
+  String get errChimeUnreachable =>
+      'The speaker could not reach your phone to play the sound. Make sure your phone and speakers are on the same Wi‑Fi network. (Android emulators can’t reach speakers on your LAN — use a real device.)';
+
+  @override
+  String get entityKindHomeTheater => 'Home theater';
+
+  @override
+  String get entityKindStereoPair => 'Stereo pair';
+
+  @override
+  String get entityKindZone => 'Zone';
+
+  @override
+  String get entityKindCustom => 'Custom group';
+
+  @override
+  String get entityKindSpeaker => 'Speaker';
+
+  @override
+  String get entityKindGroup => 'Group';
+
+  @override
+  String get stepSetUpHomeTheater => 'Set up home theater';
+
+  @override
+  String get stepScanNetwork => 'Scan network for Sonos system';
+
+  @override
+  String get stepBondSpeakers => 'Bond speakers';
+
+  @override
+  String stepBondNSpeakers(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Bond $count speakers',
+      one: 'Bond $count speaker',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String stepBondNSpeakersWithSub(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Bond $count speakers + sub',
+      one: 'Bond $count speaker + sub',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String stepRemoveUnused(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Remove $count speakers no longer used',
+      one: 'Remove $count speaker no longer used',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String stepUnbondN(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Unbond $count speakers',
+      one: 'Unbond $count speaker',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String stepCreateGroupN(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Create group ($count speakers)',
+      one: 'Create group ($count speaker)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String stepRemoveLabel(String label) {
+    return 'Remove $label';
+  }
+
+  @override
+  String get stepSpeakers => 'speakers';
+
+  @override
+  String get stepRestoreRoomName => 'Restore room name';
+
+  @override
+  String get stepRestoreSettings => 'Restore settings';
+
+  @override
+  String get stepNameGroup => 'Name the group';
+
+  @override
+  String get stepSeparateGroup => 'Separate group';
+
+  @override
+  String get stepSeparateRestore => 'Separate + restore room names';
+
+  @override
+  String get stepDetach => 'Detach from playback group';
+
+  @override
+  String get stepFreeFromBond => 'Free from its current bond';
+
+  @override
+  String get stepFreeConflicting => 'Free conflicting speakers';
+
+  @override
+  String stepFreeing(String name) {
+    return 'Freeing $name';
+  }
+
+  @override
+  String get stepWaitForSettle => 'Wait for Sonos to settle';
+
+  @override
+  String get stepWaitingSettle => 'waiting for Sonos to settle';
+
+  @override
+  String get stepWaitForConfirm => 'Wait for Sonos to confirm';
+
+  @override
+  String get stepWaitingConfirm => 'waiting for Sonos to confirm';
+
+  @override
+  String get stepApplyingSettle =>
+      'Applying — Sonos can take up to a minute to settle.';
+
+  @override
+  String get stepNameUnchanged => 'name unchanged — nothing to do';
+
+  @override
+  String get stepAlreadyFormed => 'already formed — nothing to do';
+
+  @override
+  String get stepLayoutUnchanged => 'layout unchanged — nothing to do';
+
+  @override
+  String stepSkippedMissing(String names) {
+    return 'skipped — $names not on the network';
+  }
+
+  @override
+  String get stepSkippingSettingsOffline =>
+      'Skipping settings — not on the network';
+
+  @override
+  String stepRestoring(String what, String type) {
+    return 'Restoring $what — $type';
+  }
+
+  @override
+  String get stepAudioSettings => 'audio settings';
+
+  @override
+  String get stepVolume => 'volume';
+
+  @override
+  String stepSettingsFailed(int count, String type) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count settings for $type could not be applied',
+      one: '$count setting for $type could not be applied',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get widgetsSomethingWentWrong =>
+      'Something went wrong — see the step below.';
+
+  @override
+  String get widgetsBondingTakesTime =>
+      'Bonding can take ~15–20s per step while Sonos applies and re-reads the layout.';
+
+  @override
+  String get widgetsStepFailed => 'Failed.';
+
+  @override
+  String get widgetsStepWorking => 'Working…';
+
+  @override
+  String get widgetsUnreachableSpeakerHint =>
+      'Couldn’t read this speaker’s details — check it’s powered on and on the same network.';
+
+  @override
+  String get widgetsSoundbar => 'Soundbar';
+
+  @override
+  String get widgetsFronts => 'Fronts';
+
+  @override
+  String get widgetsSurrounds => 'Surrounds';
+
+  @override
+  String get widgetsSubwoofer => 'Subwoofer';
+
+  @override
+  String get widgetsSub => 'Sub';
+
+  @override
+  String get widgetsStandaloneSpeaker => 'Standalone speaker';
+
+  @override
+  String get widgetsNoExtraSpeakers => 'No extra speakers';
+
+  @override
+  String widgetsNSpeakers(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count speakers',
+      one: '$count speaker',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get widgetsRoomNoLongerAvailable =>
+      'This room is no longer available. Rescan to refresh.';
+
+  @override
+  String get widgetsBackToScan => 'Back to scan';
+
+  @override
+  String get widgetsSpeaker => 'Speaker';
+
+  @override
+  String get widgetsBlinkLightTooltip => 'Blink the light';
+
+  @override
+  String get widgetsChimeTooltip => 'Play a test chime';
+
+  @override
+  String widgetsBlinkingLight(String room) {
+    return '💡 Blinking the light on $room…';
+  }
+
+  @override
+  String widgetsPlayingChime(String room) {
+    return '🔊 Playing a chime on $room…';
+  }
+
+  @override
+  String widgetsNoAddressFor(String room) {
+    return 'No address for $room.';
+  }
+
+  @override
+  String widgetsCouldntIdentify(String room, String error) {
+    return 'Couldn’t identify $room: $error';
+  }
+
+  @override
+  String get widgetsRefresh => 'Refresh';
+
+  @override
+  String get widgetsRenameRoomTitle => 'Rename room';
+
+  @override
+  String get widgetsRoomNameLabel => 'Room name';
+
+  @override
+  String get widgetsTvSoundbar => 'TV / Soundbar';
+
+  @override
+  String get widgetsTrueplayChecking => 'Checking…';
+
+  @override
+  String get widgetsTrueplayNotTuned =>
+      'Not tuned — run Trueplay once in the Sonos app (iOS).';
+
+  @override
+  String get widgetsTrueplayActive => 'Active';
+
+  @override
+  String get widgetsTrueplayTunedOff => 'Tuned · off';
+
+  @override
+  String widgetsTrueplayActiveCount(int enabled, int total) {
+    return '$enabled/$total active';
+  }
+
+  @override
+  String widgetsTrueplayTunedCount(int tuned, int total) {
+    return '$tuned/$total tuned';
+  }
+
+  @override
+  String get widgetsChangelog => 'Changelog';
+
+  @override
+  String profileLoadError(String error) {
+    return 'Couldn’t load profiles: $error';
+  }
+
+  @override
+  String get profileEdit => 'Edit';
+
+  @override
+  String get profileScanFirst => 'Scan your system first (System tab).';
+
+  @override
+  String get profileNew => 'New profile';
+
+  @override
+  String profileDeleteConfirm(String name) {
+    return 'Delete “$name”?';
+  }
+
+  @override
+  String get profileDeleteMessage =>
+      'This removes the saved profile. Your speakers are not changed.';
+
+  @override
+  String profileApplying(String name) {
+    return 'Applying “$name”';
+  }
+
+  @override
+  String get profileEmptyTitle => 'No profiles yet';
+
+  @override
+  String get profileEmptyBody =>
+      'A profile snapshots your current home theaters, stereo pairs and rooms so you can rebuild them in one tap — handy after moving speakers away. Tap “New profile” to capture your setup now.';
+
+  @override
+  String profileApplyConfirmTitle(String name) {
+    return 'Apply “$name”?';
+  }
+
+  @override
+  String get profileApplyConfirmBody =>
+      'This re-bonds speakers on your live system and may take a while (each step waits for Sonos to settle). Trueplay may need re-tuning afterward.';
+
+  @override
+  String profileIssueMissing(String speakers) {
+    return 'Missing: $speakers — will be skipped';
+  }
+
+  @override
+  String profileIssueFree(String speakers) {
+    return 'Will free: $speakers';
+  }
+
+  @override
+  String get profileNothingApplicable =>
+      'Nothing can be applied — all entities are missing speakers.';
+
+  @override
+  String profileApplySummary(int applicable, int total, int skipped) {
+    return 'Will apply $applicable of $total entities; $skipped skipped.';
+  }
+
+  @override
+  String get profileResnapshot => 'Re-snapshot';
+
+  @override
+  String get profileScanFirstCreate =>
+      'Scan your system first (System tab), then create a profile from it.';
+
+  @override
+  String get profileReadingSettings => 'Reading settings…';
+
+  @override
+  String get profileUseSnapshot => 'Use snapshot';
+
+  @override
+  String get profileCreate => 'Create profile';
+
+  @override
+  String get profileResnapshotNote =>
+      'Recapture your current setup, then review and save it on the profile screen.';
+
+  @override
+  String get profileApplyPrimer =>
+      'Applying a profile later rebuilds these speakers into this layout. Any speaker that’s part of a different setup at that time is removed from it first — which can dissolve another stereo pair or zone and free its other speakers.';
+
+  @override
+  String get profileIncludeHeader => 'Include';
+
+  @override
+  String get profileIncludeHelper =>
+      'Pick which of your current home theaters, pairs and rooms to capture in this profile.';
+
+  @override
+  String get profileSpeakerSettingsHeader => 'Speaker settings';
+
+  @override
+  String get profileSpeakerSettingsHelper =>
+      'Optionally snapshot each speaker’s current settings and restore them when this profile is applied.';
+
+  @override
+  String get profileSaveAudio => 'Save audio settings';
+
+  @override
+  String get profileSaveAudioSubtitle =>
+      'EQ, night sound, speech enhancement, sub & surround levels, lip sync & more';
+
+  @override
+  String get profileSaveVolume => 'Save volume';
+
+  @override
+  String get profileSaveVolumeSubtitle =>
+      'Applying the profile will change how loud each speaker plays';
+
+  @override
+  String get profileDefaultName => 'My setup';
+
+  @override
+  String get profileTitle => 'Profile';
+
+  @override
+  String get profileResnapshotTooltip => 'Re-snapshot from current setup';
+
+  @override
+  String get profileIncludedHeader => 'Included';
+
+  @override
+  String get profileRecapturedNote =>
+      'Recaptured from your current setup — press Save to keep it.';
+
+  @override
+  String get profileCapturedNote =>
+      'Captured when the profile was created. Use the re-snapshot button (top right) to recapture from your current setup.';
+
+  @override
+  String get profileSaved => 'Profile saved';
+
+  @override
+  String get profileNoSettingsSaved =>
+      'No speaker settings saved in this profile.';
+
+  @override
+  String get profileRoleSoundbar => 'Soundbar';
+
+  @override
+  String get profileRoleFront => 'Front';
+
+  @override
+  String get profileRoleSurroundL => 'Surround L';
+
+  @override
+  String get profileRoleSurroundR => 'Surround R';
+
+  @override
+  String get profileNameLabel => 'Profile name';
+
+  @override
+  String get profileNameTaken => 'A profile with this name exists';
+
+  @override
+  String get profileNoEntities => 'No entities';
+
+  @override
+  String get profileBadgeAudio => 'Audio settings';
+
+  @override
+  String get profileBadgeVolume => 'Volume';
+
+  @override
+  String get profileAppearance => 'Appearance';
+
+  @override
+  String get profileWidgetPickTitle => 'Pick profiles';
+
+  @override
+  String get profileWidgetEmpty =>
+      'No profiles yet — create one in Sonority first.';
+
+  @override
+  String get profileWidgetPickHelper =>
+      'Pick the profiles to show. Reorder them in the Profiles tab.';
+
+  @override
+  String get profileWidgetSelectAtLeastOne => 'Select at least one';
+
+  @override
+  String profileWidgetAddCount(int count) {
+    return 'Add $count to widget';
+  }
+
+  @override
+  String get discoveryDiagnostics => 'Diagnostics';
+
+  @override
+  String get discoveryRescan => 'Rescan';
+
+  @override
+  String get discoveryHomeTheaters => 'Home theaters';
+
+  @override
+  String get discoveryNoSoundbar =>
+      'No soundbar found. Dedicated fronts need an Arc, Beam, Ray, Playbar or Playbase.';
+
+  @override
+  String get discoverySpeakerGroups => 'Speaker groups';
+
+  @override
+  String get discoveryGroupSpeakers => 'Group speakers';
+
+  @override
+  String get discoveryNoGroups => 'No speaker groups yet';
+
+  @override
+  String get discoverySingleRooms => 'Single speaker rooms';
+
+  @override
+  String get discoveryOtherDevices => 'Other devices';
+
+  @override
+  String get discoverySubwoofer => 'Subwoofer';
+
+  @override
+  String get discoveryScanning => 'Scanning your network…';
+
+  @override
+  String get discoveryErrorTitle => 'Couldn’t find your system';
+
+  @override
+  String get discoveryTryAgain => 'Try again';
+
+  @override
+  String get roomTitle => 'Room';
+
+  @override
+  String get roomRenameTooltip => 'Rename room';
+
+  @override
+  String roomRenamedTo(String name) {
+    return 'Renamed to “$name”.';
+  }
+
+  @override
+  String roomRenameFailed(String error) {
+    return 'Failed: $error';
+  }
+
+  @override
+  String get groupSheetTitle => 'Speaker group';
+
+  @override
+  String get groupRenameTooltip => 'Rename group';
+
+  @override
+  String get groupSeparate => 'Separate';
+
+  @override
+  String groupRenamedTo(String name) {
+    return 'Renamed to “$name”.';
+  }
+
+  @override
+  String groupRenameFailed(String error) {
+    return 'Failed: $error';
+  }
+
+  @override
+  String get groupSeparateConfirmTitle => 'Separate group?';
+
+  @override
+  String get groupSeparateConfirmMessage =>
+      'The speakers become standalone rooms again. Their original room names will be restored.';
+
+  @override
+  String get groupSeparateProgressTitle => 'Separate group';
+
+  @override
+  String get groupFlowTitle => 'Group speakers';
+
+  @override
+  String get groupNeedTwoSpeakers =>
+      'Need at least two standalone speakers (not soundbars, subs, amps, or already bonded).';
+
+  @override
+  String get groupModeStereo => 'Stereo';
+
+  @override
+  String get groupModeZone => 'Zone';
+
+  @override
+  String get groupModeCustom => 'Custom';
+
+  @override
+  String get groupStepSelect => 'Select speakers';
+
+  @override
+  String get groupStepAddSub => 'Add a Sub';
+
+  @override
+  String get groupOptional => 'Optional';
+
+  @override
+  String get groupStepName => 'Name';
+
+  @override
+  String get groupNameLabel => 'Group name (optional)';
+
+  @override
+  String get groupNameHint => 'e.g. Downstairs';
+
+  @override
+  String get groupStepReview => 'Review & create';
+
+  @override
+  String get groupCreateStereo => 'Create stereo pair';
+
+  @override
+  String get groupCreateZone => 'Create zone';
+
+  @override
+  String get groupCreateCustom => 'Create custom group';
+
+  @override
+  String get groupCreateFailed =>
+      'Couldn’t create the group — Sonos may not allow one of these speakers. See the log for details.';
+
+  @override
+  String get groupHintStereo =>
+      'Pick two speakers — one plays left, the other right (swap below). Mismatched models are fine.';
+
+  @override
+  String get groupHintZone =>
+      'Pick 2–16 speakers. They all play full stereo (L+R) as one room.';
+
+  @override
+  String get groupHintCustom =>
+      'Pick 2–16 speakers and set each to Left, Right, or Both.';
+
+  @override
+  String get groupSideLeft => 'LEFT';
+
+  @override
+  String get groupSideRight => 'RIGHT';
+
+  @override
+  String get groupSwapSides => 'Swap sides';
+
+  @override
+  String get groupChannelLeft => 'Left';
+
+  @override
+  String get groupChannelBoth => 'Both';
+
+  @override
+  String get groupChannelRight => 'Right';
+
+  @override
+  String get groupNoSub =>
+      'No standalone Sub available. A Sub bonded to a home theater must be removed there first.';
+
+  @override
+  String get groupAddSubHint => 'Optionally add a Sub to the group.';
+
+  @override
+  String get groupSubwoofer => 'Subwoofer';
+
+  @override
+  String get groupKindStereo => 'Stereo pair';
+
+  @override
+  String groupKindZone(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Zone ($count speakers)',
+      one: 'Zone ($count speaker)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String groupKindCustom(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Custom group ($count speakers)',
+      one: 'Custom group ($count speaker)',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String groupReviewMemberLine(String room, String channel) {
+    return '$room — $channel';
+  }
+
+  @override
+  String groupReviewName(String name) {
+    return 'Name: $name';
+  }
+
+  @override
+  String groupReviewSub(String type) {
+    return 'Sub: $type';
+  }
+
+  @override
+  String get groupReviewNote =>
+      'Bonded speakers play as one room. Larger or mixed-model groups can drop out briefly — play something to confirm it works for you. Original room names are restored when you separate the group.';
+
+  @override
+  String get htHomeTheater => 'Home theater';
+
+  @override
+  String get htRenameRoomTooltip => 'Rename room';
+
+  @override
+  String get htUpdatingTitle => 'Updating your home theater…';
+
+  @override
+  String get htUpdatingSubtitle =>
+      'This can take up to ~20 seconds while Sonos reconfigures and re-reads the layout.';
+
+  @override
+  String htRenamedTo(String name) {
+    return 'Renamed to “$name”.';
+  }
+
+  @override
+  String htRenameFailed(String error) {
+    return 'Failed: $error';
+  }
+
+  @override
+  String get htSeparateConfirmTitle => 'Separate home theater?';
+
+  @override
+  String htRemoveConfirmTitle(String label) {
+    return 'Remove $label?';
+  }
+
+  @override
+  String get htSeparateMessage =>
+      'All extra speakers will be un-bonded and become standalone rooms again, leaving just the soundbar.';
+
+  @override
+  String get htRemoveMessage =>
+      'These speakers will be un-bonded and become standalone rooms again. The rest of your home theater stays as it is.';
+
+  @override
+  String get htSeparate => 'Separate';
+
+  @override
+  String get htSeparateProgressTitle => 'Separate home theater';
+
+  @override
+  String htRemoveProgressTitle(String label) {
+    return 'Remove $label';
+  }
+
+  @override
+  String get htGroupFronts => 'Fronts';
+
+  @override
+  String get htGroupSurrounds => 'Surrounds';
+
+  @override
+  String get htGroupSubwoofer => 'Subwoofer';
+
+  @override
+  String get htConfigure => 'Configure home theater';
+
+  @override
+  String get htBondedSpeakers => 'Bonded speakers';
+
+  @override
+  String get htNoBonded =>
+      'Just the soundbar — no fronts, surrounds or sub bonded yet. Tap “Configure home theater” to add some.';
+
+  @override
+  String get htSpeakerFallback => 'Speaker';
+
+  @override
+  String get htTrueplayNote =>
+      'Trueplay can only be measured from the Sonos app on iOS — tune the home theater, and the fronts separately as a stereo pair. Heads-up: Sonos often clears a tuning when speakers are bonded/unbonded, so you may see “Not tuned” after changing the layout and have to redo it. Sonority only toggles a stored tuning.';
+
+  @override
+  String get htAllExtraSpeakers => 'all extra speakers';
+
+  @override
+  String get htBonded => 'Bonded';
+
+  @override
+  String get frontSurroundsTitle => 'Set up home theater';
+
+  @override
+  String get frontSurroundsStepFronts => 'Front speakers';
+
+  @override
+  String get frontSurroundsOptional => 'Optional';
+
+  @override
+  String get frontSurroundsFrontsHint =>
+      'Pick two speakers (or a single Amp) for the front left & right, then set which is which.';
+
+  @override
+  String get frontSurroundsLeft => 'LEFT';
+
+  @override
+  String get frontSurroundsRight => 'RIGHT';
+
+  @override
+  String get frontSurroundsStepSurrounds => 'Rear surrounds';
+
+  @override
+  String get frontSurroundsSurroundsHint =>
+      'Pick two speakers for the rear left & right surrounds.';
+
+  @override
+  String get frontSurroundsRearLeft => 'REAR LEFT';
+
+  @override
+  String get frontSurroundsRearRight => 'REAR RIGHT';
+
+  @override
+  String get frontSurroundsStepSub => 'Subwoofer';
+
+  @override
+  String get frontSurroundsStepReview => 'Review & apply';
+
+  @override
+  String frontSurroundsUnbondTitle(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Unbond $count speakers?',
+      one: 'Unbond $count speaker?',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String frontSurroundsUnbondMessage(String types) {
+    return '$types will be removed from this home theater and become standalone rooms again. The rest of your layout stays as it is.';
+  }
+
+  @override
+  String get frontSurroundsUnbond => 'Unbond';
+
+  @override
+  String get frontSurroundsNoFreeSpeakers =>
+      'No free speakers available. They must be standalone (not already part of a home theater or stereo pair).';
+
+  @override
+  String get frontSurroundsPickWithAmp =>
+      'Pick two speakers (ideally identical), or a single Sonos Amp that drives both front speakers.';
+
+  @override
+  String get frontSurroundsPickExactlyTwo =>
+      'Pick exactly two — ideally an identical pair.';
+
+  @override
+  String frontSurroundsAmpSubtitle(String type) {
+    return '$type — drives both fronts (L + R)';
+  }
+
+  @override
+  String get frontSurroundsNoFreeSub =>
+      'No free subwoofer found. A Sonos Sub must be standalone (not already bonded to another home theater).';
+
+  @override
+  String get frontSurroundsSubHint =>
+      'Pick one or two subwoofers to add as low-frequency channels.';
+
+  @override
+  String frontSurroundsAmpWiring(String amp) {
+    return 'The $amp drives both front channels. Wire your left & right speakers to its L/R speaker outputs — there’s nothing to assign here.';
+  }
+
+  @override
+  String get frontSurroundsChooseTwoFirst => 'Choose two speakers first.';
+
+  @override
+  String get frontSurroundsSwapSides => 'Swap sides';
+
+  @override
+  String get frontSurroundsTapSwap => 'Tap swap if the sides are reversed.';
+
+  @override
+  String get frontSurroundsNothingSelected =>
+      'Nothing selected yet — choose speakers above.';
+
+  @override
+  String get frontSurroundsReviewNote =>
+      'The chosen speakers become hidden satellites of the soundbar (which stays the center channel). Bonding runs in steps and can take a little while; Trueplay may need re-tuning afterward. You can change this anytime.';
+
+  @override
+  String get diagNoSystemToCollect => 'No system to collect — scan first.';
+
+  @override
+  String diagBuildFailed(String error) {
+    return 'Could not build the diagnostics bundle: $error';
+  }
+
+  @override
+  String diagActionFailed(String error) {
+    return 'Could not complete the action: $error';
+  }
+
+  @override
+  String diagSavedTo(String path) {
+    return 'Saved to $path';
+  }
+
+  @override
+  String get diagTitle => 'Diagnostics';
+
+  @override
+  String get diagNoSystem => 'No system discovered yet.';
+
+  @override
+  String get diagIncludeLogs => 'Include app logs';
+
+  @override
+  String get diagIncludeLogsSubtitle =>
+      'SOAP faults, bond retries, discovery, errors (logs.txt)';
+
+  @override
+  String get diagIncludeNetwork => 'Include phone network info';
+
+  @override
+  String get diagIncludeNetworkSubtitle =>
+      'This device’s network interface addresses (network.txt)';
+
+  @override
+  String get diagAlwaysIncluded =>
+      'Always included: topology (room names, IPs, MACs, models), raw device descriptions, and your saved profiles/room names.';
+
+  @override
+  String get diagCollecting => 'Collecting…';
+
+  @override
+  String get diagEmailToDeveloper => 'Email to developer';
+
+  @override
+  String get diagShareDiagnostics => 'Share diagnostics';
+
+  @override
+  String get diagEmailBody =>
+      'Describe what went wrong (what you tried, what you expected, what happened):\n\n\n——— the diagnostics bundle is attached below ———';
+}

--- a/lib/state/localized_error.dart
+++ b/lib/state/localized_error.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import '../core/l10n.dart';
+import '../data/sonos/cancellation.dart';
+import '../data/sonos/friendly_error.dart';
+import '../data/sonos/identify_errors.dart';
+import '../data/sonos/soap_client.dart';
+import '../data/sonos/sonority_error.dart';
+
+/// Words an engine/state error for on-screen display, translated via
+/// [AppLocalizations]. The counterpart to the engine's English `friendlyError`
+/// (kept for CLI tools / the diagnostics bundle) — this is the single place the
+/// UI turns a raw exception into user copy. Anything unrecognized falls back to
+/// `friendlyError`'s English so no error is ever swallowed.
+///
+/// Pass `context.l10n`, or `appL10n()` from context-less code.
+String localizedError(AppLocalizations l10n, Object e) {
+  if (e is SonorityError) {
+    final a = e.arg ?? '';
+    switch (e.code) {
+      case SonorityErrorCode.systemNotFound:
+        return l10n.errSystemNotFound;
+      case SonorityErrorCode.noDevicesFound:
+        return l10n.errNoDevicesFound;
+      case SonorityErrorCode.descriptionsUnreadable:
+        return l10n.errDescriptionsUnreadable;
+      case SonorityErrorCode.topologyUnreadable:
+        return l10n.errTopologyUnreadable;
+      case SonorityErrorCode.entityNotOnNetwork:
+        return l10n.errEntityNotOnNetwork(a);
+      case SonorityErrorCode.coordinatorNotOnNetwork:
+        return l10n.errCoordinatorNotOnNetwork(a);
+      case SonorityErrorCode.speakerInEntityNotOnNetwork:
+        return l10n.errSpeakerInEntityNotOnNetwork(a);
+      case SonorityErrorCode.subNotOnNetwork:
+        return l10n.errSubNotOnNetwork(a);
+      case SonorityErrorCode.soundbarNotOnNetwork:
+        return l10n.errSoundbarNotOnNetwork(a);
+      case SonorityErrorCode.entityMissingSpeakers:
+        return l10n.errEntityMissingSpeakers(a);
+      case SonorityErrorCode.malformedGroup:
+        return l10n.errMalformedGroup;
+      case SonorityErrorCode.malformedHomeTheater:
+        return l10n.errMalformedHomeTheater;
+      case SonorityErrorCode.didNotForm:
+        return l10n.errDidNotForm(a);
+      case SonorityErrorCode.didNotCreateGroup:
+        return l10n.errDidNotCreateGroup;
+      case SonorityErrorCode.didNotSeparate:
+        return l10n.errDidNotSeparate;
+      case SonorityErrorCode.didNotRemove:
+        return l10n.errDidNotRemove(a);
+      case SonorityErrorCode.groupNeedsTwo:
+        return l10n.errGroupNeedsTwo;
+      case SonorityErrorCode.speakerIpUnknown:
+        return l10n.errSpeakerIpUnknown;
+      case SonorityErrorCode.soundbarIpUnknown:
+        return l10n.errSoundbarIpUnknown;
+      case SonorityErrorCode.coordinatorIpUnknown:
+        return l10n.errCoordinatorIpUnknown;
+      case SonorityErrorCode.bondingIncomplete:
+        return l10n.errBondingIncomplete(a);
+      case SonorityErrorCode.noLanIpForChime:
+        return l10n.errNoLanIpForChime;
+      case SonorityErrorCode.cannotBlinkLight:
+        return l10n.errCannotBlinkLight;
+    }
+  }
+  if (e is OperationCancelled) return l10n.errAborted;
+  if (e is SpeakerUnreachable) return l10n.errChimeUnreachable;
+  if (e is TimeoutException) return l10n.errTimeout;
+  if (e is SonosSoapException) {
+    switch (e.faultCode) {
+      case '800':
+        return l10n.errSonosBusy;
+      case '401':
+        return l10n.errUnsupportedCombo;
+      case '402':
+        return l10n.errInvalidRequest;
+    }
+    final code = e.faultCode;
+    return code == null ? l10n.errSonosGeneric : l10n.errSonosCode(code);
+  }
+  // Unknown: fall back to the engine's English (never swallow an error).
+  return friendlyError(e);
+}

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -1,21 +1,33 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../core/l10n.dart';
 import '../data/models/sonos_models.dart';
 import '../data/sonos/apply_progress.dart';
 import '../data/sonos/cancellation.dart';
 import '../data/sonos/channel_map.dart';
 import '../data/sonos/diagnostics_log.dart';
-import '../data/sonos/friendly_error.dart';
 import '../data/sonos/front_layout.dart' as front_layout;
 import '../data/sonos/identify_service.dart';
 import '../data/sonos/led_identify.dart';
 import '../data/sonos/sonos_repository.dart';
+import '../data/sonos/sonority_error.dart';
 import '../data/sonos/speaker_settings.dart';
 import '../features/profiles/profile.dart';
 import '../features/profiles/profile_controller.dart'
     show EntityIssue, preflightProfile;
+import 'localized_error.dart';
 import 'shared_preferences_store.dart';
+
+/// Localized name for an entity kind — used in progress step labels. The
+/// `kindLabel` getter on [EntitySnapshot] is the widget-side equivalent.
+String _kindLabel(AppLocalizations l10n, EntityKind kind) => switch (kind) {
+      EntityKind.homeTheater => l10n.entityKindHomeTheater,
+      EntityKind.stereoPair => l10n.entityKindStereoPair,
+      EntityKind.zone => l10n.entityKindZone,
+      EntityKind.custom => l10n.entityKindCustom,
+      EntityKind.single => l10n.entityKindSpeaker,
+    };
 
 final sonosRepositoryProvider = Provider<SonosRepository>(
     (ref) => SonosRepository(store: SharedPreferencesKeyValueStore()));
@@ -164,24 +176,25 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   Future<void> _restoreSettings(
       EntitySnapshot e, SonosSystem sys, Phases ph) async {
     if (e.settings.isEmpty) return;
-    ph.phase('settings', 'Restore settings');
+    final l10n = appL10n();
+    ph.phase('settings', l10n.stepRestoreSettings);
     for (final entry in e.settings.entries) {
       _activeOp?.throwIfCancelled();
       final dev = sys.device(entry.key);
       final ip = dev?.ip;
       if (ip == null) {
-        ph.note('skipping settings for ${entry.key} — not on the network');
+        ph.note(l10n.stepSkippingSettingsOffline);
         continue;
       }
       final s = entry.value;
       final what = [
-        if (s.hasAudioSettings) 'audio settings',
-        if (s.hasVolume) 'volume',
+        if (s.hasAudioSettings) l10n.stepAudioSettings,
+        if (s.hasVolume) l10n.stepVolume,
       ].join(' + ');
-      ph.note('restoring $what — ${dev!.typeLabel}');
+      ph.note(l10n.stepRestoring(what, dev!.typeLabel));
       final failed = await _settings.apply(ip, s);
       if (failed > 0) {
-        ph.note('$failed setting(s) for ${dev.typeLabel} could not be applied');
+        ph.note(l10n.stepSettingsFailed(failed, dev.typeLabel));
       }
     }
   }
@@ -236,8 +249,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       preserveExisting: false,
     );
 
+    final l10n = appL10n();
     final tracker = _newTracker(
-        [const ApplyStep(id: 'bond', label: 'Set up home theater')]);
+        [ApplyStep(id: 'bond', label: l10n.stepSetUpHomeTheater)]);
     _activeOp = CancellationToken();
 
     final previous = state.value;
@@ -245,7 +259,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     final result = await AsyncValue.guard(() async {
       tracker.start('bond');
       final ph = _phases(tracker, 'bond');
-      ph.seed([('bond', 'Bond ${target.entries.length - 1} speakers')]);
+      ph.seed([('bond', l10n.stepBondNSpeakers(target.entries.length - 1))]);
       try {
         final sys = await _applyHtTarget(
           bar: soundbarDevice,
@@ -257,8 +271,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         tracker.done('bond');
         return sys;
       } catch (e) {
-        // OperationCancelled lands here too — its toString is 'Aborted'.
-        tracker.fail('bond', friendlyError(e));
+        // OperationCancelled lands here too — its message is the aborted text.
+        tracker.fail('bond', localizedError(l10n, e));
         rethrow;
       }
     });
@@ -278,9 +292,11 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         profile.entities.where((e) => !skip.contains(e.primaryUuid)).toList();
     if (entities.isEmpty) return;
 
+    final l10n = appL10n();
     final tracker = _newTracker([
       for (final e in entities)
-        ApplyStep(id: e.primaryUuid, label: '${e.kindLabel}: ${e.label}'),
+        ApplyStep(
+            id: e.primaryUuid, label: '${_kindLabel(l10n, e.kind)}: ${e.label}'),
     ]);
     _activeOp = CancellationToken();
 
@@ -307,10 +323,12 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     // too (not just once bonding starts).
     final cancel = CancellationToken();
     _activeOp = cancel;
+    final l10n = appL10n();
     final tracker = _newTracker([
-      const ApplyStep(id: _scanStepId, label: 'Scan network for Sonos system'),
+      ApplyStep(id: _scanStepId, label: l10n.stepScanNetwork),
       for (final e in profile.entities)
-        ApplyStep(id: e.primaryUuid, label: '${e.kindLabel}: ${e.label}'),
+        ApplyStep(
+            id: e.primaryUuid, label: '${_kindLabel(l10n, e.kind)}: ${e.label}'),
     ]);
 
     // ponytail: cooperative cancel — steps 1–2 (scan/preflight/confirm) run
@@ -337,10 +355,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
                        → scanned stays null → handled below */}
       cancel.throwIfCancelled(); // aborted during the scan? stop before any write
       if (scanned == null) {
-        tracker.fail(
-            _scanStepId, 'Couldn’t find your Sonos system on the network.');
+        tracker.fail(_scanStepId, l10n.errSystemNotFound);
         throw state.error ??
-            Exception('Couldn’t find your Sonos system on the network.');
+            const SonorityError(SonorityErrorCode.systemNotFound);
       }
       tracker.done(_scanStepId);
 
@@ -363,8 +380,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       for (final e in profile.entities) {
         final miss = blocked[e.primaryUuid];
         if (miss != null) {
-          tracker.done(e.primaryUuid,
-              detail: 'skipped — $miss not on the network');
+          tracker.done(e.primaryUuid, detail: l10n.stepSkippedMissing(miss));
         } else {
           applicable.add(e);
         }
@@ -375,7 +391,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       // Abort during scan/pre-flight: mark the step that was running. No-op for
       // the "not found" path (scan step already failed) and a confirm decline
       // (no step active), so only a real abort attaches the reason.
-      tracker.failActive('Aborted');
+      tracker.failActive(l10n.errAborted);
       rethrow;
     }
 
@@ -394,6 +410,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   /// [applyProfile] and [scanAndApplyProfile]; [sys] is the current live system.
   Future<SonosSystem> _runEntitySteps(
       List<EntitySnapshot> entities, SonosSystem sys, ApplyProgress tracker) async {
+    final l10n = appL10n();
     for (final e in entities) {
       _activeOp?.throwIfCancelled(); // abort before starting the next entity
       tracker.start(e.primaryUuid);
@@ -402,11 +419,11 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       // (freeing conflicts, removing changed satellites) pop in when needed.
       ph.seed([
         if (e.kind == EntityKind.homeTheater)
-          ('bond', 'Bond ${e.involvedUuids.length - 1} speakers')
+          ('bond', l10n.stepBondNSpeakers(e.involvedUuids.length - 1))
         else if (e.kind != EntityKind.single)
-          ('bond', 'Bond ${e.involvedUuids.length} speakers'),
-        ('names', 'Restore room name'),
-        if (e.settings.isNotEmpty) ('settings', 'Restore settings'),
+          ('bond', l10n.stepBondNSpeakers(e.involvedUuids.length)),
+        ('names', l10n.stepRestoreRoomName),
+        if (e.settings.isNotEmpty) ('settings', l10n.stepRestoreSettings),
       ]);
       try {
         sys = await _applyEntity(e, sys, ph);
@@ -414,8 +431,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         await _restoreSettings(e, sys, ph);
         tracker.done(e.primaryUuid);
       } catch (err) {
-        // OperationCancelled lands here too — its toString is 'Aborted'.
-        tracker.fail(e.primaryUuid, friendlyError(err));
+        // OperationCancelled lands here too — its message is the aborted text.
+        tracker.fail(e.primaryUuid, localizedError(l10n, err));
         rethrow;
       }
     }
@@ -424,45 +441,49 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
 
   Future<SonosSystem> _applyEntity(
       EntitySnapshot e, SonosSystem sys, Phases ph) async {
+    final l10n = appL10n();
     switch (e.kind) {
       case EntityKind.single:
         final dev = sys.device(e.primaryUuid);
         if (dev?.ip == null) {
-          throw Exception('“${e.label}” isn’t on the network.');
+          throw SonorityError(SonorityErrorCode.entityNotOnNetwork, e.label);
         }
         if (sys.ownerOf(e.primaryUuid) != null) {
           _activeOp?.throwIfCancelled();
-          ph.phase('free', 'Free from its current bond');
+          ph.phase('free', l10n.stepFreeFromBond);
           await _repo.freeSpeaker(sys, e.primaryUuid);
-          ph.note('waiting for Sonos to settle');
+          ph.note(l10n.stepWaitingSettle);
           sys = await _settleRead(sys, dev!.ip!);
         }
         _activeOp?.throwIfCancelled();
-        ph.phase('names', 'Restore room name');
+        ph.phase('names', l10n.stepRestoreRoomName);
         if (!await _repo.setRoomName(
             ip: dev!.ip!, name: e.names[e.primaryUuid] ?? dev.roomName)) {
-          ph.skipPhase(detail: 'name unchanged — nothing to do');
+          ph.skipPhase(detail: l10n.stepNameUnchanged);
         }
         return sys;
 
       // Stereo pair / zone / custom all share one channel-map bond path.
       case EntityKind.stereoPair || EntityKind.zone || EntityKind.custom:
         final map = e.mapSet;
-        if (map == null) throw Exception('Stored group is malformed.');
+        if (map == null) {
+          throw const SonorityError(SonorityErrorCode.malformedGroup);
+        }
         final coord = sys.device(e.primaryUuid);
         if (coord?.ip == null) {
-          throw Exception('“${e.label}” coordinator isn’t on the network.');
+          throw SonorityError(
+              SonorityErrorCode.coordinatorNotOnNetwork, e.label);
         }
         final involved = e.involvedUuids.toList();
         // Already exactly this group? Just re-assert the name (no disruptive write).
         if (_isGroupFormed(sys, e.primaryUuid, involved)) {
-          ph.phase('bond', 'Bond ${involved.length} speakers');
-          ph.skipPhase(detail: 'already formed — nothing to do');
+          ph.phase('bond', l10n.stepBondNSpeakers(involved.length));
+          ph.skipPhase(detail: l10n.stepAlreadyFormed);
           _activeOp?.throwIfCancelled();
-          ph.phase('names', 'Restore room name');
+          ph.phase('names', l10n.stepRestoreRoomName);
           if (!await _repo.setRoomName(
               ip: coord!.ip!, name: e.names[coord.uuid] ?? coord.roomName)) {
-            ph.skipPhase(detail: 'name unchanged — nothing to do');
+            ph.skipPhase(detail: l10n.stepNameUnchanged);
           }
           return sys;
         }
@@ -471,8 +492,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           final owner = sys.ownerOf(u);
           if (owner != null && !involved.contains(owner)) {
             _activeOp?.throwIfCancelled();
-            ph.phase('free', 'Free conflicting speakers');
-            ph.note('freeing ${sys.device(u)?.roomName ?? u}');
+            ph.phase('free', l10n.stepFreeConflicting);
+            ph.note(l10n.stepFreeing(sys.device(u)?.roomName ?? u));
             await _repo.freeSpeaker(sys, u);
             sys = await _settleRead(sys, coord!.ip!);
           }
@@ -484,23 +505,28 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         for (final entry in parsed.groupChannels.entries) {
           final d = sys.device(entry.key);
           if (d?.ip == null) {
-            throw Exception('A speaker in “${e.label}” isn’t on the network.');
+            throw SonorityError(
+                SonorityErrorCode.speakerInEntityNotOnNetwork, e.label);
           }
           memberEntries.add((device: d!, channel: entry.value));
         }
         final subU = parsed.subUuid;
         final sub = subU == null ? null : sys.device(subU);
         if (subU != null && sub?.ip == null) {
-          throw Exception('The Sub for “${e.label}” isn’t on the network.');
+          throw SonorityError(SonorityErrorCode.subNotOnNetwork, e.label);
         }
         if (memberEntries.length < 2) {
-          throw Exception('“${e.label}” is missing speakers.');
+          throw SonorityError(
+              SonorityErrorCode.entityMissingSpeakers, e.label);
         }
         _activeOp?.throwIfCancelled();
-        ph.phase('bond',
-            'Bond ${memberEntries.length} speakers${sub != null ? ' + sub' : ''}');
+        ph.phase(
+            'bond',
+            sub != null
+                ? l10n.stepBondNSpeakersWithSub(memberEntries.length)
+                : l10n.stepBondNSpeakers(memberEntries.length));
         await _repo.createGroup(members: memberEntries, sub: sub);
-        ph.note('waiting for Sonos to confirm');
+        ph.note(l10n.stepWaitingConfirm);
         sys = await _pollUntil(
           previous: sys,
           ip: coord!.ip,
@@ -508,23 +534,25 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           until: (s) => _isGroupFormed(s, e.primaryUuid, involved),
         );
         if (!_isGroupFormed(sys, e.primaryUuid, involved)) {
-          throw Exception('Sonos did not form “${e.label}”.');
+          throw SonorityError(SonorityErrorCode.didNotForm, e.label);
         }
         _activeOp?.throwIfCancelled();
-        ph.phase('names', 'Restore room name');
+        ph.phase('names', l10n.stepRestoreRoomName);
         if (!await _repo.setRoomName(
             ip: coord.ip!, name: e.names[coord.uuid] ?? coord.roomName)) {
-          ph.skipPhase(detail: 'name unchanged — nothing to do');
+          ph.skipPhase(detail: l10n.stepNameUnchanged);
         }
         return sys;
 
       case EntityKind.homeTheater:
         final bar = sys.device(e.primaryUuid);
         if (bar?.ip == null) {
-          throw Exception('Soundbar for “${e.label}” isn’t on the network.');
+          throw SonorityError(SonorityErrorCode.soundbarNotOnNetwork, e.label);
         }
         final map = e.mapSet;
-        if (map == null) throw Exception('Stored home theater is malformed.');
+        if (map == null) {
+          throw const SonorityError(SonorityErrorCode.malformedHomeTheater);
+        }
         // The saved map IS the exact target (bar + every satellite, including a
         // second Sub in a dual-sub setup) — use it directly rather than a
         // channel→uuid map, which would collapse two SW entries into one.
@@ -535,8 +563,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           final owner = sys.ownerOf(u);
           if (owner != null && owner != bar!.uuid) {
             _activeOp?.throwIfCancelled();
-            ph.phase('free', 'Free conflicting speakers');
-            ph.note('freeing ${sys.device(u)?.roomName ?? u}');
+            ph.phase('free', l10n.stepFreeConflicting);
+            ph.note(l10n.stepFreeing(sys.device(u)?.roomName ?? u));
             await _repo.freeSpeaker(sys, u);
             sys = await _settleRead(sys, bar.ip!);
           }
@@ -556,10 +584,10 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           ph: ph,
         );
         _activeOp?.throwIfCancelled();
-        ph.phase('names', 'Restore room name');
+        ph.phase('names', l10n.stepRestoreRoomName);
         if (!await _repo.setRoomName(
             ip: bar.ip!, name: e.names[bar.uuid] ?? bar.roomName)) {
-          ph.skipPhase(detail: 'name unchanged — nothing to do');
+          ph.skipPhase(detail: l10n.stepNameUnchanged);
         }
         return sys;
     }
@@ -577,20 +605,21 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     required SonosSystem sys,
     required Phases ph,
   }) async {
+    final l10n = appL10n();
     final diff = front_layout.diffHtLayout(current: current, target: target);
-    final bondLabel = 'Bond ${target.entries.length - 1} speakers';
+    final bondLabel = l10n.stepBondNSpeakers(target.entries.length - 1);
     if (diff.isNoOp) {
       ph.phase('bond', bondLabel);
-      ph.skipPhase(detail: 'layout unchanged — nothing to do');
+      ph.skipPhase(detail: l10n.stepLayoutUnchanged);
       return sys;
     }
     if (diff.toRemove.isNotEmpty) {
       // Only genuine leaves reach here (a dropped sub / a replaced speaker) —
       // a speaker that merely moves channel stays bonded and reassigns in place.
-      ph.phase('remove', 'Remove ${diff.toRemove.length} speakers no longer used');
+      ph.phase('remove', l10n.stepRemoveUnused(diff.toRemove.length));
       await _repo.removeHtSatellites(
           soundbarIp: bar.ip!, uuids: diff.toRemove, cancel: _activeOp);
-      ph.note('waiting for Sonos to settle');
+      ph.note(l10n.stepWaitingSettle);
       sys = await _settleRead(sys, bar.ip!);
     }
     ph.phase('bond', bondLabel);
@@ -598,7 +627,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     // retry churn stays in the log (ph.log) rather than flickering the timeline
     // — a swap 800s and re-asserts several times, which reads as alarming
     // otherwise even though it's normal Sonos settling.
-    ph.note('Applying — Sonos can take up to a minute to settle.');
+    ph.note(l10n.stepApplyingSettle);
     return _repo.bondAndVerify(
         coordinator: bar,
         target: target,
@@ -624,7 +653,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     required String name,
   }) async {
     final ip = device.ip;
-    if (ip == null) throw Exception('Speaker IP unknown; rescan and retry.');
+    if (ip == null) {
+      throw const SonorityError(SonorityErrorCode.speakerIpUnknown);
+    }
     final previous = state.value;
     state = const AsyncValue.loading();
     final result = await AsyncValue.guard(() async {
@@ -660,16 +691,21 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     required ZoneGroupMember soundbar,
     required SonosDevice soundbarDevice,
     required Set<SonosChannel> channels,
-    String label = 'speakers',
+    String? label,
   }) async {
     final ip = soundbarDevice.ip;
-    if (ip == null) throw Exception('Soundbar IP unknown; rescan and retry.');
+    if (ip == null) {
+      throw const SonorityError(SonorityErrorCode.soundbarIpUnknown);
+    }
     final uuids = <String>{
       for (final c in channels) ...soundbar.uuidsForChannel(c),
     };
     if (uuids.isEmpty) return;
 
-    final tracker = _newTracker([ApplyStep(id: 'remove', label: 'Remove $label')]);
+    final l10n = appL10n();
+    final lbl = label ?? l10n.stepSpeakers;
+    final tracker =
+        _newTracker([ApplyStep(id: 'remove', label: l10n.stepRemoveLabel(lbl))]);
     _activeOp = CancellationToken();
 
     final previous = state.value;
@@ -678,14 +714,14 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       tracker.start('remove');
       final ph = _phases(tracker, 'remove');
       ph.seed([
-        ('unbond', 'Unbond ${uuids.length} speaker(s)'),
-        ('settle', 'Wait for Sonos to settle'),
+        ('unbond', l10n.stepUnbondN(uuids.length)),
+        ('settle', l10n.stepWaitForSettle),
       ]);
       try {
-        ph.phase('unbond', 'Unbond ${uuids.length} speaker(s)');
+        ph.phase('unbond', l10n.stepUnbondN(uuids.length));
         await _repo.removeHtSatellites(
             soundbarIp: ip, uuids: uuids, cancel: _activeOp);
-        ph.phase('settle', 'Wait for Sonos to settle');
+        ph.phase('settle', l10n.stepWaitForSettle);
         // The soundbar itself always survives an unbond; a null member here is
         // the transient mid-reshuffle drop-out, NOT confirmation — keep polling.
         bool rolesGone(SonosSystem s) {
@@ -697,13 +733,13 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         final sys = await _pollUntil(previous: previous, ip: ip, until: rolesGone);
         // Sonos can 200-OK an unbond yet silently no-op — re-assert before done.
         if (!rolesGone(sys)) {
-          throw Exception('Sonos did not remove the $label — try again.');
+          throw SonorityError(SonorityErrorCode.didNotRemove, lbl);
         }
         tracker.done('remove');
         return sys;
       } catch (e) {
-        // OperationCancelled lands here too — its toString is 'Aborted'.
-        tracker.fail('remove', friendlyError(e));
+        // OperationCancelled lands here too — its message is the aborted text.
+        tracker.fail('remove', localizedError(l10n, e));
         rethrow;
       }
     });
@@ -721,7 +757,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
   }) async {
     assert(members.length >= 2, 'createGroup needs ≥2 members (UI must gate this)');
     if (members.length < 2) {
-      throw Exception('A group needs at least 2 speakers.');
+      throw const SonorityError(SonorityErrorCode.groupNeedsTwo);
     }
     final coord = members.first.device;
     final involved = [
@@ -729,8 +765,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       if (sub != null) sub.uuid,
     ];
 
+    final l10n = appL10n();
     final tracker = _newTracker([
-      ApplyStep(id: 'group', label: 'Create group (${members.length} speakers)'),
+      ApplyStep(id: 'group', label: l10n.stepCreateGroupN(members.length)),
     ]);
     _activeOp = CancellationToken();
 
@@ -741,15 +778,15 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       final ph = _phases(tracker, 'group');
       final wanted = name?.trim();
       ph.seed([
-        ('bond', 'Bond speakers'),
-        ('confirm', 'Wait for Sonos to confirm'),
+        ('bond', l10n.stepBondSpeakers),
+        ('confirm', l10n.stepWaitForConfirm),
         if (wanted != null && wanted.isNotEmpty && coord.ip != null)
-          ('name', 'Name the group'),
+          ('name', l10n.stepNameGroup),
       ]);
       try {
-        ph.phase('bond', 'Bond speakers');
+        ph.phase('bond', l10n.stepBondSpeakers);
         await _repo.createGroup(members: members, sub: sub);
-        ph.phase('confirm', 'Wait for Sonos to confirm');
+        ph.phase('confirm', l10n.stepWaitForConfirm);
         var system = await _pollUntil(
           previous: previous,
           ip: coord.ip ?? _lastIp,
@@ -763,11 +800,10 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         // Sonos accepts the command (200) but silently no-ops if a speaker is
         // incompatible — confirm the group actually formed.
         if (!_isGroupFormed(system, coord.uuid, involved)) {
-          throw Exception(
-              'Sonos did not create the group — a speaker may be incompatible.');
+          throw const SonorityError(SonorityErrorCode.didNotCreateGroup);
         }
         if (wanted != null && wanted.isNotEmpty && coord.ip != null) {
-          ph.phase('name', 'Name the group');
+          ph.phase('name', l10n.stepNameGroup);
           await _repo.setRoomName(ip: coord.ip!, name: wanted);
           system = await _pollUntil(
             previous: system,
@@ -780,8 +816,8 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
         tracker.done('group');
         return system;
       } catch (e) {
-        // OperationCancelled lands here too — its toString is 'Aborted'.
-        tracker.fail('group', friendlyError(e));
+        // OperationCancelled lands here too — its message is the aborted text.
+        tracker.fail('group', localizedError(l10n, e));
         rethrow;
       }
     });
@@ -810,8 +846,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
     final audioReappear =
         members.where((m) => m.uuid != coord.uuid && m.uuid != subU);
 
+    final l10n = appL10n();
     final tracker =
-        _newTracker([const ApplyStep(id: 'ungroup', label: 'Separate group')]);
+        _newTracker([ApplyStep(id: 'ungroup', label: l10n.stepSeparateGroup)]);
     _activeOp = CancellationToken();
 
     final previous = sys;
@@ -820,14 +857,14 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
       tracker.start('ungroup');
       final ph = _phases(tracker, 'ungroup');
       ph.seed([
-        ('separate', 'Separate + restore room names'),
-        ('settle', 'Wait for Sonos to settle'),
+        ('separate', l10n.stepSeparateRestore),
+        ('settle', l10n.stepWaitForSettle),
       ]);
       try {
         // 1. A bond can't be dissolved while the coordinator is a non-coordinator
         //    member of a larger playback group — detach into its own group first.
         if (coord.ip != null && !_isOwnGroupCoordinator(previous, coord.uuid)) {
-          ph.phase('detach', 'Detach from playback group');
+          ph.phase('detach', l10n.stepDetach);
           await _repo.detachFromGroup(coord.ip!);
           await _pollUntil(
             previous: previous,
@@ -837,9 +874,9 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
           );
         }
         // 2. Dissolve (SeparateStereoPair on the live map) + restore names.
-        ph.phase('separate', 'Separate + restore room names');
+        ph.phase('separate', l10n.stepSeparateRestore);
         await _repo.separateGroup(members: members, channelMapSet: cms);
-        ph.phase('settle', 'Wait for Sonos to settle');
+        ph.phase('settle', l10n.stepWaitForSettle);
         final system = await _pollUntil(
           previous: previous,
           ip: coord.ip ?? _lastIp,
@@ -849,13 +886,13 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
               audioReappear.every((m) => s.allMembers.any((x) => x.uuid == m.uuid)),
         );
         if (_isGroupFormed(system, coord.uuid, involved)) {
-          throw Exception('Sonos did not separate the group — try again.');
+          throw const SonorityError(SonorityErrorCode.didNotSeparate);
         }
         tracker.done('ungroup');
         return system;
       } catch (e) {
-        // OperationCancelled lands here too — its toString is 'Aborted'.
-        tracker.fail('ungroup', friendlyError(e));
+        // OperationCancelled lands here too — its message is the aborted text.
+        tracker.fail('ungroup', localizedError(l10n, e));
         rethrow;
       }
     });

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -283,6 +283,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -399,6 +404,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   io:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  # Localization: MaterialLocalizations for supported locales + the intl runtime
+  # our generated AppLocalizations depends on. See l10n.yaml / lib/l10n/.
+  flutter_localizations:
+    sdk: flutter
+  intl: any
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -113,6 +118,10 @@ flutter_native_splash:
 
 # The following section is specific to Flutter packages.
 flutter:
+
+  # Generate the localization delegate (AppLocalizations) from lib/l10n/*.arb
+  # per l10n.yaml on build / `flutter gen-l10n`.
+  generate: true
 
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in

--- a/test/changelog_parser_test.dart
+++ b/test/changelog_parser_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:sonority/l10n/app_localizations.dart';
 import 'package:sonority/features/widgets/version_badge.dart';
 
 const _sample = '''
@@ -73,6 +74,8 @@ void main() {
       buildNumber: '50008',
     );
     await tester.pumpWidget(MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
       home: Builder(
         builder: (ctx) => TextButton(
           onPressed: () => showVersionSheet(ctx, info),

--- a/test/friendly_error_test.dart
+++ b/test/friendly_error_test.dart
@@ -5,6 +5,7 @@ import 'package:sonority/data/sonos/cancellation.dart';
 import 'package:sonority/data/sonos/friendly_error.dart';
 import 'package:sonority/data/sonos/identify_errors.dart';
 import 'package:sonority/data/sonos/soap_client.dart';
+import 'package:sonority/data/sonos/sonority_error.dart';
 
 void main() {
   group('friendlyError', () {
@@ -44,6 +45,19 @@ void main() {
     test('a bare exception drops the noisy "Exception: " prefix', () {
       expect(friendlyError(Exception('Sonos did not remove the Surrounds — try again.')),
           'Sonos did not remove the Surrounds — try again.');
+    });
+
+    test('a coded SonorityError renders its English message', () {
+      expect(friendlyError(const SonorityError(SonorityErrorCode.groupNeedsTwo)),
+          'A group needs at least 2 speakers.');
+      expect(
+          friendlyError(
+              const SonorityError(SonorityErrorCode.didNotRemove, 'Surrounds')),
+          'Sonos did not remove the Surrounds — try again.');
+      expect(
+          friendlyError(
+              const SonorityError(SonorityErrorCode.entityNotOnNetwork, 'Den')),
+          '“Den” isn’t on the network.');
     });
   });
 }

--- a/test/l10n_test.dart
+++ b/test/l10n_test.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/data/sonos/cancellation.dart';
+import 'package:sonority/data/sonos/identify_errors.dart';
+import 'package:sonority/data/sonos/sonority_error.dart';
+import 'package:sonority/l10n/app_localizations.dart';
+import 'package:sonority/state/localized_error.dart';
+
+void main() {
+  // English is the only shipped locale; lookup is synchronous so no async setup.
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  group('AppLocalizations (en)', () {
+    test('placeholder interpolation', () {
+      expect(l10n.errEntityNotOnNetwork('Den'), '“Den” isn’t on the network.');
+    });
+
+    test('ICU plural picks the right branch', () {
+      expect(l10n.stepBondNSpeakers(1), 'Bond 1 speaker');
+      expect(l10n.stepBondNSpeakers(3), 'Bond 3 speakers');
+    });
+  });
+
+  group('localizedError', () {
+    test('maps a coded error to its localized string', () {
+      expect(localizedError(l10n, const SonorityError(SonorityErrorCode.groupNeedsTwo)),
+          'A group needs at least 2 speakers.');
+    });
+
+    test('falls back to English for an unrecognized error', () {
+      expect(localizedError(l10n, Exception('boom')), 'boom');
+    });
+
+    test('maps a timeout and a SOAP busy fault', () {
+      expect(localizedError(l10n, TimeoutException('x')), l10n.errTimeout);
+    });
+
+    // The engine renders these two via toString() (CLI/diagnostics stay
+    // English); the UI renders them from the ARB. Pin the two so they can't
+    // silently drift apart.
+    test('engine English and localized strings agree for pass-through errors',
+        () {
+      expect(l10n.errChimeUnreachable, const SpeakerUnreachable().toString());
+      expect(localizedError(l10n, const SpeakerUnreachable()),
+          const SpeakerUnreachable().toString());
+      expect(l10n.errAborted, const OperationCancelled().toString());
+      expect(localizedError(l10n, const OperationCancelled()),
+          const OperationCancelled().toString());
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a complete Flutter **gen-l10n** localization pipeline and extracts **every user-facing string** into `lib/l10n/app_en.arb` (~350 strings, with ICU plurals + placeholders). **English is the only bundled locale for now** — a new language is added by dropping in `app_<lang>.arb` + one `supportedLocales` entry, no code changes. The app follows the **system locale** (no in-app picker). No visible change yet.

## Engine-error design (keeps the engine Flutter-free)

The pure-Dart engine (`lib/data/sonos/`) must not import the generated `AppLocalizations`, so it never holds a *translated* string. User-facing engine/state failures now throw a coded **`SonorityError(SonorityErrorCode, [arg])`** — identity, not prose. Two renderers word it:
- `friendlyError()` — English, for CLI tools + the diagnostics bundle, and the fallback.
- `localizedError(l10n, e)` — translated; the single UI wording chokepoint (also maps Timeout / SOAP-fault / abort / unreachable).

Context-less code (controller progress labels) uses `appL10n()`; widgets use `context.l10n`.

## Scope
- Pipeline: `pubspec` (`flutter_localizations`, `intl`, `generate: true`), `l10n.yaml`, delegates on both `MaterialApp`s, `CFBundleLocalizations` on iOS/macOS.
- Extraction across `lib/features/**` + the controller progress timeline.
- Model-layer English getters (`groupChannelShort`, channel tokens) stay English by design; entity-kind labels map to shared `entityKind*` keys.

## Testing
- `flutter analyze` clean; `flutter test` green (192 tests) incl. new `test/l10n_test.dart` (placeholder/plural formatting, coded→localized mapping, English/localized drift pins) + `SonorityError` coverage in `friendly_error_test.dart`.
- Demo build driven on Android: home overview, profiles, create-profile, and group-creation flow all render correctly (plurals, entity-kind labels, wizard copy) — no missing keys.
- Pre-merge review (independent subagent + `/code-review` + `/ponytail-review`): no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)