### PR TITLE
fix(profiles): lock the profile form while it captures EQ/volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ section into the GitHub Release notes regardless of the build suffix
 - Reconfiguring a home theater (e.g. swapping which speakers are fronts vs surrounds) no longer unbonds speakers that are only moving to a different channel — they're reassigned in place, so the setup no longer briefly drops to one speaker per side. The progress screen shows a single calm "Applying…" step (Sonos can still take up to a minute to settle) instead of a scary per-attempt retry log.
 - Identify chime is now a repeated percussive ping (sharp attack, bright harmonics) instead of a soft two-tone sine — it's far easier to tell which speaker it's coming from by ear.
 
+### Fixed
+- The New/Re-snapshot profile form is now locked and dimmed while it reads a speaker's EQ/volume, so you can no longer flip the capture toggles or change the selection mid-save.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -134,73 +134,81 @@ class _State extends ConsumerState<ProfileCreateScreen> {
                 : context.l10n.profileCreate,
         onPressed: canSave ? () => _save(name, existing) : null,
       ),
-      body: ListView(
-        padding: const EdgeInsets.fromLTRB(16, 8, 16, 96),
-        children: [
-          if (isResnapshot) ...[
-            // Non-destructive: nothing is written until the user saves on the
-            // profile screen, so this is a light note, not a warning.
-            InfoNote(context.l10n.profileResnapshotNote),
-            Gap.l,
-          ] else
-            // Name + appearance are edited on the profile screen for an existing
-            // profile; only create-new needs them here.
-            Padding(
-              padding: const EdgeInsets.only(bottom: 24),
-              child: ProfileNameField(
-                controller: _name,
-                iconId: _iconId,
-                color: _color,
-                nameTaken: taken,
-                onChanged: () => setState(() {}),
-                onAppearanceChanged: (icon, color) => setState(() {
-                  _iconId = icon;
-                  _color = color;
-                }),
+      // While saving (reading EQ/volume over SOAP), lock the whole form and dim
+      // it so no toggle/checkbox/name edit can race the in-flight capture.
+      body: AbsorbPointer(
+        absorbing: _saving,
+        child: Opacity(
+          opacity: _saving ? 0.5 : 1,
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 96),
+            children: [
+              if (isResnapshot) ...[
+                // Non-destructive: nothing is written until the user saves on the
+                // profile screen, so this is a light note, not a warning.
+                InfoNote(context.l10n.profileResnapshotNote),
+                Gap.l,
+              ] else
+                // Name + appearance are edited on the profile screen for an existing
+                // profile; only create-new needs them here.
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 24),
+                  child: ProfileNameField(
+                    controller: _name,
+                    iconId: _iconId,
+                    color: _color,
+                    nameTaken: taken,
+                    onChanged: () => setState(() {}),
+                    onAppearanceChanged: (icon, color) => setState(() {
+                      _iconId = icon;
+                      _color = color;
+                    }),
+                  ),
+                ),
+              // Only the create flow needs the "what applying does" primer; on
+              // re-snapshot the profile already exists and the detail screen owns
+              // the review.
+              if (!isResnapshot) ...[
+                InfoNote(context.l10n.profileApplyPrimer),
+                Gap.l,
+              ],
+              SectionHeader(
+                context.l10n.profileIncludeHeader,
+                helper: context.l10n.profileIncludeHelper,
               ),
-            ),
-          // Only the create flow needs the "what applying does" primer; on
-          // re-snapshot the profile already exists and the detail screen owns
-          // the review.
-          if (!isResnapshot) ...[
-            InfoNote(context.l10n.profileApplyPrimer),
-            Gap.l,
-          ],
-          SectionHeader(
-            context.l10n.profileIncludeHeader,
-            helper: context.l10n.profileIncludeHelper,
+              for (final e in _entities)
+                _SelectableEntityCard(
+                  entity: e,
+                  included: _included[e.primaryUuid] ?? true,
+                  onChanged: (v) => setState(() => _included[e.primaryUuid] = v),
+                ),
+              Gap.l,
+              SectionHeader(
+                context.l10n.profileSpeakerSettingsHeader,
+                helper: context.l10n.profileSpeakerSettingsHelper,
+              ),
+              // Flat settings rows (not a card) — these are toggles, matching the
+              // Trueplay / diagnostics registers.
+              SettingsSection(children: [
+                SwitchListTile(
+                  value: _saveAudio,
+                  onChanged: (v) => setState(() => _saveAudio = v),
+                  secondary: const Icon(Icons.tune),
+                  title: Text(context.l10n.profileSaveAudio),
+                  subtitle: Text(context.l10n.profileSaveAudioSubtitle),
+                ),
+                const Divider(height: 1),
+                SwitchListTile(
+                  value: _saveVolume,
+                  onChanged: (v) => setState(() => _saveVolume = v),
+                  secondary: const Icon(Icons.volume_up),
+                  title: Text(context.l10n.profileSaveVolume),
+                  subtitle: Text(context.l10n.profileSaveVolumeSubtitle),
+                ),
+              ]),
+            ],
           ),
-          for (final e in _entities)
-            _SelectableEntityCard(
-              entity: e,
-              included: _included[e.primaryUuid] ?? true,
-              onChanged: (v) => setState(() => _included[e.primaryUuid] = v),
-            ),
-          Gap.l,
-          SectionHeader(
-            context.l10n.profileSpeakerSettingsHeader,
-            helper: context.l10n.profileSpeakerSettingsHelper,
-          ),
-          // Flat settings rows (not a card) — these are toggles, matching the
-          // Trueplay / diagnostics registers.
-          SettingsSection(children: [
-            SwitchListTile(
-              value: _saveAudio,
-              onChanged: (v) => setState(() => _saveAudio = v),
-              secondary: const Icon(Icons.tune),
-              title: Text(context.l10n.profileSaveAudio),
-              subtitle: Text(context.l10n.profileSaveAudioSubtitle),
-            ),
-            const Divider(height: 1),
-            SwitchListTile(
-              value: _saveVolume,
-              onChanged: (v) => setState(() => _saveVolume = v),
-              secondary: const Icon(Icons.volume_up),
-              title: Text(context.l10n.profileSaveVolume),
-              subtitle: Text(context.l10n.profileSaveVolumeSubtitle),
-            ),
-          ]),
-        ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## What

While a New / Re-snapshot profile is reading a speaker's EQ / volume over SOAP (`_saving`), only the **Save button** was disabled. The "Save EQ", "Save volume" toggles, the entity include checkboxes, and the name/appearance picker all stayed interactive — so you could flip toggles or change the selection mid-capture, racing the in-flight read.

## Fix

Wrap the form `body` `ListView` in `AbsorbPointer(absorbing: _saving)` + `Opacity(opacity: _saving ? 0.5 : 1)`, both keyed on the existing `_saving` flag. The whole form is now locked and visibly dimmed until the capture settles. One wrap catches every current (and future) control — no per-control gating to thread through the sub-widgets.

- The Save button was already correctly gated via `canSave`/`_saving`; it stays outside the dimmed body so its "reading settings…" label remains visible.
- Back navigation is intentionally left active — the `_save` path is `mounted`-guarded, so leaving mid-save is safe.
- `_saving` is only ever true on the `_saveAudio || _saveVolume` path (the no-settings save completes instantly and never dims).

## Notes / reviewed tradeoffs

- Pre-merge review (subagent + `/code-review` + `/ponytail-review`): no correctness bugs; diff is lean.
- Known minor gap, consciously accepted for this brief lock: `AbsorbPointer` blocks pointers but not the semantics tree, so a screen reader still presents the dimmed controls as actionable (a tap silently no-ops). Adding `ExcludeSemantics` would close it but forces a full-subtree re-indent for a few-second lock — deferred.

## Verification

- `flutter analyze` clean, `flutter test` green (203 passed; presentation-only change, no new test warranted).
- Manual: create a profile with "Save EQ / audio settings" on → while the button reads "reading settings…", the form is dimmed and the toggles/checkboxes/name field don't respond; it returns to normal once capture finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)