### PR TITLE
fix(ui): pull-to-refresh on short overview & home-theater pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ section into the GitHub Release notes regardless of the build suffix
 - Reconfiguring a home theater (e.g. swapping which speakers are fronts vs surrounds) no longer unbonds speakers that are only moving to a different channel — they're reassigned in place, so the setup no longer briefly drops to one speaker per side. The progress screen shows a single calm "Applying…" step (Sonos can still take up to a minute to settle) instead of a scary per-attempt retry log.
 - Identify chime is now a repeated percussive ping (sharp attack, bright harmonics) instead of a soft two-tone sine — it's far easier to tell which speaker it's coming from by ear.
 
+### Fixed
+- Pull-to-refresh on the System overview and home-theater pages now works even when the content is short enough to fit the screen without scrolling (previously the pull gesture did nothing there).
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/lib/features/discovery/discovery_screen.dart
+++ b/lib/features/discovery/discovery_screen.dart
@@ -109,6 +109,9 @@ class _SystemView extends ConsumerWidget {
     // Owns its own scroll, filling the screen-sized body. The app bar is fixed,
     // so there's no collapse to lose; Rescan / pull-to-refresh cover refresh.
     return SingleChildScrollView(
+      // Always overscrollable so pull-to-refresh fires even when the content
+      // is shorter than the viewport (a sparse system of a few cards).
+      physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/lib/features/widgets/scroll_footer.dart
+++ b/lib/features/widgets/scroll_footer.dart
@@ -30,6 +30,10 @@ class ScrollFooter extends StatelessWidget {
     // — always a simple button/text — sits under SliverFillRemaining, whose
     // trial layout only ever measures the footer.
     return CustomScrollView(
+      // Always overscrollable so a wrapping RefreshIndicator's pull-to-refresh
+      // fires even when the content is shorter than the viewport (the footer's
+      // SliverFillRemaining makes short content fill it exactly).
+      physics: const AlwaysScrollableScrollPhysics(),
       slivers: [
         SliverPadding(
           padding: padding.copyWith(bottom: 0),


### PR DESCRIPTION
## What

Pull-to-refresh was still wired up on the System overview and home-theater pages (a `RefreshIndicator` in `AppScaffold`, `onRefresh: () => controller.scan()`), but it silently did nothing when the content was short enough to fit the screen without scrolling — the reported "pull-to-refresh is gone" symptom.

## Why

Both scroll views used the platform default physics:
- Overview `_SystemView` → `SingleChildScrollView` (shrink-wraps).
- Home-theater `_Content` → shared `ScrollFooter`'s `CustomScrollView` (`SliverFillRemaining` makes short content fill the viewport exactly).

With `maxScrollExtent == 0` the default physics won't emit the overscroll drag the `RefreshIndicator` needs, so the pull gesture never triggers. (The app-bar Rescan / refresh button kept working, masking the bug.)

## Change

One line on each scroll view: `physics: const AlwaysScrollableScrollPhysics()`. Harmless for the other `ScrollFooter` callers (group / room detail) that don't wire `onRefresh` — it only enables an iOS bounce on short content.

- `lib/features/discovery/discovery_screen.dart`
- `lib/features/widgets/scroll_footer.dart`
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`

## Verification

`flutter analyze` + `flutter test` green (203 tests). On-device: swipe down on the System / home-theater tab with only a few cards — the spinner now appears and `scan()` / `refreshAll()` re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)