### PR TITLE
fix(ui): narrow the wide-layout navigation rail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ section into the GitHub Release notes regardless of the build suffix
 - Reconfiguring a home theater (e.g. swapping which speakers are fronts vs surrounds) no longer unbonds speakers that are only moving to a different channel — they're reassigned in place, so the setup no longer briefly drops to one speaker per side. The progress screen shows a single calm "Applying…" step (Sonos can still take up to a minute to settle) instead of a scary per-attempt retry log.
 - Identify chime is now a repeated percussive ping (sharp attack, bright harmonics) instead of a soft two-tone sine — it's far easier to tell which speaker it's coming from by ear.
 - An unreachable speaker's card is now shown dimmed with a short "Unreachable" subtitle instead of an alarming red warning tile with a long hint.
+- The wide-layout navigation rail is a bit narrower, giving the content pane more room.
 
 ### Fixed
 - The System overview no longer jitters / jumps while overscrolling with a trackpad on macOS (and iPad) — it now scrolls as a list view instead of a single scrolling column, which the platform bounce handles smoothly.

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -195,6 +195,7 @@ class _HomeShell extends StatelessWidget {
                         ),
                         Expanded(
                           child: NavigationRail(
+                            minExtendedWidth: 200,
                             selectedIndex: shell.currentIndex,
                             onDestinationSelected: _go,
                             extended: true,


### PR DESCRIPTION
## What

On wide layouts (iPad landscape / wide macOS) the left `NavigationRail` sidebar used Material's default extended width of **256px**, which felt too wide. Set `minExtendedWidth: 200` so the sidebar is narrower and the content pane gets ~56px more room.

One line in `lib/app.dart`; no logic touched. The wordmark and all three rail labels (System / Profiles / Diagnostics) still fit; version pill unchanged. Phone layout unaffected.

## Verification

- `flutter analyze` clean, `flutter test` green (209 passing).
- Built + ran the macOS demo build wide and eyeballed it: sidebar visibly narrower, nothing clipped, content wider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)