### PR TITLE
fix(ui): clamp macOS overscroll so it stops jittering back to the top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ section into the GitHub Release notes regardless of the build suffix
 - An unreachable speaker's card is now shown dimmed with a short "Unreachable" subtitle instead of an alarming red warning tile with a long hint.
 
 ### Fixed
+- macOS overscroll no longer jitters/springs back to the top: scroll views now clamp on macOS (like the other desktops) instead of using the iOS rubber-band bounce, which stuttered under trackpad overscroll. Pull-to-refresh still works.
 - Pull-to-refresh on the System overview and home-theater pages now works even when the content is short enough to fit the screen without scrolling (previously the pull gesture did nothing there).
 - The New/Re-snapshot profile form is now locked and dimmed while it reads a speaker's EQ/volume, so you can no longer flip the capture toggles or change the selection mid-save.
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -359,6 +359,22 @@ class _AnimatedBranchContainerState extends State<_AnimatedBranchContainer>
   }
 }
 
+/// macOS defaults to iOS-style [BouncingScrollPhysics], so overscrolling
+/// rubber-bands — and on a trackpad (pan/zoom events overscroll, unlike a mouse
+/// wheel which clamps) short content springs back to the top, reading as a
+/// jitter. Clamp on macOS like the other desktops (Android/Windows/Linux
+/// already do); a wrapping [AlwaysScrollableScrollPhysics] still parents onto
+/// this, so pull-to-refresh keeps firing without the bounce.
+class AppScrollBehavior extends MaterialScrollBehavior {
+  const AppScrollBehavior();
+
+  @override
+  ScrollPhysics getScrollPhysics(BuildContext context) =>
+      getPlatform(context) == TargetPlatform.macOS
+      ? const ClampingScrollPhysics(parent: RangeMaintainingScrollPhysics())
+      : super.getScrollPhysics(context);
+}
+
 class SonorityApp extends ConsumerStatefulWidget {
   const SonorityApp({super.key});
 
@@ -432,6 +448,7 @@ class _SonorityAppState extends ConsumerState<SonorityApp> {
             useDynamic ? darkDynamic?.harmonized() : null,
           ).copyWith(platform: platform),
           themeMode: ThemeMode.system,
+          scrollBehavior: const AppScrollBehavior(),
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           routerConfig: _router,

--- a/test/scroll_physics_test.dart
+++ b/test/scroll_physics_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/app.dart';
+
+// macOS must clamp overscroll (no rubber-band jitter); every other platform
+// keeps its native physics. Regression guard for the overscroll-jitter fix.
+void main() {
+  Future<ScrollPhysics> physicsFor(
+    WidgetTester tester,
+    TargetPlatform platform,
+  ) async {
+    late ScrollPhysics physics;
+    await tester.pumpWidget(
+      Theme(
+        data: ThemeData(platform: platform),
+        child: Builder(
+          builder: (context) {
+            physics = const AppScrollBehavior().getScrollPhysics(context);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+    return physics;
+  }
+
+  testWidgets('macOS clamps overscroll', (tester) async {
+    expect(
+      await physicsFor(tester, TargetPlatform.macOS),
+      isA<ClampingScrollPhysics>(),
+    );
+  });
+
+  testWidgets('iOS keeps its bouncy physics', (tester) async {
+    expect(
+      await physicsFor(tester, TargetPlatform.iOS),
+      isA<BouncingScrollPhysics>(),
+    );
+  });
+}


### PR DESCRIPTION
## What

On macOS, overscrolling the System overview and Profiles overview jittered — the view sprang back to the top when you tried to scroll past the content. Reported live; the user confirmed **it only happens when overscrolling**.

## Root cause

macOS is the only platform Flutter gives iOS-style `BouncingScrollPhysics` (`_bouncingDesktopPhysics`); Android/Windows/Linux already clamp. A trackpad two-finger scroll arrives as pan/zoom (drag-like) events that **overscroll** (unlike a mouse wheel, which clamps), so on content that fits the viewport the rubber-band spring snaps back to the top — the jitter. #61 made the System overview newly overscrollable (`AlwaysScrollableScrollPhysics`), and the Profiles overview bounces the same way via the plain macOS default. Same mechanism, one fix.

## Fix

Add an `AppScrollBehavior` that clamps on macOS (matching the other desktops) and wire it into `MaterialApp.router` via `scrollBehavior:`. `AlwaysScrollableScrollPhysics` (from #61) still parents onto the clamp, so pull-to-refresh keeps firing on short content — it just no longer springs. One app-wide change fixes both pages and every other scroll view.

## Verification

- `flutter analyze` + `flutter test` green (205 tests).
- New `test/scroll_physics_test.dart` locks macOS→`ClampingScrollPhysics`, iOS→`BouncingScrollPhysics`.
- Rebuilt and ran on the real macOS app.
- Pre-merge reviews (review subagent + `/code-review` + `/ponytail-review`): no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)