### PR TITLE
Dim unreachable entity cards with a short "Unreachable" subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ section into the GitHub Release notes regardless of the build suffix
 - Internal cleanup: deduplicated shared widgets/helpers and removed dead code; the Sonos engine is now fully decoupled from Flutter (persistence via an injected storage port). No user-facing behaviour change.
 - Reconfiguring a home theater (e.g. swapping which speakers are fronts vs surrounds) no longer unbonds speakers that are only moving to a different channel — they're reassigned in place, so the setup no longer briefly drops to one speaker per side. The progress screen shows a single calm "Applying…" step (Sonos can still take up to a minute to settle) instead of a scary per-attempt retry log.
 - Identify chime is now a repeated percussive ping (sharp attack, bright harmonics) instead of a soft two-tone sine — it's far easier to tell which speaker it's coming from by ear.
+- An unreachable speaker's card is now shown dimmed with a short "Unreachable" subtitle instead of an alarming red warning tile with a long hint.
 
 ## [0.6.0] - 2026-07-17
 

--- a/lib/features/widgets/entity_cards.dart
+++ b/lib/features/widgets/entity_cards.dart
@@ -130,7 +130,7 @@ class EntityCardModel {
 /// The one entity card — a dumb renderer over [EntityCardModel], shared by the
 /// system overview (live) and the profile detail list (snapshot). [onTap] adds a
 /// chevron; [footer] (e.g. saved-settings pills) stacks under the composition. An
-/// unreachable single is flagged with a warning glyph + hint and made
+/// unreachable single is dimmed with a short "Unreachable" subtitle and made
 /// non-tappable regardless of the passed [onTap].
 class EntityCard extends StatelessWidget {
   final EntityCardModel model;
@@ -145,7 +145,9 @@ class EntityCard extends StatelessWidget {
     final unreachable = !model.reachable;
     final tap = unreachable ? null : onTap;
 
-    return Padding(
+    // Unreachable = a dimmed, non-interactive card with a short "Unreachable"
+    // subtitle, rather than an alarming error-red variant.
+    final content = Padding(
       padding: const EdgeInsets.only(bottom: kCardGap),
       child: Card(
         child: InkWell(
@@ -155,11 +157,7 @@ class EntityCard extends StatelessWidget {
             padding: const EdgeInsets.all(16),
             child: Row(
               children: [
-                EntityGlyph(
-                  icon: unreachable ? Icons.warning_amber_rounded : model.icon,
-                  background: unreachable ? scheme.errorContainer : null,
-                  foreground: unreachable ? scheme.onErrorContainer : null,
-                ),
+                EntityGlyph(icon: model.icon),
                 Gap.m,
                 Expanded(
                   child: Column(
@@ -168,9 +166,9 @@ class EntityCard extends StatelessWidget {
                       Text(model.title, style: theme.textTheme.bodyLarge),
                       if (unreachable)
                         Text(
-                          context.l10n.widgetsUnreachableSpeakerHint,
+                          context.l10n.widgetsUnreachable,
                           style: theme.textTheme.bodyMedium?.copyWith(
-                            color: scheme.error,
+                            color: scheme.onSurfaceVariant,
                           ),
                         )
                       else if (model.subtitle != null)
@@ -206,5 +204,7 @@ class EntityCard extends StatelessWidget {
         ),
       ),
     );
+
+    return unreachable ? Opacity(opacity: 0.5, child: content) : content;
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -247,6 +247,7 @@
   "widgetsStepFailed": "Failed.",
   "widgetsStepWorking": "Working…",
   "widgetsUnreachableSpeakerHint": "Couldn’t read this speaker’s details — check it’s powered on and on the same network.",
+  "widgetsUnreachable": "Unreachable",
   "widgetsSoundbar": "Soundbar",
   "widgetsFronts": "Fronts",
   "widgetsSurrounds": "Surrounds",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -700,6 +700,12 @@ abstract class AppLocalizations {
   /// **'Couldn’t read this speaker’s details — check it’s powered on and on the same network.'**
   String get widgetsUnreachableSpeakerHint;
 
+  /// No description provided for @widgetsUnreachable.
+  ///
+  /// In en, this message translates to:
+  /// **'Unreachable'**
+  String get widgetsUnreachable;
+
   /// No description provided for @widgetsSoundbar.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -407,6 +407,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Couldn’t read this speaker’s details — check it’s powered on and on the same network.';
 
   @override
+  String get widgetsUnreachable => 'Unreachable';
+
+  @override
   String get widgetsSoundbar => 'Soundbar';
 
   @override


### PR DESCRIPTION
## What

An unreachable speaker's entity card no longer renders as an alarming error-red warning tile (warning glyph + long hint). It's now shown **dimmed** (0.5 opacity) with its **normal glyph** and a short **"Unreachable"** subtitle. It stays non-tappable.

## Why

The red warning tile read as a hard error for what's usually a transient/offline speaker. A dimmed "disabled" look communicates the same thing more calmly.

## Screenshot

Kitchen (bottom, "Single speaker rooms") shows the new dimmed treatment; the other entities render normally.

## Changes

- `lib/features/widgets/entity_cards.dart` — drop the three-way warning-glyph coloring, use the default `EntityGlyph`, wrap in a single `Opacity` when unreachable, and use the new short subtitle. Class docstring updated.
- `lib/l10n/app_en.arb` (+ generated) — new `widgetsUnreachable` = "Unreachable". The old `widgetsUnreachableSpeakerHint` is kept (still used by `bondable_speaker_tile.dart`).
- `CHANGELOG.md` — entry under `[Unreleased]`.

## Checks

- `flutter analyze` clean, `flutter test` green (203 passing).
- Verified in the demo web build.
- Pre-merge review + `/code-review` + `/ponytail-review`: one finding (stale docstring) addressed; otherwise clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)