### PR TITLE
fix(ui): stop System overview jittering on macOS/iPad trackpad overscroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ section into the GitHub Release notes regardless of the build suffix
 - An unreachable speaker's card is now shown dimmed with a short "Unreachable" subtitle instead of an alarming red warning tile with a long hint.
 
 ### Fixed
+- The System overview no longer jitters / jumps while overscrolling with a trackpad on macOS (and iPad) — it now scrolls as a list view instead of a single scrolling column, which the platform bounce handles smoothly.
 - Pull-to-refresh on the System overview and home-theater pages now works even when the content is short enough to fit the screen without scrolling (previously the pull gesture did nothing there).
 - The New/Re-snapshot profile form is now locked and dimmed while it reads a speaker's EQ/volume, so you can no longer flip the capture toggles or change the selection mid-save.
 

--- a/lib/features/discovery/discovery_screen.dart
+++ b/lib/features/discovery/discovery_screen.dart
@@ -66,11 +66,11 @@ class DiscoveryScreen extends ConsumerWidget {
             icon: const Icon(Icons.refresh),
           ),
       ],
-      // The scanning/error placeholders center themselves (their Center
-      // expands to the body height); _SystemView shrink-wraps when short. The
-      // switcher's default layout is a center-aligned Stack, which floats that
-      // shrink-wrapped content to the vertical middle mid-transition (when the
-      // expanding placeholder inflates the Stack) — top-align it instead.
+      // The scanning/error placeholders (Center) and _SystemView (a ListView)
+      // all fill the body height. The switcher's default layout is a
+      // center-aligned Stack, which would float a smaller child to the vertical
+      // middle mid-transition (when an expanding sibling inflates the Stack) —
+      // top-align it instead so content stays pinned to the top throughout.
       body: PageTransitionSwitcher(
         duration: const Duration(milliseconds: 250),
         reverse: state.isLoading,
@@ -108,80 +108,80 @@ class _SystemView extends ConsumerWidget {
         .toList();
     // Owns its own scroll, filling the screen-sized body. The app bar is fixed,
     // so there's no collapse to lose; Rescan / pull-to-refresh cover refresh.
-    return SingleChildScrollView(
-      // Always overscrollable so pull-to-refresh fires even when the content
-      // is shorter than the viewport (a sparse system of a few cards).
+    // A sliver ListView, NOT SingleChildScrollView + Column: the interactive
+    // EntityCards in a CardGrid Wrap inside a SingleChildScrollView jitter on
+    // macOS/iPad trackpad overscroll (hover hit-test churn against the Wrap); a
+    // sliver viewport doesn't, and keeps the platform bounce. AlwaysScrollable so
+    // pull-to-refresh still fires when the content is shorter than the viewport.
+    return ListView(
       physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.all(16),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          SectionHeader(context.l10n.discoveryHomeTheaters,
-              icon: Icons.theaters_outlined),
-          if (theaters.isEmpty) _EmptyHint(context.l10n.discoveryNoSoundbar),
+      children: [
+        SectionHeader(context.l10n.discoveryHomeTheaters,
+            icon: Icons.theaters_outlined),
+        if (theaters.isEmpty) _EmptyHint(context.l10n.discoveryNoSoundbar),
+        _cardGrid([
+          for (final m in theaters)
+            EntityCard(
+              model: EntityCardModel.fromMember(system, m),
+              onTap: () => context.push('/theater/${m.uuid}'),
+            ),
+        ]),
+        Gap.l,
+        // The "+" lives in the header; the flow itself explains if there
+        // aren't two free speakers to bond.
+        SectionHeader(
+          context.l10n.discoverySpeakerGroups,
+          icon: Icons.speaker_group_outlined,
+          onAdd: () => context.push('/group'),
+          addTooltip: context.l10n.discoveryGroupSpeakers,
+        ),
+        if (groups.isEmpty)
+          _EmptyHint(context.l10n.discoveryNoGroups)
+        else
           _cardGrid([
-            for (final m in theaters)
+            for (final m in groups)
               EntityCard(
                 model: EntityCardModel.fromMember(system, m),
-                onTap: () => context.push('/theater/${m.uuid}'),
+                onTap: () => context.push('/group/${m.uuid}'),
               ),
           ]),
+        // Single speaker rooms — hidden entirely when there are none.
+        if (singleRooms.isNotEmpty) ...[
           Gap.l,
-          // The "+" lives in the header; the flow itself explains if there
-          // aren't two free speakers to bond.
           SectionHeader(
-            context.l10n.discoverySpeakerGroups,
-            icon: Icons.speaker_group_outlined,
-            onAdd: () => context.push('/group'),
-            addTooltip: context.l10n.discoveryGroupSpeakers,
+            context.l10n.discoverySingleRooms,
+            icon: Icons.meeting_room_outlined,
           ),
-          if (groups.isEmpty)
-            _EmptyHint(context.l10n.discoveryNoGroups)
-          else
-            _cardGrid([
-              for (final m in groups)
-                EntityCard(
-                  model: EntityCardModel.fromMember(system, m),
-                  onTap: () => context.push('/group/${m.uuid}'),
-                ),
-            ]),
-          // Single speaker rooms — hidden entirely when there are none.
-          if (singleRooms.isNotEmpty) ...[
-            Gap.l,
-            SectionHeader(
-              context.l10n.discoverySingleRooms,
-              icon: Icons.meeting_room_outlined,
-            ),
-            _cardGrid([
-              for (final m in singleRooms)
-                EntityCard(
-                  model: EntityCardModel.fromMember(system, m),
-                  onTap: () => context.push('/room/${m.uuid}'),
-                ),
-            ]),
-          ],
-          // Other devices: unbonded Subs are shown so they're visible (they're
-          // Invisible members with no room). Tapping opens a small sheet to
-          // identify it and explains how to bond it — a standalone sub has no
-          // config of its own, so this is the only affordance.
-          if (system.bondableSubs.isNotEmpty) ...[
-            Gap.l,
-            SectionHeader(context.l10n.discoveryOtherDevices,
-                icon: Icons.devices_other_outlined),
-            _cardGrid([
-              for (final sub in system.bondableSubs)
-                EntityCard(
-                  model: EntityCardModel(
-                    icon: Icons.graphic_eq,
-                    title: context.l10n.discoverySubwoofer,
-                    subtitle: sub.typeLabel,
-                  ),
-                  onTap: () => _showSubSheet(context, sub),
-                ),
-            ]),
-          ],
+          _cardGrid([
+            for (final m in singleRooms)
+              EntityCard(
+                model: EntityCardModel.fromMember(system, m),
+                onTap: () => context.push('/room/${m.uuid}'),
+              ),
+          ]),
         ],
-      ),
+        // Other devices: unbonded Subs are shown so they're visible (they're
+        // Invisible members with no room). Tapping opens a small sheet to
+        // identify it and explains how to bond it — a standalone sub has no
+        // config of its own, so this is the only affordance.
+        if (system.bondableSubs.isNotEmpty) ...[
+          Gap.l,
+          SectionHeader(context.l10n.discoveryOtherDevices,
+              icon: Icons.devices_other_outlined),
+          _cardGrid([
+            for (final sub in system.bondableSubs)
+              EntityCard(
+                model: EntityCardModel(
+                  icon: Icons.graphic_eq,
+                  title: context.l10n.discoverySubwoofer,
+                  subtitle: sub.typeLabel,
+                ),
+                onTap: () => _showSubSheet(context, sub),
+              ),
+          ]),
+        ],
+      ],
     );
   }
 }


### PR DESCRIPTION
## What

The System overview stuttered / jumped toward the top while two-finger **overscrolling** on macOS (and iPad). This swaps its scroll host from `SingleChildScrollView` + `Column` to a sliver **`ListView`** (children unchanged), which fixes the jitter while **keeping the platform bounce** — no clamping.

## Why it jittered (root cause)

Isolated empirically with a temporary in-app scroll-lab (toggles for each variable, tested on a real trackpad; the lab has been removed):

- Neither the physics (`AlwaysScrollableScrollPhysics`), the `RefreshIndicator`, nor the `PageTransitionSwitcher` wrapper was the cause.
- The trigger is an **`InkWell`'s hover `MouseRegion` inside `CardGrid`'s multi-column `Wrap`** (wide layout), hosted in a **`SingleChildScrollView`**. During overscroll the content translates under a stationary cursor; the hover hit-test churn against the `Wrap`'s cards destabilises the scroll position.
- A bare `InkWell` in a `Column` doesn't jitter, and the `Wrap` without an `InkWell` doesn't — it's the pair inside a `SingleChildScrollView`.
- Hosting the **same content** in a sliver `ListView` removes the jitter. This is the same reason **Profiles** stopped jittering once #64 made it a sliver reorderable grid.

Diagnostics never jittered because it's `SingleChildScrollView → SelectableText` (no `InkWell`).

## Scope

Fixes the reported **System overview** only. The same latent pattern (`SingleChildScrollView` + `CardGrid`) exists on a few other pages (Home Theater / Group detail, the setup flows) — a follow-up can extend the same host swap if wanted.

## Testing

- Verified on the real macOS overview: jitter gone, bounce still feels normal.
- `flutter analyze` clean; `flutter test` green (209 passing).
- Pull-to-refresh on short content still works (physics retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)