### PR TITLE
fix(fronts): offer a Port/Connect as one-box front speakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Fixed
+- A Sonos Port (and Connect) is now offered as dedicated front speakers the same way a Sonos Amp is — one box driving both front channels (`LF,RF`) — instead of appearing as a single-channel speaker. Sonos firmware may still refuse the bond: unlike the Amp, a Port has never been an officially bondable satellite, and community reports so far are negative.
+
 ## [0.6.0] - 2026-07-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,10 +366,13 @@ interpolated) then use it.
   soundbar is **`CC` (center)**, NOT `LF,RF`. To add **dedicated fronts**: keep the
   bar as `CC`, append the two chosen speakers as `LF` / `RF`, preserve existing
   rears/sub. This produces a real 5.1 with discrete fronts. (`front_layout.dart`.)
-- **Amp as fronts**: a single Sonos Amp drives two passive front speakers, so it
-  occupies BOTH front channels in one entry — `AMP:LF,RF` — instead of two
-  separate Sonos speakers. Bar still becomes `CC`. (`buildAmpFrontsMap`;
-  detected via `SonosDevice.isAmp`.) **Audio is per-soundbar and NOT
+- **Amp/Port as fronts**: a line-out box (Amp, Connect:Amp, Port, Connect) has no
+  drivers of its own and feeds two external front speakers, so it occupies BOTH
+  front channels in one entry — `AMP:LF,RF` — instead of two separate Sonos
+  speakers. Bar still becomes `CC`. (`buildLayoutMap` collapses the two channels
+  by UUID; detected via `SonosDevice.drivesExternalSpeakers` — the same getter
+  excludes these boxes from Trueplay lists and zone candidates, since neither
+  applies to a device with no speakers.) **Audio is per-soundbar and NOT
   API-discoverable** — confirmed working on a **Playbase + Connect:Amp**, but
   **silent on an Arc Ultra + Amp (S16)** despite a clean, correct bond (the Atmos
   bar appears not to route fronts to a satellite). Track confirmed/failing combos
@@ -567,7 +570,9 @@ adb shell input swipe <x1> <y1> <x2> <y2> [ms]            # scroll/swipe
 ## Feature status
 - ✅ Discovery + topology + Material 3 UI (discovery → home-theater diagram).
 - ✅ Dedicated front surrounds (add with guided flow + Identify; remove), incl. a
-  single **Sonos Amp** driving passive fronts (`AMP:LF,RF`; exclusive selection).
+  single line-out box (**Amp / Connect:Amp / Port / Connect**) driving both
+  external fronts (`AMP:LF,RF`; exclusive selection — `drivesExternalSpeakers`).
+  Port/Connect is offered but community-reported not to bond (`COMPATIBILITY.md`).
 - ✅ Identify a speaker by **blinking its status LED** (`led_identify.dart`, default,
   all platforms incl. macOS) with the audio chime as a mobile-only extra. Offered
   in the pick-a-speaker flows AND per-speaker in the room detail sheet / group &

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -29,14 +29,19 @@ working Beam and the silent Arc Ultra are on near-identical `96.x` builds).
 
 ## Dedicated fronts (soundbar becomes center, external speakers take L/R)
 
-Fronts can be either **two discrete speakers** (one `LF`, one `RF`) or **one Amp
-on both** (`AMP:LF,RF`). Both are tracked below.
+Fronts can be either **two discrete speakers** (one `LF`, one `RF`) or **one
+line-out box on both** (`AMP:LF,RF` — Amp, Connect:Amp, Port, Connect). Both are
+tracked below.
 
 | Soundbar          | Soundbar fw  | Fronts device        | Result       | Source         |
 |-------------------|--------------|----------------------|--------------|----------------|
 | Beam (Gen 2, S31) | 96.1-78270   | 2× One SL (S22), discrete | ✅ audio | developer (live) |
 | Playbase          | (unknown)    | Connect:Amp (Gen 2)  | ✅ audio     | user-confirmed |
-| Arc Ultra (S45)   | 96.0-78270   | Amp (S16), fw 96.0-78270 | ❌ silent | user-confirmed |
+| Arc Ultra (S45)   | 96.0-78270   | Amp (S16), fw 96.0-78270 | ❌ silent (disputed) | user-confirmed |
+| Playbase          | (unknown)    | Port (S23)           | ❌ won't bond | community (r/SonoSequencr) |
+| Playbase          | (unknown)    | Connect (line-out)   | ❌ won't bond | community (r/SonoSequencr) |
+| Arc Ultra (S45)   | (unknown)    | Connect (line-out)   | ❌ won't bond | community (r/SonoSequencr) |
+| Arc Ultra (S45)   | (unknown)    | Amp (current gen)    | ✅ audio (disputes the ❌ above) | community (r/SonoSequencr) |
 
 ### ✅ Beam (Gen 2, S31) + 2× One SL (discrete fronts) — works
 
@@ -86,6 +91,33 @@ standalone room** (ungrouped) in the official Sonos app.
 - Passive speakers play → Amp/wiring is fine; the Arc Ultra isn't routing fronts (suspect #1) — nothing Sonority can fix.
 - Still silent → the Amp's own setup/wiring, unrelated to Sonority.
 
+### ❌ Port / Connect as fronts — community reports it never bonds
+
+Sonority offers a Port/Connect as one-box fronts (same `LF,RF` map shape as an
+Amp), but no one has yet reported it *working*. From r/SonoSequencr:
+
+- One user tried a **Port** as fronts on a **Playbase**, then a **Connect** on the
+  same Playbase, then the **Connect on an Arc Ultra** — none took. Also tried
+  Playbase↔Connect wired ethernet (the "older gear needs 5 GHz/wired" theory) with
+  no change. Their conclusion: neither Connect nor Port can serve as fronts.
+- A second user reports the same for front/surround, and separately confirmed a
+  **Port can't be a sub** either.
+- The SonoSequencr developer has asked the sub twice whether anyone got a
+  Connect (S15) working as fronts/surrounds; both threads went unanswered.
+
+**Failure mode differs from the Arc Ultra + Amp case above.** That one bonds
+cleanly and is merely silent. Here the *bond itself* doesn't take — meaning
+Sonority's `bondAndVerify` will burn its retries and surface an error, rather
+than quietly producing a mute front pair. Not great, but honest and reversible.
+
+Cause is presumably the same firmware gate: the Amp is an *officially* bondable
+surround device, the Port/Connect never has been.
+
+> Still worth leaving the option in the app: it costs nothing, the map shape is
+> identical to the Amp's, this is one user's testing on two bars (never a Beam),
+> and the whole point of Sonority is not gating on Sonos' blessed list. If a Beam
+> owner confirms it works, this row flips.
+
 ## Notes / recurring gotchas
 
 - **"Needs attention" + phantom "not connected" products in the official Sonos
@@ -96,9 +128,21 @@ standalone room** (ungrouped) in the official Sonos app.
   the same *bond-applies-but-silent* false positive (which two users here hit
   before verifying audio). Only treat a combo as ✅ once someone reports **heard
   audio**.
-- **Amp as fronts is one device on both channels** (`AMP:LF,RF`), exclusive
-  selection — not two separate front speakers. The passive speakers wired to the
-  Amp are not network devices and correctly never appear in the app.
+- **A line-out box as fronts is one device on both channels** (`AMP:LF,RF`),
+  exclusive selection — not two separate front speakers. Applies to the Amp,
+  Connect:Amp, **Port**, and Connect: none has drivers of its own, so one box
+  covers L+R. The speakers wired to it are not network devices and correctly
+  never appear in the app.
+- **Port/Connect fronts are offered but community-reported broken** — see the
+  section above. Needs one success report to flip.
+- **The Arc Ultra + Amp ❌ row is disputed.** A r/SonoSequencr user reports the
+  current-gen Sonos Amp driving bookshelf fronts on an **Arc Ultra** working
+  well, incl. all Arc Ultra drivers except its own L/R (they blame a YouTube
+  reviewer's misconfiguration for the "it disables up-firing" rumour). They also
+  note a **Connect:Amp** needs ethernet (itself + the bar, or the bar + another
+  wired Sonos) since it has no 5 GHz radio — which the silent Arc Ultra + Amp
+  report did not obviously rule in or out. So Amp-on-Arc-Ultra may be
+  setup-dependent rather than a hard firmware block.
 
 ## Adding a finding
 

--- a/lib/data/models/sonos_models.dart
+++ b/lib/data/models/sonos_models.dart
@@ -104,10 +104,19 @@ class SonosDevice {
     return base.isEmpty ? 'Speaker' : base;
   }
 
-  /// A Sonos Amp / Connect:Amp drives passive L/R speakers, so it can serve as
-  /// BOTH front channels at once (`LF,RF`) — unlike a normal speaker, which is
-  /// a single side. Used to offer it as a one-box dedicated-fronts option.
-  bool get isAmp => modelName.toLowerCase().contains('amp');
+  /// Has no built-in drivers — it feeds external stereo speakers (Amp /
+  /// Connect:Amp via speaker terminals, Port / Connect via line-out). So ONE
+  /// box covers BOTH front channels at once (`LF,RF`), unlike a normal speaker
+  /// which is a single side. Also means it can't be Trueplay-tuned.
+  /// Word-bounded so a SYMFONISK Table **Lamp** isn't read as an Amp.
+  bool get drivesExternalSpeakers =>
+      modelName.toLowerCase().contains(RegExp(r'\b(amp|port|connect)\b'));
+
+  /// An Amp / Connect:Amp specifically — the one line-out box Sonos' stated
+  /// zone limits exclude. Narrower than [drivesExternalSpeakers] on purpose: a
+  /// Port/Connect has always been offered as a zone member and nobody has
+  /// reported that failing, so widening this would drop a working capability.
+  bool get isAmp => modelName.toLowerCase().contains(RegExp(r'\bamp\b'));
 
   SonosDevice copyWith({String? ip, String? roomName}) => SonosDevice(
         uuid: uuid,

--- a/lib/features/diagnostics/diagnostics_bundle.dart
+++ b/lib/features/diagnostics/diagnostics_bundle.dart
@@ -153,7 +153,7 @@ Map<String, dynamic> topologyJson(SonosSystem system) => {
         'reachable': d.reachable,
         'isSoundbar': d.isSoundbar,
         'isSub': d.isSub,
-        'isAmp': d.isAmp,
+        'drivesExternalSpeakers': d.drivesExternalSpeakers,
       },
   ],
 };

--- a/lib/features/front_surrounds/front_surrounds_flow.dart
+++ b/lib/features/front_surrounds/front_surrounds_flow.dart
@@ -320,10 +320,13 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
     );
   }
 
-  bool _deviceIsAmp(String uuid) =>
-      ref.read(sonosControllerProvider).value?.device(uuid)?.isAmp ?? false;
+  bool _drivesExternalSpeakers(String uuid) =>
+      ref.read(sonosControllerProvider).value?.device(uuid)?.drivesExternalSpeakers ??
+      false;
 
-  bool get _ampMode => _fronts.length == 1 && _deviceIsAmp(_fronts.first);
+  /// One line-out box (Amp/Port) on both front channels instead of two speakers.
+  bool get _ampMode =>
+      _fronts.length == 1 && _drivesExternalSpeakers(_fronts.first);
   bool get _frontsValid => _fronts.isEmpty || _fronts.length == 2 || _ampMode;
   bool get _surroundsValid => _surrounds.isEmpty || _surrounds.length == 2;
 
@@ -352,7 +355,7 @@ class _FrontSurroundsFlowState extends ConsumerState<FrontSurroundsFlow>
       _fronts.remove(d.uuid);
       return;
     }
-    if (d.isAmp) {
+    if (d.drivesExternalSpeakers) {
       _fronts
         ..clear()
         ..add(d.uuid);
@@ -531,7 +534,7 @@ class _ChooseSpeakers extends StatelessWidget {
     if (candidates.isEmpty) {
       return Text(context.l10n.frontSurroundsNoFreeSpeakers);
     }
-    final hasAmp = allowAmp && candidates.any((d) => d.isAmp);
+    final hasAmp = allowAmp && candidates.any((d) => d.drivesExternalSpeakers);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -549,7 +552,7 @@ class _ChooseSpeakers extends StatelessWidget {
 
   Widget _card(BuildContext context, SonosDevice d) {
     final isSel = selected.contains(d.uuid);
-    final isAmp = allowAmp && d.isAmp;
+    final isAmp = allowAmp && d.drivesExternalSpeakers;
     final disabled = !isSel && !isAmp && selected.length >= 2;
     // The side is the speaker's slot in [selected] (0 = left, 1 = right). The
     // in-card toggle only appears once BOTH are chosen — before that there's no

--- a/lib/features/home_theater/home_theater_screen.dart
+++ b/lib/features/home_theater/home_theater_screen.dart
@@ -41,7 +41,7 @@ class HomeTheaterScreen extends ConsumerWidget {
         ? <String>{member.uuid, ...member.channelAssignments.values}
               .map((u) => system.device(u))
               .whereType<SonosDevice>()
-              .where((d) => !d.isAmp)
+              .where((d) => !d.drivesExternalSpeakers)
               .toList()
         : <SonosDevice>[];
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -726,7 +726,7 @@
   "frontSurroundsTitle": "Configure home theater",
   "frontSurroundsStepFronts": "Front speakers",
   "frontSurroundsOptional": "Optional",
-  "frontSurroundsFrontsHint": "Pick two speakers (or a single Amp) for the front left & right, then set which is which.",
+  "frontSurroundsFrontsHint": "Pick two speakers (or a single Amp or Port) for the front left & right, then set which is which.",
   "frontSurroundsStepSurrounds": "Rear surrounds",
   "frontSurroundsSurroundsHint": "Pick two speakers for the rear left & right surrounds.",
   "frontSurroundsStepSub": "Subwoofer",
@@ -749,7 +749,7 @@
   },
   "frontSurroundsUnbond": "Unbond",
   "frontSurroundsNoFreeSpeakers": "No free speakers available. They must be standalone (not already part of a home theater or stereo pair).",
-  "frontSurroundsPickWithAmp": "Pick two speakers (ideally identical), or a single Sonos Amp that drives both front speakers.",
+  "frontSurroundsPickWithAmp": "Pick two speakers (ideally identical), or a single Sonos Amp or Port that feeds both front speakers.",
   "frontSurroundsPickExactlyTwo": "Pick exactly two — ideally an identical pair.",
   "frontSurroundsAmpSubtitle": "{type} — drives both fronts (L + R)",
   "@frontSurroundsAmpSubtitle": {
@@ -761,7 +761,7 @@
   },
   "frontSurroundsNoFreeSub": "No free subwoofer found. A Sonos Sub must be standalone (not already bonded to another home theater).",
   "frontSurroundsSubHint": "Pick one or two subwoofers to add as low-frequency channels.",
-  "frontSurroundsAmpWiring": "The {amp} drives both front channels. Wire your left & right speakers to its L/R speaker outputs — there’s nothing to assign here.",
+  "frontSurroundsAmpWiring": "The {amp} drives both front channels. Wire your left & right speakers to its L/R outputs — there’s nothing to assign here.",
   "@frontSurroundsAmpWiring": {
     "placeholders": {
       "amp": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1999,7 +1999,7 @@ abstract class AppLocalizations {
   /// No description provided for @frontSurroundsFrontsHint.
   ///
   /// In en, this message translates to:
-  /// **'Pick two speakers (or a single Amp) for the front left & right, then set which is which.'**
+  /// **'Pick two speakers (or a single Amp or Port) for the front left & right, then set which is which.'**
   String get frontSurroundsFrontsHint;
 
   /// No description provided for @frontSurroundsStepSurrounds.
@@ -2053,7 +2053,7 @@ abstract class AppLocalizations {
   /// No description provided for @frontSurroundsPickWithAmp.
   ///
   /// In en, this message translates to:
-  /// **'Pick two speakers (ideally identical), or a single Sonos Amp that drives both front speakers.'**
+  /// **'Pick two speakers (ideally identical), or a single Sonos Amp or Port that feeds both front speakers.'**
   String get frontSurroundsPickWithAmp;
 
   /// No description provided for @frontSurroundsPickExactlyTwo.
@@ -2083,7 +2083,7 @@ abstract class AppLocalizations {
   /// No description provided for @frontSurroundsAmpWiring.
   ///
   /// In en, this message translates to:
-  /// **'The {amp} drives both front channels. Wire your left & right speakers to its L/R speaker outputs — there’s nothing to assign here.'**
+  /// **'The {amp} drives both front channels. Wire your left & right speakers to its L/R outputs — there’s nothing to assign here.'**
   String frontSurroundsAmpWiring(String amp);
 
   /// No description provided for @frontSurroundsChooseTwoFirst.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1212,7 +1212,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get frontSurroundsFrontsHint =>
-      'Pick two speakers (or a single Amp) for the front left & right, then set which is which.';
+      'Pick two speakers (or a single Amp or Port) for the front left & right, then set which is which.';
 
   @override
   String get frontSurroundsStepSurrounds => 'Rear surrounds';
@@ -1252,7 +1252,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get frontSurroundsPickWithAmp =>
-      'Pick two speakers (ideally identical), or a single Sonos Amp that drives both front speakers.';
+      'Pick two speakers (ideally identical), or a single Sonos Amp or Port that feeds both front speakers.';
 
   @override
   String get frontSurroundsPickExactlyTwo =>
@@ -1273,7 +1273,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String frontSurroundsAmpWiring(String amp) {
-    return 'The $amp drives both front channels. Wire your left & right speakers to its L/R speaker outputs — there’s nothing to assign here.';
+    return 'The $amp drives both front channels. Wire your left & right speakers to its L/R outputs — there’s nothing to assign here.';
   }
 
   @override

--- a/test/build_layout_map_test.dart
+++ b/test/build_layout_map_test.dart
@@ -116,13 +116,29 @@ void main() {
     expect(m.subUuids, [sub, sub2]);
   });
 
-  test('isAmp matches Amp / Connect:Amp but not speakers, subs, or soundbars', () {
+  test('drivesExternalSpeakers matches Amp/Port/Connect but not speakers, '
+      'subs, or soundbars', () {
+    SonosDevice d(String model) =>
+        SonosDevice(uuid: amp, roomName: amp, modelName: model, ip: '1.2.3.4');
+    expect(d('Sonos Amp').drivesExternalSpeakers, isTrue);
+    expect(d('Sonos Connect:Amp').drivesExternalSpeakers, isTrue);
+    expect(d('Sonos Port').drivesExternalSpeakers, isTrue);
+    expect(d('Sonos Connect').drivesExternalSpeakers, isTrue);
+    expect(d('Sonos Beam').drivesExternalSpeakers, isFalse);
+    expect(d('Sonos One SL').drivesExternalSpeakers, isFalse);
+    expect(d('Sonos Sub').drivesExternalSpeakers, isFalse);
+    // Word-bounded: a SYMFONISK Table Lamp is a speaker, not an "amp".
+    expect(d('SYMFONISK Table Lamp').drivesExternalSpeakers, isFalse);
+  });
+
+  test('isAmp stays narrower than drivesExternalSpeakers (zones)', () {
     SonosDevice d(String model) =>
         SonosDevice(uuid: amp, roomName: amp, modelName: model, ip: '1.2.3.4');
     expect(d('Sonos Amp').isAmp, isTrue);
     expect(d('Sonos Connect:Amp').isAmp, isTrue);
-    expect(d('Sonos Beam').isAmp, isFalse);
-    expect(d('Sonos One SL').isAmp, isFalse);
-    expect(d('Sonos Sub').isAmp, isFalse);
+    // A Port/Connect keeps its (pre-existing) zone eligibility.
+    expect(d('Sonos Port').isAmp, isFalse);
+    expect(d('Sonos Connect').isAmp, isFalse);
+    expect(d('SYMFONISK Table Lamp').isAmp, isFalse);
   });
 }

--- a/test/zone_test.dart
+++ b/test/zone_test.dart
@@ -112,9 +112,15 @@ void main() {
         'sub': SonosDevice(uuid: 'sub', roomName: 'C', modelName: 'Sonos Sub', ip: '3'),
         'bar': SonosDevice(uuid: 'bar', roomName: 'D', modelName: 'Sonos Beam', ip: '4'),
         'play': SonosDevice(uuid: 'play', roomName: 'E', modelName: 'Sonos Play:1', ip: '5'),
+        // A Port drives external speakers (so it can take both HT fronts), but
+        // that must NOT cost it its zone eligibility — only Amps are excluded.
+        'port': SonosDevice(uuid: 'port', roomName: 'F', modelName: 'Sonos Port', ip: '6'),
       },
     );
-    expect(system.zoneableSpeakers.map((d) => d.uuid).toSet(), {'one', 'play'});
+    expect(
+      system.zoneableSpeakers.map((d) => d.uuid).toSet(),
+      {'one', 'play', 'port'},
+    );
   });
 
   test('EntitySnapshot captures a zone and round-trips through JSON', () {

--- a/tool/roundtrip.dart
+++ b/tool/roundtrip.dart
@@ -110,7 +110,7 @@ Future<void> main(List<String> argv) async {
   print('🎚️  Mode: $mode');
 
   if (!ampMode) _sanityCheck(fronts[0], fronts[1]);
-  if (ampMode && !fronts.first.isAmp) {
+  if (ampMode && !fronts.first.drivesExternalSpeakers) {
     print('⚠️  Note: ${fronts.first.modelName} is not an Amp; AMP:LF,RF assumes '
         'one device that drives both passive front speakers.');
   }


### PR DESCRIPTION
A user (Sonos Port feeding a pair of powered studio monitors) reported the Port showing up in the dedicated-fronts picker as a single-channel speaker. He's right — the "this box drives two external speakers, so it takes both front channels" check was `modelName.contains('amp')`, and a Port fell straight through it.

## What changed

`SonosDevice.drivesExternalSpeakers` (new) — Amp, Connect:Amp, Port, Connect: anything with no drivers of its own. Drives the fronts picker (exclusive one-box selection → `PORT:LF,RF`, bar moves to `CC`) and the HT Trueplay list (no drivers ⇒ nothing to tune).

`isAmp` stays, narrowed to Amps only, and still gates `zoneableSpeakers`. Deliberate: a Port/Connect has always been offered as a group member and nobody has reported that failing, so the widened predicate must not quietly take that away.

Both are now word-bounded (`\b(amp|port|connect)\b`) so a SYMFONISK Table **Lamp** isn't classed as an Amp — a latent bug in the old `contains('amp')`.

No engine change was needed: `buildLayoutMap` already collapses two channels on one UUID into a single entry.

## Will it actually work?

Probably not, and the docs say so. r/SonoSequencr reports a Port and a Connect both refusing to bond as fronts, on a Playbase and an Arc Ultra, wired and wireless; nobody has reported success anywhere, and the SonoSequencr developer has twice asked without an answer. Presumably the same firmware gate — the Amp is an officially bondable satellite, the Port never has been.

Worth shipping anyway: the map shape is identical to the Amp's, applying is reversible, and **none of those reports involved a Beam** — the one bar with confirmed working dedicated fronts. Note the failure mode differs from Arc Ultra + Amp: that bonds cleanly and is silent, this reportedly won't bond, so `bondAndVerify` surfaces an error rather than handing over a mute front pair.

`docs/COMPATIBILITY.md` records it as ❌, plus a r/SonoSequencr report disputing our Arc Ultra + Amp "silent" row (a user reports the current-gen Amp working there).

## Verification

`flutter analyze` clean, `flutter test` 225 passing. Tests pin both getters (incl. the Table Lamp negative) and that a Port keeps its zone candidacy.

Not hardware-tested — no Port on the dev system.

## Left alone deliberately

- Rear surrounds still pass `allowAmp: false`, so a line-out box is offered there as a single rear channel. Pre-existing for the Amp; an Amp driving two passive rears (`AMP:LR,RR`) is a separate feature, not this fix.
- Amp-flavoured internal identifiers (`_ampMode`, `allowAmp`, the `frontSurrounds*Amp*` ARB keys) — renaming churns three files for no user-visible gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)