### PR TITLE
refactor(ui): consistency pass on non-default Material deviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Changed
+- UI consistency pass: the Profiles list now aligns to the same page gutter as the other screens, share/save and empty-state layouts use consistent sizing, and short animations share one duration — plus removed a few redundant theme overrides that just restated Flutter defaults. No behaviour change.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/lib/core/theme.dart
+++ b/lib/core/theme.dart
@@ -100,14 +100,13 @@ class AppTheme {
         ? Color.alphaBlend(Colors.black.withValues(alpha: 0.35), scheme.surface)
         : scheme.surface;
     return ThemeData(
-      useMaterial3: true,
       colorScheme: scheme,
       // Center glyphs within their line box on every platform. The macOS system
       // font (SF) puts most of its line leading ABOVE the glyph, so text sits a
       // few px low in tiles/cards there; "even" splits the leading top/bottom so
       // it looks vertically centered cross-platform (Android already does this).
       textTheme: _evenLeading(
-        ThemeData(useMaterial3: true, colorScheme: scheme).textTheme,
+        ThemeData(colorScheme: scheme).textTheme,
       ),
       scaffoldBackgroundColor: pageBg,
       appBarTheme: AppBarTheme(
@@ -119,7 +118,6 @@ class AppTheme {
         // no shadow, no tint.
         elevation: 0,
         scrolledUnderElevation: 0,
-        shadowColor: scheme.shadow,
         titleTextStyle: TextStyle(
           color: scheme.onSurface,
           fontSize: 22,
@@ -141,7 +139,6 @@ class AppTheme {
       // A distinct bottom nav surface (the top divider is added in the shell).
       navigationBarTheme: NavigationBarThemeData(
         backgroundColor: scheme.surfaceContainerHigh,
-        indicatorColor: scheme.secondaryContainer,
         surfaceTintColor: Colors.transparent,
         elevation: 0,
       ),
@@ -207,6 +204,10 @@ const RoundedRectangleBorder kFlatTileShape =
 /// Vertical gap between stacked cards in a list (applied as a card `margin` /
 /// bottom padding, so it's a `double` rather than a [Gap] SizedBox).
 const double kCardGap = 12;
+
+/// The app's standard short UI-animation duration (crossfades, switchers,
+/// reorder). One source so a "quick" transition can't drift between 200/240ms.
+const Duration kShortAnim = Duration(milliseconds: 240);
 
 /// Width at/above which the UI switches to its wide (desktop/large-window)
 /// layout: a left `NavigationRail` instead of the bottom nav bar, and content

--- a/lib/features/diagnostics/diagnostics_screen.dart
+++ b/lib/features/diagnostics/diagnostics_screen.dart
@@ -15,6 +15,7 @@ import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/busy_spinner.dart';
+import '../widgets/settings_section.dart';
 import 'diagnostics_bundle.dart';
 
 const _devEmail = 'casperverswijveltdev@gmail.com';
@@ -172,31 +173,32 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
                   ),
           ),
           // Bundle-content toggles + note + escalation actions, pinned below the
-          // scrolling topology.
-          const Divider(height: 1),
-          SwitchListTile(
-            value: _includeLogs,
-            onChanged: _isBusy ? null : (v) => setState(() => _includeLogs = v),
-            title: Text(context.l10n.diagIncludeLogs),
-            subtitle: Text(context.l10n.diagIncludeLogsSubtitle),
-            dense: true,
-            shape: kFlatTileShape,
-          ),
-          SwitchListTile(
-            value: _includeNetwork,
-            onChanged:
-                _isBusy ? null : (v) => setState(() => _includeNetwork = v),
-            title: Text(context.l10n.diagIncludeNetwork),
-            subtitle: Text(context.l10n.diagIncludeNetworkSubtitle),
-            dense: true,
-            shape: kFlatTileShape,
-          ),
+          // scrolling topology. The toggles are a flat register (leading divider +
+          // square ink) via the shared SettingsSection, like the room / new-profile
+          // registers.
+          SettingsSection(children: [
+            SwitchListTile(
+              value: _includeLogs,
+              onChanged:
+                  _isBusy ? null : (v) => setState(() => _includeLogs = v),
+              title: Text(context.l10n.diagIncludeLogs),
+              subtitle: Text(context.l10n.diagIncludeLogsSubtitle),
+              dense: true,
+            ),
+            SwitchListTile(
+              value: _includeNetwork,
+              onChanged:
+                  _isBusy ? null : (v) => setState(() => _includeNetwork = v),
+              title: Text(context.l10n.diagIncludeNetwork),
+              subtitle: Text(context.l10n.diagIncludeNetworkSubtitle),
+              dense: true,
+            ),
+          ]),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
             child: Text(
               context.l10n.diagAlwaysIncluded,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.mutedText,
             ),
           ),
           Padding(
@@ -211,7 +213,7 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
                             _emailSupported ? _Action.email : _Action.share,
                             _emailSupported ? _email : _share,
                           ),
-                    style: FilledButton.styleFrom(minimumSize: const Size(0, 52)),
+                    style: FilledButton.styleFrom(minimumSize: const Size(0, 54)),
                     icon: _busyIcon(
                       _emailSupported ? _Action.email : _Action.share,
                       _emailSupported ? Icons.mail_outline : Icons.share,
@@ -236,7 +238,7 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
                         : () => _run(_Action.share, _share),
                     style: FilledButton.styleFrom(
                       padding: const EdgeInsets.symmetric(horizontal: 14),
-                      minimumSize: const Size(0, 52),
+                      minimumSize: const Size(0, 54),
                     ),
                     child: _busyIcon(_Action.share, Icons.share),
                   ),
@@ -251,7 +253,7 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
                         : () => _run(_Action.save, _save),
                     style: FilledButton.styleFrom(
                       padding: const EdgeInsets.symmetric(horizontal: 14),
-                      minimumSize: const Size(0, 52),
+                      minimumSize: const Size(0, 54),
                     ),
                     child: _busyIcon(_Action.save, Icons.save_alt),
                   ),

--- a/lib/features/home_theater/home_theater_screen.dart
+++ b/lib/features/home_theater/home_theater_screen.dart
@@ -303,7 +303,6 @@ class _GroupCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Card(
-      margin: EdgeInsets.zero,
       child: ListTile(
         leading: Icon(group.icon, color: theme.colorScheme.primary),
         title: Text(group.label),

--- a/lib/features/profiles/profile_create_screen.dart
+++ b/lib/features/profiles/profile_create_screen.dart
@@ -103,7 +103,7 @@ class _State extends ConsumerState<ProfileCreateScreen> {
                 : context.l10n.profileNew)),
         body: Center(
           child: Padding(
-            padding: const EdgeInsets.all(32),
+            padding: const EdgeInsets.all(24),
             child: Text(
               context.l10n.profileScanFirstCreate,
               textAlign: TextAlign.center,

--- a/lib/features/profiles/profile_entity_detail_screen.dart
+++ b/lib/features/profiles/profile_entity_detail_screen.dart
@@ -172,10 +172,7 @@ class _SettingsBlock extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(title, style: theme.textTheme.titleMedium),
-          if (role != null)
-            Text(role!,
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(color: scheme.onSurfaceVariant)),
+          if (role != null) Text(role!, style: theme.mutedText),
           Gap.s,
           for (final r in rows)
             Padding(

--- a/lib/features/profiles/profile_ui.dart
+++ b/lib/features/profiles/profile_ui.dart
@@ -291,7 +291,6 @@ class ProfileCard extends StatelessWidget {
     final tonal = profileTonal(profile.color, theme.brightness);
     final summary = profile.entities.map((e) => e.label).join(' · ');
     return Card(
-      margin: EdgeInsets.zero,
       color: selected
           ? Color.alphaBlend(
               scheme.primary.withValues(alpha: 0.12),
@@ -383,7 +382,7 @@ class ProfileCard extends StatelessWidget {
                     // Cross-fade when the trailing swaps (⋮ menu ↔ drag handle
                     // when toggling reorder mode).
                     AnimatedSwitcher(
-                      duration: const Duration(milliseconds: 240),
+                      duration: kShortAnim,
                       child: trailing!,
                     ),
                   ],
@@ -402,7 +401,7 @@ class ProfileCard extends StatelessWidget {
               // grid measures the changing height each frame and its rows follow.
               if (actions != null)
                 AnimatedCrossFade(
-                  duration: const Duration(milliseconds: 240),
+                  duration: kShortAnim,
                   sizeCurve: Curves.easeInOut,
                   firstCurve: Curves.easeInOut,
                   secondCurve: Curves.easeInOut,

--- a/lib/features/profiles/profile_widget.dart
+++ b/lib/features/profiles/profile_widget.dart
@@ -253,7 +253,7 @@ class _WidgetConfigScreenState extends State<_WidgetConfigScreen> {
           : list.isEmpty
               ? Center(
                   child: Padding(
-                    padding: const EdgeInsets.all(32),
+                    padding: const EdgeInsets.all(24),
                     child: Text(context.l10n.profileWidgetEmpty,
                         textAlign: TextAlign.center),
                   ),
@@ -262,7 +262,8 @@ class _WidgetConfigScreenState extends State<_WidgetConfigScreen> {
                   children: [
                     Expanded(
                       child: ListView(
-                        padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
+                        padding: const EdgeInsets.fromLTRB(
+                            kPageGutter, 0, kPageGutter, 12),
                         children: [
                           Padding(
                             padding: const EdgeInsets.fromLTRB(4, 8, 4, 12),

--- a/lib/features/profiles/profiles_screen.dart
+++ b/lib/features/profiles/profiles_screen.dart
@@ -48,7 +48,7 @@ class _ProfilesScreenState extends ConsumerState<ProfilesScreen> {
           items: list,
           idOf: (p) => p.id,
           reordering: _editing,
-          padding: const EdgeInsets.fromLTRB(12, 0, 12, 96),
+          padding: const EdgeInsets.fromLTRB(kPageGutter, 0, kPageGutter, 96),
           itemBuilder: (context, p) =>
               _profileCard(context, ref, p, editing: _editing),
           onReorder: (from, to) =>
@@ -230,7 +230,7 @@ class _EmptyState extends StatelessWidget {
     final theme = Theme.of(context);
     return Center(
       child: Padding(
-        padding: const EdgeInsets.all(32),
+        padding: const EdgeInsets.all(24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/widgets/busy_view.dart
+++ b/lib/features/widgets/busy_view.dart
@@ -16,7 +16,7 @@ class BusyView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Padding(
-        padding: const EdgeInsets.all(32),
+        padding: const EdgeInsets.all(24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [

--- a/lib/features/widgets/info_note.dart
+++ b/lib/features/widgets/info_note.dart
@@ -13,7 +13,6 @@ class InfoNote extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Card(
-      margin: EdgeInsets.zero,
       color: theme.colorScheme.surfaceContainerHighest,
       child: Padding(
         padding: const EdgeInsets.all(12),

--- a/lib/features/widgets/member_channel_card.dart
+++ b/lib/features/widgets/member_channel_card.dart
@@ -30,7 +30,6 @@ class MemberChannelCard extends StatelessWidget {
     final scheme = theme.colorScheme;
     final channel = this.channel;
     return Card(
-      margin: EdgeInsets.zero,
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Row(

--- a/lib/features/widgets/reorderable_card_grid.dart
+++ b/lib/features/widgets/reorderable_card_grid.dart
@@ -66,8 +66,6 @@ class ReorderableCardGrid<T> extends StatefulWidget {
 }
 
 class _ReorderableCardGridState<T> extends State<ReorderableCardGrid<T>> {
-  static const _anim = Duration(milliseconds: 240);
-
   final _stackKey = GlobalKey();
 
   /// Visual order — mirrors [widget.items], but reorders live during a drag.
@@ -248,7 +246,7 @@ class _ReorderableCardGridState<T> extends State<ReorderableCardGrid<T>> {
     // Only drop the "on top" flag once THIS drop's animation has finished, so
     // the z-order never flickers mid-flight — the token guards against a fast
     // re-drag whose timer would otherwise clear the new drop early.
-    Future.delayed(_anim, () {
+    Future.delayed(kShortAnim, () {
       if (mounted && _dropToken == token) setState(() => _droppingId = null);
     });
   }
@@ -379,7 +377,7 @@ class _ReorderableCardGridState<T> extends State<ReorderableCardGrid<T>> {
       // to their slot. On release `dragging` flips false, so the ex-dragged item
       // animates from the finger to its slot — the drop. A resize snaps (see
       // above) so sizes never tween.
-      duration: (dragging || resized) ? Duration.zero : _anim,
+      duration: (dragging || resized) ? Duration.zero : kShortAnim,
       curve: Curves.easeInOut,
       left: pos.dx,
       top: pos.dy,

--- a/lib/features/widgets/selectable_speaker_card.dart
+++ b/lib/features/widgets/selectable_speaker_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/l10n.dart';
+import '../../core/theme.dart';
 import '../../data/models/sonos_models.dart';
 import 'bondable_speaker_tile.dart';
 
@@ -60,9 +61,9 @@ class SelectableSpeakerCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // No card margin — the CardGrid / caller owns the spacing between cards.
+    // Card margin comes from the theme (zero) — the CardGrid / caller owns the
+    // spacing between cards.
     return Card(
-      margin: EdgeInsets.zero,
       clipBehavior: Clip.antiAlias,
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -77,7 +78,7 @@ class SelectableSpeakerCard extends StatelessWidget {
           // CrossFade (not just AnimatedSize) so the control fades out WHILE the
           // height collapses on deselect, instead of vanishing instantly.
           AnimatedCrossFade(
-            duration: const Duration(milliseconds: 200),
+            duration: kShortAnim,
             sizeCurve: Curves.easeInOut,
             alignment: Alignment.topCenter,
             crossFadeState: showControl && control != null

--- a/lib/features/widgets/version_badge.dart
+++ b/lib/features/widgets/version_badge.dart
@@ -103,7 +103,7 @@ Future<void> showVersionSheet(BuildContext context, PackageInfo info) {
               Uri.parse(_repoUrl),
               mode: LaunchMode.externalApplication,
             ),
-            style: FilledButton.styleFrom(minimumSize: const Size(0, 52)),
+            style: FilledButton.styleFrom(minimumSize: const Size(0, 54)),
             icon: const Icon(Icons.open_in_new),
             label: const Text('GitHub'),
           ),


### PR DESCRIPTION
## What & why

A cleanup pass hunting places where the UI deviates from Material 3 / Flutter defaults, in the spirit of *fewer custom behaviours = fewer ways to introduce inconsistency*. Where a tuned variant is worth keeping, this makes it **consistent** by routing through one token/helper. **No behaviour change intended.**

## Changes

**Deleted redundant theme overrides** (`lib/core/theme.dart`) — each just restated the current Flutter default, so removing them changes nothing:
- `useMaterial3: true` (SDK default now), `navigationBarTheme.indicatorColor: secondaryContainer` (the M3 default), `appBarTheme.shadowColor` (moot at `elevation: 0`).

**Unified drifted values onto one variant/token:**
- Profiles list (and the home-widget picker screen) gutter `12` → `kPageGutter` (16), so cards align with every other screen.
- Short-animation durations — a `200ms` outlier, inline `240`s, and a local `_anim` const — → a new shared `kShortAnim` (240ms) token.
- Full-width-escape button heights `Size(0, 52)` → `Size(0, 54)` to match the theme (keeps min-width `0`).
- Empty/busy-state padding `32` → `24`.

**Reuse / dedup:**
- Removed redundant `margin: EdgeInsets.zero` on 5 `Card` call-sites (the `cardTheme` already sets it).
- Diagnostics: replaced a hand-rolled flat register (manual `Divider` + inline per-tile `shape: kFlatTileShape`) with the shared `SettingsSection`; replaced two inline `bodySmall + onSurfaceVariant` styles with the `theme.mutedText` extension.

**Explicitly left as-is** (deliberate deviations): the `FilledButton` theme (squared radius-16, full-width, 54px), the destructive-button variants, `ScrollFooter`'s custom layout + `AlwaysScrollableScrollPhysics`, and the hand-captured `ColorScheme`s.

## Verification
- `flutter analyze` — clean.
- `flutter test` — all 210 pass.
- Ran on macOS (debug) and spot-checked the Profiles gutter, Diagnostics register/button row, and empty states.
- Pre-merge review (fresh subagent + `/code-review` + `/ponytail-review`); findings addressed (a stray blank line; aligned the home-widget picker's gutter/empty-state that had been missed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)