### PR TITLE
feat(ios): add Apple-approved multicast networking entitlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ section into the GitHub Release notes regardless of the build suffix
 - Diagnostics bundle now includes `speaker_settings.json` — a read-only per-speaker snapshot of EQ / volume / mute (RenderingControl), to help debug "configured but silent" reports (e.g. a muted or zero-volume bonded speaker).
 
 ### Changed
+- iOS now carries the Apple-approved multicast entitlement, so discovery uses native SSDP multicast on physical iPhones instead of relying on the unicast /24 sweep fallback (which stays as a backstop for multicast-filtering networks).
 - GitHub Pages landing page now deploys automatically on each release tag (via an LFS-aware Actions workflow) and shows the current app version; the page is generated in CI rather than committed.
 - Internal cleanup: deduplicated shared widgets/helpers and removed dead code; the Sonos engine is now fully decoupled from Flutter (persistence via an injected storage port). No user-facing behaviour change.
 - Reconfiguring a home theater (e.g. swapping which speakers are fronts vs surrounds) no longer unbonds speakers that are only moving to a different channel — they're reassigned in place, so the setup no longer briefly drops to one speaker per side. The progress screen shows a single calm "Applying…" step (Sonos can still take up to a minute to settle) instead of a scary per-attempt retry log.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,20 +445,19 @@ Run on the same Wi-Fi as the Sonos system:
 ## Platform notes
 - iOS: `Info.plist` has `NSLocalNetworkUsageDescription` + `NSBonjourServices`
   (mandatory on iOS 14+ or all LAN traffic is silently blocked).
-- **iOS device multicast is blocked (cost a real TestFlight bug):** physical
-  iPhones silently drop multicast sends (SSDP M-SEARCH) unless the app carries
-  the *restricted* `com.apple.developer.networking.multicast` entitlement —
-  the iOS target has no entitlements file. Simulator doesn't enforce it (sim
-  worked, device didn't); the local-network permission prompt covers unicast
-  only. Fix: `SsdpDiscovery.discover()` falls back to a unicast TCP :1400
-  sweep of each interface's /24 (assumed /24 — `dart:io` exposes no netmask;
-  ~600ms, one hit suffices since topology recovers the rest). Also helps
-  multicast-filtering mesh/guest networks. **Future improvement:** request the
-  multicast entitlement from Apple (developer.apple.com → "Multicast Networking
-  Entitlement Request", days–weeks), enable the capability on the App ID, add
-  `ios/Runner/Runner.entitlements` + `CODE_SIGN_ENTITLEMENTS` in the pbxproj,
-  regenerate match profiles (`docs/SIGNING.md`) — restores native SSDP on
-  device; keep the sweep as fallback regardless.
+- **iOS device multicast (cost a real TestFlight bug):** physical iPhones
+  silently drop multicast sends (SSDP M-SEARCH) unless the app carries the
+  *restricted* `com.apple.developer.networking.multicast` entitlement.
+  Simulator doesn't enforce it (sim worked, device didn't); the local-network
+  permission prompt covers unicast only. **Now granted:** Apple approved the
+  Multicast Networking Entitlement, so `ios/Runner/Runner.entitlements` carries
+  `com.apple.developer.networking.multicast` (`CODE_SIGN_ENTITLEMENTS` already
+  wired for the app group). Enable the capability on the App ID + regenerate
+  match profiles when cutting the first release that ships it (`docs/SIGNING.md`).
+  Belt-and-suspenders fallback stays regardless: `SsdpDiscovery.discover()`
+  falls back to a unicast TCP :1400 sweep of each interface's /24 (assumed /24 —
+  `dart:io` exposes no netmask; ~600ms, one hit suffices since topology recovers
+  the rest), which also helps multicast-filtering mesh/guest networks.
 - macOS: entitlements include `network.client` + `network.server`; window is locked
   to a fixed **420×880 portrait** (`MainFlutterWindow.swift`) so the UI only ever
   handles one mobile layout.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -150,8 +150,12 @@ end
 
 platform :ios do
   desc "Create/refresh the shared iOS signing assets in the match repo"
-  lane :certificates do
-    match(type: "appstore", platform: "ios", readonly: false, api_key: asc_key)
+  # Pass force:true to re-issue profiles even when the existing ones are still
+  # valid — needed after enabling a new App ID capability (e.g. multicast),
+  # since match won't otherwise notice the entitlement drift.
+  lane :certificates do |options|
+    match(type: "appstore", platform: "ios", readonly: false, api_key: asc_key,
+          force: options[:force] || false)
   end
 
   desc "Build and upload an iOS build to TestFlight"

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -6,5 +6,7 @@
 	<array>
 		<string>group.be.casperverswijvelt.sonority</string>
 	</array>
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Apple approved the Multicast Networking Entitlement request, so we can now ship native SSDP multicast discovery on physical iPhones instead of relying only on the unicast /24 sweep fallback.

## Changes
- `ios/Runner/Runner.entitlements`: add `com.apple.developer.networking.multicast`. `CODE_SIGN_ENTITLEMENTS` was already wired (for the app group), so no pbxproj change needed.
- `CHANGELOG.md` / `CLAUDE.md`: note the entitlement is granted; the note is no longer a "future improvement".

The unicast TCP :1400 sweep stays as a belt-and-suspenders fallback (multicast-filtering mesh/guest networks), so runtime behaviour degrades gracefully if a profile ever lacks the entitlement.

## ⚠️ Manual signing steps before the first release that ships this
Code alone isn't enough — the App ID and provisioning profiles must carry the capability:
1. developer.apple.com → Certificates, IDs & Profiles → Identifiers → `be.casperverswijvelt.sonority` → enable **Multicast Networking** → Save.
2. Regenerate the match App Store profile so it includes the entitlement: `bundle exec fastlane ios certificates` (match `readonly:false`). If the existing profile is still valid match won't refresh it — force it (`fastlane match appstore --force`) or delete the profile from the portal + match repo first.
3. Build a real TestFlight/device build and confirm discovery uses SSDP (diagnostics log: `discovery: SSDP multicast found N`) rather than the sweep fallback.

`flutter analyze` clean. No Dart logic changed, so no new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)