### PR TITLE
chore(license): source-available under PolyForm Perimeter 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ section into the GitHub Release notes regardless of the build suffix
 
 ## [Unreleased]
 
+### Added
+- Sonority now carries a license: the code is source-available under PolyForm Perimeter 1.0.1 — read, build, modify and contribute freely, but redistributing a competing product (paid or free) isn't permitted. The "Sonority" name, icon, wordmark and marketing assets remain reserved, and `CONTRIBUTING.md` documents the licensing grant that pull requests carry.
+
 ## [0.7.0] - 2026-08-18
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to Sonority
+
+Bug reports, hardware findings and pull requests are all welcome — especially reports
+from Sonos models I don't own, since most of what this app knows was derived by testing
+against real speakers (see [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)).
+
+## Licensing of contributions — please read before opening a PR
+
+Sonority is **source-available, not open source**: the code is under the
+[PolyForm Perimeter License 1.0.1](LICENSE), which lets you read, build, run, modify and
+contribute to it, but not ship other people a product that competes with it. Paid builds
+on the App Store and Google Play are published by the copyright holder.
+
+Because of that, accepting a contribution needs the right to use it in those builds — so
+your PR carries a grant:
+
+> By submitting a pull request, you grant Casper Verswijvelt a perpetual, irrevocable,
+> worldwide, royalty-free, non-exclusive license to use, reproduce, modify, distribute,
+> sublicense and **relicense** your contribution, including under proprietary terms and
+> in binaries distributed through app stores. You keep the copyright in your
+> contribution and may use it however you like elsewhere.
+
+Confirm this by signing off each commit, which also certifies you wrote the code and
+have the right to submit it (the [Developer Certificate of Origin][dco]):
+
+```
+git commit -s -m "your message"     # adds: Signed-off-by: Your Name <you@example.com>
+```
+
+If you'd rather not grant that, please open an issue describing the change instead of a
+PR — a described fix is genuinely useful and costs you nothing.
+
+## Before you open the PR
+
+- `~/fvm/versions/3.44.6/bin/flutter analyze` and `flutter test` must be green.
+- Add a `CHANGELOG.md` entry under `## [Unreleased]` — one line.
+- Don't bump `version:` in `pubspec.yaml`; that happens on `main` when a release is cut.
+- Anything with a visible result: include a screenshot. Capture it on an **emulator**,
+  never a personal device — a real phone's status bar leaks notification icons and
+  contact avatars into a public PR.
+- Read [CLAUDE.md](CLAUDE.md) first. It documents the product principle (don't duplicate
+  features the official Sonos app already has), the pure-Dart engine vs. UI split, and
+  the gotchas that cost real debugging — the ≈15s topology lag, poll-until-settled after
+  every write, and reading state from the authoritative channel-map attributes.
+
+## Writes hit somebody's real living room
+
+Bonding calls reconfigure hardware that people watch films on, and some of them fail in
+ways that need a manual recovery. Keep the existing patterns: snapshot before you write,
+gate destructive actions behind an explicit confirmation, make it self-reverting where
+you can, and verify by re-reading rather than trusting a `200 OK`. Validate against real
+speakers if you have them — the `tool/` CLI spikes exist for exactly that, and most are
+read-only or self-restoring.
+
+[dco]: https://developercertificate.org/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,73 @@
+Required Notice: Copyright 2026 Casper Verswijvelt (https://github.com/CasperVerswijvelt/Sonority)
+
+# PolyForm Perimeter License 1.0.1
+
+<https://polyformproject.org/licenses/perimeter/1.0.1>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncompete
+
+Any purpose is a permitted purpose, except for providing to others any product that competes with the software.
+
+## Competition
+
+If you use this software to market a product as a substitute for the functionality or value of the software, it competes with the software. A product may compete regardless how it is designed or deployed. For example, a product may compete even if it provides its functionality via any kind of interface (including services, libraries or plug-ins), even if it is ported to a different platform or programming language, and even if it is provided free of charge.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+A **product** can be a good or service, or a combination of them.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ restriction) — and **config profiles** that snapshot a layout and re-apply it 
 undocumented local UPnP API. A focused, better‑UX alternative to *SonoSequencr*.
 
 > [!NOTE]
-> **Built with AI-assisted programming.** I'm a software engineer, but every line
-> of code here was written by an AI coding agent under close direction — I specified
-> exactly what each change had to do rather than typing it myself. I worked to keep
-> it from becoming "AI slop": exhaustive testing against my own Sonos hardware,
-> deliberate attention to code quality and architecture, unit tests, and thorough
-> documentation throughout. Sharing this openly for transparency.
+> **Built with AI-assisted programming.** I'm a software engineer, and I directed this
+> project end to end: I decided what to build and why, specified exactly what each
+> change had to do, reviewed and revised every one of them, and validated the behaviour
+> against my own Sonos hardware — an AI coding agent did the typing. I worked to keep it
+> from becoming "AI slop": exhaustive testing against real speakers, deliberate
+> attention to code quality and architecture, unit tests, and thorough documentation
+> throughout. Sharing this openly for transparency.
 
 ## Screenshots
 
@@ -166,7 +167,30 @@ there if a different model/firmware ever needs it.
 
 ## Contributing / architecture
 
-See **[CLAUDE.md](CLAUDE.md)** — the product principle (don't duplicate Sonos-app
-features), the pure-Dart engine vs. UI split, the local UPnP API details, and the
-critical gotchas (≈15s topology lag, poll-until-settled, authoritative channel-map
-parsing, firmware-gated pairs, the macOS-sandbox chime limitation).
+See **[CONTRIBUTING.md](CONTRIBUTING.md)** first — pull requests carry a licensing
+grant, and it explains why.
+
+For the code itself see **[CLAUDE.md](CLAUDE.md)** — the product principle (don't
+duplicate Sonos-app features), the pure-Dart engine vs. UI split, the local UPnP API
+details, and the critical gotchas (≈15s topology lag, poll-until-settled, authoritative
+channel-map parsing, firmware-gated pairs, the macOS-sandbox chime limitation).
+
+## License
+
+**The name and the marks are not licensed.** "Sonority", the app icon, the wordmark and
+the store listings are reserved, and no trademark rights are granted here. Anything you
+build on this must be renamed and rebranded.
+
+**Brand and marketing assets are excluded from the code license** and are all rights
+reserved: `assets/brand/`, `design/`, `docs/screenshots/`, `docs/badges/`.
+
+**The code** is source-available under the **[PolyForm Perimeter License 1.0.1](LICENSE)**
+— Copyright © 2026 Casper Verswijvelt. In plain terms: read it, build it, run it, modify
+it for yourself, and contribute changes back — all fine, commercial setting included.
+What you may not do is provide other people a product that competes with Sonority. Per
+the license that holds however it's built or deployed, "even if it is ported to a
+different platform or programming language, and even if it is provided free of charge".
+
+This is deliberately not an open-source license. The source is public so you can audit
+exactly what an app that reconfigures your speakers does, build it yourself, and improve
+it — not so it can be repackaged and shipped by someone else.


### PR DESCRIPTION
Sonority has been public and shipping on both stores with **no stated terms at all** (`licenseInfo: null`). This adds a license, sized to one narrow goal: keep the code readable, buildable and contributable, while stopping anyone from repackaging it as their own product.

## What's here

| File | Change |
|---|---|
| `LICENSE` | PolyForm Perimeter 1.0.1, verbatim, with a `Required Notice:` copyright line |
| `CONTRIBUTING.md` | New — the grant a PR carries, plus DCO sign-off |
| `README.md` | Reworded the AI-authorship note; new `## License` section |
| `CHANGELOG.md` | One line under `[Unreleased]` |

## Why Perimeter and not an open-source license

The requirement was "block copycats, paid **or** unpaid, but keep the code open and contributable." Those pull in opposite directions under every OSI license, so the shortlist came down to what each one actually permits:

| | Commercial use by others | Redistribution (free or paid) | Contributions / private mods |
|---|---|---|---|
| AGPL-3.0 | ✅ allowed | ✅ allowed if they publish source | ✅ allowed |
| PolyForm Noncommercial | ❌ blocked | ⚠️ allowed if noncommercial | ✅ allowed |
| PolyForm Strict | ❌ blocked | ❌ blocked | ❌ **also blocked** |
| **PolyForm Perimeter 1.0.1** | ✅ allowed | ❌ **blocked if it competes** | ✅ allowed |

**AGPL was rejected for the opposite reason people usually pick it.** A copycat who publishes their source is *compliant* — there'd be nothing to file a complaint about. Perimeter's **Noncompete** clause permits any purpose *"except for providing to others any product that competes with the software"*, and the **Competition** clause states this holds *"regardless how it is designed or deployed… even if it is ported to a different platform or programming language, and **even if it is provided free of charge**."* The unpaid rebranded clone is barred in the license text, so a cloner has no argument to make on a Google Play / Apple IP form or a GitHub DMCA notice.

Crucially it still grants a **Changes and New Works License** and a **Distribution License**, so forking, patching and contributing back stay licensed — no bolted-on custom exceptions, which is what PolyForm Strict would have needed.

**The name and marks are reserved** ("Sonority", the icon, the wordmark, the store listings), and `assets/brand/`, `design/`, `docs/screenshots/`, `docs/badges/` are excluded from the code license. No trademark rights are granted, which is what a store copycat complaint actually rests on.

## Accepted trade-offs

- **Not open source, not OSI-approved.** No F-Droid listing, and GitHub will show "Other" rather than a license name.
- **"Competes" is broad**, so an independent fork that adds features and publishes it is also barred from distributing. Contributions flow *into* this repo, not into rival forks. Openness here means auditable and contributable, not forkable into a rival.
- **Enforcement is unchanged** — litigation isn't realistic for a solo developer. What improves is the *complaint*: the store and DMCA forms are free and form-based, and this license removes the copycat's only defence.

## Also in here

**The AI-authorship note is reworded, not removed.** It still says the agent did the typing; it now leads with the direction, review and hardware validation. Both are true, but only human-directed selection and arrangement is copyrightable — and that sentence is what a DMCA counter-notice would quote back.

## Deliberately not done

- **No EUIPO trademark registration.** ~€850 against €1.49-tier revenue, and the store complaint routes work without it — two live listings are first-use evidence. Revisit if a clone appears or revenue grows, accepting the ~4–6 month filing lag.
- **No per-file SPDX headers** across ~200 files; a root `LICENSE` suffices until someone else's code is in the tree.
- **No `license:` field in `pubspec.yaml`** — `publish_to: 'none'` makes it inert.
- **No in-app license screen**, and **nothing about the Trueplay work**, which stays unpublished for now.

## Verification

- `head -5 LICENSE` → the `Required Notice:` line, then `# PolyForm Perimeter License 1.0.1`
- `grep -rn "AGPL\|Affero\|agpl" README.md CONTRIBUTING.md CHANGELOG.md LICENSE` → **no hits** (an earlier revision of this PR was AGPL; this is the check that no stale rationale survived)
- `flutter analyze` → **No issues found**
- `flutter test` → **All 247 tests passed**
- No screenshots: docs-only, nothing visible changes in the app.

Note that `gh repo view --json licenseInfo` will *not* report this license — GitHub only auto-detects SPDX/OSI-style licenses, so expect `null` or "Other". Cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)