### PR TITLE
Require an issue description before emailing a diagnostics bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ section into the GitHub Release notes regardless of the build suffix
 ## [Unreleased]
 
 ### Added
+- Emailing a diagnostics bundle now asks what went wrong first (at least 20 characters) and puts that description in the mail body and in the bundle as `user_note.txt`, so a report never arrives without an explanation. Share and save-to-disk are unchanged.
 - Sonority now carries a license: the code is source-available under PolyForm Perimeter 1.0.1 — read, build, modify and contribute freely, but redistributing a competing product (paid or free) isn't permitted. The "Sonority" name, icon, wordmark and marketing assets remain reserved, and `CONTRIBUTING.md` documents the licensing grant that pull requests carry.
 
 ## [0.7.0] - 2026-08-18

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -692,13 +692,16 @@ adb shell input swipe <x1> <y1> <x2> <y2> [ms]            # scroll/swipe
   (read-only per-speaker EQ/volume/mute reads, role-gated by `settingsReadPlan` /
   `SonosSystem.extendedEqUuids`), plus optional `logs.txt` +
   `network.txt` toggles (both default on). **The email path prompts for a
-  description first** (`features/widgets/issue_note_dialog.dart`, min
+  description first** (`features/diagnostics/issue_note_dialog.dart`, min
   `kMinIssueNoteLength` = 20 trimmed chars, Continue disabled below it,
   cancel = build nothing) — bundles kept arriving with an empty mail body, so
   the text is now collected in-app and written BOTH into the mail body and into
   the zip as `user_note.txt` (`DiagnosticsOptions.note`), which survives the
   composer and any onward forwarding of the file. Share/save don't prompt, so
-  their bundles carry no note. Shares via `share_plus`, a prefilled
+  their bundles carry no note. The typed text is held in `_pendingNote` until
+  the send actually succeeds (`_run` returns a bool) and re-seeds the dialog —
+  a failed send (no mail account configured) must not cost the reporter their
+  report. Shares via `share_plus`, a prefilled
   developer email (`flutter_email_sender`, iOS/Android/macOS), or save-to-disk
   via a native save dialog on every platform (`file_saver`; macOS needs the
   `files.user-selected.read-write` sandbox entitlement — self-granted, no Apple

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -599,7 +599,16 @@ adb shell input swipe <x1> <y1> <x2> <y2> [ms]            # scroll/swipe
   needed; the marketing-screenshot path (`docs/MARKETING-ASSETS.md` §2). UI work
   can be verified against it without touching the real system: navigation-only —
   write/identify taps fail fast (the demo SOAP client throws, so a demo build
-  emits no network I/O; IPs are unrouteable TEST-NET besides).
+  emits no network I/O; IPs are unrouteable TEST-NET besides). **Every client
+  that talks to a speaker must be overridable, or demo mode silently waits out
+  real timeouts against the TEST-NET IPs** — `SpeakerSettingsClient` was
+  constructed inside `SonosController` and `DeviceDescriptionClient` wasn't
+  passed to the demo repository, so a diagnostics bundle took >15min in demo
+  mode (EQ reads 8s each + a 5s description fetch per device) instead of 2s.
+  Both are injected now (`speakerSettingsProvider`, overridden in
+  `demoOverrides()`; `descriptions: DeviceDescriptionClient(_DemoHttpClient())`
+  — the HTTP path needs its own stub since it isn't SOAP). Add the override
+  when you add a client.
 - **Web is a screenshot-only demo target, NOT a shipped platform.** A browser
   can't do SSDP/sockets, so the app only runs meaningfully on web under
   `DEMO=true`. The engine's `dart:io` bits (`ssdp_discovery.dart`,
@@ -682,7 +691,14 @@ adb shell input swipe <x1> <y1> <x2> <y2> [ms]            # scroll/swipe
   `app_state.json` (all app SharedPreferences), `speaker_settings.json`
   (read-only per-speaker EQ/volume/mute reads, role-gated by `settingsReadPlan` /
   `SonosSystem.extendedEqUuids`), plus optional `logs.txt` +
-  `network.txt` toggles (both default on). Shares via `share_plus`, a prefilled
+  `network.txt` toggles (both default on). **The email path prompts for a
+  description first** (`features/widgets/issue_note_dialog.dart`, min
+  `kMinIssueNoteLength` = 20 trimmed chars, Continue disabled below it,
+  cancel = build nothing) — bundles kept arriving with an empty mail body, so
+  the text is now collected in-app and written BOTH into the mail body and into
+  the zip as `user_note.txt` (`DiagnosticsOptions.note`), which survives the
+  composer and any onward forwarding of the file. Share/save don't prompt, so
+  their bundles carry no note. Shares via `share_plus`, a prefilled
   developer email (`flutter_email_sender`, iOS/Android/macOS), or save-to-disk
   via a native save dialog on every platform (`file_saver`; macOS needs the
   `files.user-selected.read-write` sandbox entitlement — self-granted, no Apple

--- a/lib/demo/demo_mode.dart
+++ b/lib/demo/demo_mode.dart
@@ -11,8 +11,8 @@ import '../data/sonos/identify_service.dart';
 import '../data/sonos/led_identify.dart';
 import '../data/sonos/room_calibration.dart';
 import '../data/sonos/soap_client.dart';
-import '../data/sonos/speaker_settings.dart';
 import '../data/sonos/sonos_repository.dart';
+import '../data/sonos/speaker_settings.dart';
 import '../data/sonos/zone_layout.dart' show buildGroupMap;
 import '../data/sonos/zone_topology.dart';
 import '../features/profiles/profile.dart';
@@ -27,8 +27,8 @@ import '../state/sonos_controller.dart';
 const kDemoMode = bool.fromEnvironment('DEMO');
 
 /// The provider overrides demo mode swaps in: the repository (topology +
-/// Trueplay reads), the profile store, and the identify clients. Everything on
-/// screen derives from these.
+/// Trueplay reads), the profile store, the identify clients, and the speaker
+/// settings client. Everything on screen derives from these.
 List<Override> demoOverrides() => [
       sonosRepositoryProvider.overrideWithValue(_DemoSonosRepository()),
       profileStoreProvider.overrideWithValue(_DemoProfileStore()),
@@ -49,15 +49,6 @@ final _demoSoap = _DemoSoapClient();
 
 /// Throws on any SOAP call, so NOTHING in a demo build can emit network I/O —
 /// including repository write methods and any read method added later.
-/// Same idea for the plain-HTTP path: `device_description.xml` fetches don't go
-/// through SOAP, so the diagnostics bundle's raw-description dump would hit the
-/// unrouteable demo IPs for real (a 5s timeout per device).
-class _DemoHttpClient extends http.BaseClient {
-  @override
-  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
-      throw StateError('demo mode: no network I/O (${request.url})');
-}
-
 class _DemoSoapClient extends SonosSoapClient {
   @override
   Future<XmlElement> call({
@@ -69,6 +60,15 @@ class _DemoSoapClient extends SonosSoapClient {
     Duration timeout = const Duration(seconds: 8),
   }) async =>
       throw StateError('demo mode: no network I/O ($action)');
+}
+
+/// Same idea for the plain-HTTP path: `device_description.xml` fetches don't go
+/// through SOAP, so the diagnostics bundle's raw-description dump would hit the
+/// unrouteable demo IPs for real (a 5s timeout per device).
+class _DemoHttpClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
+      throw StateError('demo mode: no network I/O (${request.url})');
 }
 
 // ponytail: demo is navigation-only — write flows (apply/bond/separate/rename)

--- a/lib/demo/demo_mode.dart
+++ b/lib/demo/demo_mode.dart
@@ -1,14 +1,17 @@
 import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:http/http.dart' as http;
 import 'package:xml/xml.dart' show XmlElement;
 
 import '../data/models/sonos_models.dart';
 import '../data/sonos/av_transport.dart';
 import '../data/sonos/channel_map.dart';
+import '../data/sonos/device_description.dart';
 import '../data/sonos/device_properties.dart';
 import '../data/sonos/identify_service.dart';
 import '../data/sonos/led_identify.dart';
 import '../data/sonos/room_calibration.dart';
 import '../data/sonos/soap_client.dart';
+import '../data/sonos/speaker_settings.dart';
 import '../data/sonos/sonos_repository.dart';
 import '../data/sonos/zone_layout.dart' show buildGroupMap;
 import '../data/sonos/zone_topology.dart';
@@ -34,12 +37,27 @@ List<Override> demoOverrides() => [
       ledIdentifyProvider.overrideWithValue(LedIdentifyClient(_demoSoap)),
       identifyServiceProvider
           .overrideWithValue(IdentifyServiceClient(_demoSoap)),
+      // Profile settings-capture and the diagnostics bundle both read EQ/volume
+      // per speaker; against the unrouteable demo IPs every read would burn its
+      // full 8s timeout (a bundle took >15min). Reads swallow failures, so a
+      // throwing client just yields empty settings, instantly.
+      speakerSettingsProvider
+          .overrideWithValue(SpeakerSettingsClient(_demoSoap)),
     ];
 
 final _demoSoap = _DemoSoapClient();
 
 /// Throws on any SOAP call, so NOTHING in a demo build can emit network I/O —
 /// including repository write methods and any read method added later.
+/// Same idea for the plain-HTTP path: `device_description.xml` fetches don't go
+/// through SOAP, so the diagnostics bundle's raw-description dump would hit the
+/// unrouteable demo IPs for real (a 5s timeout per device).
+class _DemoHttpClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async =>
+      throw StateError('demo mode: no network I/O (${request.url})');
+}
+
 class _DemoSoapClient extends SonosSoapClient {
   @override
   Future<XmlElement> call({
@@ -56,12 +74,11 @@ class _DemoSoapClient extends SonosSoapClient {
 // ponytail: demo is navigation-only — write flows (apply/bond/separate/rename)
 // fail fast on _DemoSoapClient instead of succeeding against fake state. Fake
 // the write semantics (mutate demoSystem) if a demo of a full apply is ever
-// needed. Known leak: SpeakerSettingsClient is constructed inside
-// SonosController, so the profile-create "save speaker settings" toggle still
-// times out against the (unrouteable TEST-NET) demo IPs.
+// needed.
 class _DemoSonosRepository extends SonosRepository {
   _DemoSonosRepository()
       : super(
+          descriptions: DeviceDescriptionClient(_DemoHttpClient()),
           topology: ZoneTopologyClient(_demoSoap),
           deviceProps: DevicePropertiesClient(_demoSoap),
           calibration: RoomCalibrationClient(_demoSoap),

--- a/lib/features/diagnostics/diagnostics_bundle.dart
+++ b/lib/features/diagnostics/diagnostics_bundle.dart
@@ -11,16 +11,22 @@ import '../../data/sonos/speaker_settings.dart';
 import '../widgets/version_badge.dart' show fullVersionLabel;
 import 'diagnostics_platform.dart';
 
-/// Which optional sources to fold into the bundle (both default on in the UI).
-/// The core files — README, parsed_topology.json, topology.txt, raw_topology.xml,
-/// device_descriptions/, app_state.json — are always included.
+/// Which optional sources to fold into the bundle (the two bools default on in
+/// the UI). The core files — README, parsed_topology.json, topology.txt,
+/// raw_topology.xml, device_descriptions/, app_state.json — are always included.
 class DiagnosticsOptions {
   const DiagnosticsOptions({
     this.includeLogs = true,
     this.includeNetwork = true,
+    this.note,
   });
   final bool includeLogs;
   final bool includeNetwork;
+
+  /// The reporter's description of the problem, collected in the app before an
+  /// email escalation. Written as `user_note.txt`; null on the share/save paths,
+  /// which don't prompt for one.
+  final String? note;
 }
 
 /// Builds the diagnostics zip and returns its file path. Re-fetches the raw
@@ -33,6 +39,7 @@ Future<String> buildDiagnosticsZip({
   required SonosRepository repo,
   required PackageInfo package,
   required DateTime now,
+  required SpeakerSettingsClient settings,
   DiagnosticsOptions options = const DiagnosticsOptions(),
 }) async {
   final archive = Archive();
@@ -40,6 +47,10 @@ Future<String> buildDiagnosticsZip({
     final bytes = utf8.encode(content);
     archive.addFile(ArchiveFile(name, bytes.length, bytes));
   }
+
+  // The reporter's own words first — the file that says why the bundle exists.
+  final note = options.note;
+  if (note != null) add('user_note.txt', note);
 
   // Core topology views.
   add(
@@ -79,7 +90,7 @@ Future<String> buildDiagnosticsZip({
   add(
     'speaker_settings.json',
     const JsonEncoder.withIndent('  ')
-        .convert(await readSpeakerSettings(system, SpeakerSettingsClient())),
+        .convert(await readSpeakerSettings(system, settings)),
   );
 
   if (options.includeNetwork) {
@@ -370,6 +381,8 @@ String _readme(
   DiagnosticsOptions o,
 ) {
   final files = [
+    if (o.note != null)
+      'user_note.txt           — what the reporter said went wrong',
     'README.txt              — this file',
     'parsed_topology.json    — machine-readable system dump (all members incl. hidden)',
     'topology.txt            — human-readable version of the same',

--- a/lib/features/diagnostics/diagnostics_screen.dart
+++ b/lib/features/diagnostics/diagnostics_screen.dart
@@ -15,6 +15,7 @@ import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/busy_spinner.dart';
+import '../widgets/issue_note_dialog.dart';
 import '../widgets/settings_section.dart';
 import 'diagnostics_bundle.dart';
 
@@ -41,7 +42,7 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
 
   bool get _isBusy => _busy != null;
 
-  Future<String?> _collect() async {
+  Future<String?> _collect(String? note) async {
     final system = ref.read(sonosControllerProvider).value;
     if (system == null) return null;
     final pkg = await PackageInfo.fromPlatform();
@@ -50,9 +51,11 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
       repo: ref.read(sonosRepositoryProvider),
       package: pkg,
       now: DateTime.now(),
+      settings: ref.read(speakerSettingsProvider),
       options: DiagnosticsOptions(
         includeLogs: _includeLogs,
         includeNetwork: _includeNetwork,
+        note: note,
       ),
     );
   }
@@ -69,14 +72,15 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
 
   Future<void> _run(
     _Action which,
-    Future<void> Function(String path) action,
-  ) async {
+    Future<void> Function(String path) action, {
+    String? note,
+  }) async {
     final l10n = context.l10n;
     setState(() => _busy = which);
     try {
       final String path;
       try {
-        final built = await _collect();
+        final built = await _collect(note);
         if (built == null) {
           _snack(l10n.diagNoSystemToCollect);
           return;
@@ -113,11 +117,21 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
   Widget _busyIcon(_Action which, IconData icon) =>
       _busy == which ? const BusySpinner() : Icon(icon);
 
-  Future<void> _email(String path) => FlutterEmailSender.send(
+  /// Ask for the description, then collect + email. Cancelling the dialog
+  /// builds nothing. The note travels twice — in the mail body (what gets read
+  /// first) and as `user_note.txt` inside the zip, which survives the composer
+  /// and any onward forwarding of the file.
+  Future<void> _emailFlow() async {
+    final note = await showIssueNoteDialog(context);
+    if (note == null) return;
+    await _run(_Action.email, (path) => _email(path, note), note: note);
+  }
+
+  Future<void> _email(String path, String note) => FlutterEmailSender.send(
     Email(
       subject: 'Sonority diagnostics',
       recipients: const [_devEmail],
-      body: context.l10n.diagEmailBody,
+      body: '$note\n\n${context.l10n.diagEmailAttached}',
       attachmentPaths: [path],
     ),
   );
@@ -209,10 +223,9 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
                   child: FilledButton.icon(
                     onPressed: (_isBusy || !hasSystem)
                         ? null
-                        : () => _run(
-                            _emailSupported ? _Action.email : _Action.share,
-                            _emailSupported ? _email : _share,
-                          ),
+                        : (_emailSupported
+                            ? _emailFlow
+                            : () => _run(_Action.share, _share)),
                     style: FilledButton.styleFrom(minimumSize: const Size(0, 54)),
                     icon: _busyIcon(
                       _emailSupported ? _Action.email : _Action.share,

--- a/lib/features/diagnostics/diagnostics_screen.dart
+++ b/lib/features/diagnostics/diagnostics_screen.dart
@@ -15,9 +15,9 @@ import '../../state/localized_error.dart';
 import '../../state/sonos_controller.dart';
 import '../widgets/app_scaffold.dart';
 import '../widgets/busy_spinner.dart';
-import '../widgets/issue_note_dialog.dart';
 import '../widgets/settings_section.dart';
 import 'diagnostics_bundle.dart';
+import 'issue_note_dialog.dart';
 
 const _devEmail = 'casperverswijveltdev@gmail.com';
 
@@ -39,6 +39,10 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
   bool _includeLogs = true;
   bool _includeNetwork = true;
   _Action? _busy; // null = idle; else the action currently running
+
+  /// The typed description, held only while a send is outstanding, so a failed
+  /// email (no mail app configured) doesn't discard what the reporter wrote.
+  String? _pendingNote;
 
   bool get _isBusy => _busy != null;
 
@@ -70,7 +74,10 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
           defaultTargetPlatform == TargetPlatform.android ||
           defaultTargetPlatform == TargetPlatform.macOS);
 
-  Future<void> _run(
+  /// Runs [action] on a freshly built bundle. Returns true only if [action]
+  /// itself completed — the email path uses that to decide whether the typed
+  /// note can be dropped.
+  Future<bool> _run(
     _Action which,
     Future<void> Function(String path) action, {
     String? note,
@@ -83,17 +90,19 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
         final built = await _collect(note);
         if (built == null) {
           _snack(l10n.diagNoSystemToCollect);
-          return;
+          return false;
         }
         path = built;
       } catch (e) {
         _snack(l10n.diagBuildFailed(localizedError(l10n, e)));
-        return;
+        return false;
       }
       try {
         await action(path);
+        return true;
       } catch (e) {
         _snack(l10n.diagActionFailed(localizedError(l10n, e)));
+        return false;
       }
     } finally {
       if (mounted) setState(() => _busy = null);
@@ -122,16 +131,22 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
   /// first) and as `user_note.txt` inside the zip, which survives the composer
   /// and any onward forwarding of the file.
   Future<void> _emailFlow() async {
-    final note = await showIssueNoteDialog(context);
-    if (note == null) return;
-    await _run(_Action.email, (path) => _email(path, note), note: note);
+    final note = await showIssueNoteDialog(context, initial: _pendingNote);
+    if (note == null || !mounted) return;
+    _pendingNote = note;
+    // Compose the body here, while the context is known-good — collecting the
+    // bundle takes seconds, and _email runs after it.
+    final body = '$note\n\n${context.l10n.diagEmailAttached}';
+    final sent =
+        await _run(_Action.email, (path) => _email(path, body), note: note);
+    if (sent) _pendingNote = null;
   }
 
-  Future<void> _email(String path, String note) => FlutterEmailSender.send(
+  Future<void> _email(String path, String body) => FlutterEmailSender.send(
     Email(
       subject: 'Sonority diagnostics',
       recipients: const [_devEmail],
-      body: '$note\n\n${context.l10n.diagEmailAttached}',
+      body: body,
       attachmentPaths: [path],
     ),
   );
@@ -186,7 +201,8 @@ class _DiagnosticsScreenState extends ConsumerState<DiagnosticsScreen> {
                     ),
                   ),
           ),
-          // Bundle-content toggles + note + escalation actions, pinned below the
+          // Bundle-content toggles + the always-included line + escalation
+          // actions, pinned below the
           // scrolling topology. The toggles are a flat register (leading divider +
           // square ink) via the shared SettingsSection, like the room / new-profile
           // registers.

--- a/lib/features/diagnostics/issue_note_dialog.dart
+++ b/lib/features/diagnostics/issue_note_dialog.dart
@@ -10,9 +10,10 @@ const kMinIssueNoteLength = 20;
 /// Prompts for a description of the problem before a diagnostics bundle is
 /// emailed. Returns the trimmed text, or null if cancelled — the caller then
 /// builds nothing. Continue stays disabled until the text passes
-/// [kMinIssueNoteLength].
-Future<String?> showIssueNoteDialog(BuildContext context) {
-  final controller = TextEditingController();
+/// [kMinIssueNoteLength]. [initial] pre-fills the field so a send that failed
+/// (no mail app configured) doesn't cost the reporter their typed text.
+Future<String?> showIssueNoteDialog(BuildContext context, {String? initial}) {
+  final controller = TextEditingController(text: initial);
   return showDialog<String>(
     context: context,
     // StatefulBuilder so Continue enables live on the threshold without a
@@ -21,6 +22,9 @@ Future<String?> showIssueNoteDialog(BuildContext context) {
       builder: (ctx, setState) {
         final text = controller.text.trim();
         return AlertDialog(
+          // A 3-line field + helper + actions can outgrow the dialog at a large
+          // text scale with the keyboard up.
+          scrollable: true,
           title: Text(ctx.l10n.diagNoteTitle),
           content: TextField(
             controller: controller,
@@ -36,7 +40,11 @@ Future<String?> showIssueNoteDialog(BuildContext context) {
               hintText: ctx.l10n.diagNoteHint,
               hintMaxLines: 3,
               helperText: ctx.l10n.diagNoteHelper(kMinIssueNoteLength),
-              counterText: '${text.length}/$kMinIssueNoteLength',
+              // Counter only while short: Material's "n/max" shape reads as an
+              // exceeded limit once past a MINimum ("200/20").
+              counterText: text.length >= kMinIssueNoteLength
+                  ? ''
+                  : '${text.length}/$kMinIssueNoteLength',
             ),
             onChanged: (_) => setState(() {}),
           ),

--- a/lib/features/widgets/issue_note_dialog.dart
+++ b/lib/features/widgets/issue_note_dialog.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../core/l10n.dart';
+
+/// Minimum length of the reporter's problem description. A diagnostics bundle
+/// with no explanation costs a round-trip before triage can start, so the email
+/// escalation won't build one until there's at least a sentence.
+const kMinIssueNoteLength = 20;
+
+/// Prompts for a description of the problem before a diagnostics bundle is
+/// emailed. Returns the trimmed text, or null if cancelled — the caller then
+/// builds nothing. Continue stays disabled until the text passes
+/// [kMinIssueNoteLength].
+Future<String?> showIssueNoteDialog(BuildContext context) {
+  final controller = TextEditingController();
+  return showDialog<String>(
+    context: context,
+    // StatefulBuilder so Continue enables live on the threshold without a
+    // widget class of its own.
+    builder: (ctx) => StatefulBuilder(
+      builder: (ctx, setState) {
+        final text = controller.text.trim();
+        return AlertDialog(
+          title: Text(ctx.l10n.diagNoteTitle),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            minLines: 3,
+            maxLines: 6,
+            keyboardType: TextInputType.multiline,
+            textCapitalization: TextCapitalization.sentences,
+            // Guidance as a wrapping hint, not a floating label: the label
+            // clips to one line at dialog width, and the box is 3 lines tall
+            // anyway. Helper stays short so it fits beside the counter.
+            decoration: InputDecoration(
+              hintText: ctx.l10n.diagNoteHint,
+              hintMaxLines: 3,
+              helperText: ctx.l10n.diagNoteHelper(kMinIssueNoteLength),
+              counterText: '${text.length}/$kMinIssueNoteLength',
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+          // Both TextButton: the theme stretches a FilledButton full width,
+          // which would stack the actions (see confirm_dialog.dart).
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: Text(ctx.l10n.actionCancel),
+            ),
+            TextButton(
+              onPressed: text.length >= kMinIssueNoteLength
+                  ? () => Navigator.pop(ctx, text)
+                  : null,
+              child: Text(ctx.l10n.actionContinue),
+            ),
+          ],
+        );
+      },
+    ),
+  );
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -809,5 +809,13 @@
   "diagCollecting": "Collecting…",
   "diagEmailToDeveloper": "Email to developer",
   "diagShareDiagnostics": "Share diagnostics",
-  "diagEmailBody": "Describe what went wrong (what you tried, what you expected, what happened):\n\n\n——— the diagnostics bundle is attached below ———"
+  "diagEmailAttached": "——— the diagnostics bundle is attached below ———",
+  "diagNoteTitle": "What went wrong?",
+  "diagNoteHint": "What you tried, what you expected, what happened",
+  "diagNoteHelper": "At least {min} characters",
+  "@diagNoteHelper": {
+    "placeholders": {
+      "min": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2200,11 +2200,29 @@ abstract class AppLocalizations {
   /// **'Share diagnostics'**
   String get diagShareDiagnostics;
 
-  /// No description provided for @diagEmailBody.
+  /// No description provided for @diagEmailAttached.
   ///
   /// In en, this message translates to:
-  /// **'Describe what went wrong (what you tried, what you expected, what happened):\n\n\n——— the diagnostics bundle is attached below ———'**
-  String get diagEmailBody;
+  /// **'——— the diagnostics bundle is attached below ———'**
+  String get diagEmailAttached;
+
+  /// No description provided for @diagNoteTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'What went wrong?'**
+  String get diagNoteTitle;
+
+  /// No description provided for @diagNoteHint.
+  ///
+  /// In en, this message translates to:
+  /// **'What you tried, what you expected, what happened'**
+  String get diagNoteHint;
+
+  /// No description provided for @diagNoteHelper.
+  ///
+  /// In en, this message translates to:
+  /// **'At least {min} characters'**
+  String diagNoteHelper(int min);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1345,6 +1345,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diagShareDiagnostics => 'Share diagnostics';
 
   @override
-  String get diagEmailBody =>
-      'Describe what went wrong (what you tried, what you expected, what happened):\n\n\n——— the diagnostics bundle is attached below ———';
+  String get diagEmailAttached =>
+      '——— the diagnostics bundle is attached below ———';
+
+  @override
+  String get diagNoteTitle => 'What went wrong?';
+
+  @override
+  String get diagNoteHint => 'What you tried, what you expected, what happened';
+
+  @override
+  String diagNoteHelper(int min) {
+    return 'At least $min characters';
+  }
 }

--- a/lib/state/sonos_controller.dart
+++ b/lib/state/sonos_controller.dart
@@ -103,6 +103,12 @@ final ledIdentifyProvider = Provider<LedIdentifyClient>((ref) {
   });
 });
 
+/// Reads/writes per-speaker EQ + volume (profile capture/restore, and the
+/// diagnostics bundle's read-only snapshot). A provider so demo mode can swap in
+/// a client that can't touch the network.
+final speakerSettingsProvider =
+    Provider<SpeakerSettingsClient>((ref) => SpeakerSettingsClient());
+
 final sonosControllerProvider =
     AsyncNotifierProvider<SonosController, SonosSystem?>(SonosController.new);
 
@@ -127,7 +133,7 @@ class SonosController extends AsyncNotifier<SonosSystem?> {
 
   SonosRepository get _repo => ref.read(sonosRepositoryProvider);
 
-  final _settings = SpeakerSettingsClient();
+  SpeakerSettingsClient get _settings => ref.read(speakerSettingsProvider);
 
   /// Reads each entity's per-speaker settings ([audio] bundle and/or [volume])
   /// and returns copies enriched with a `settings` map. Called by

--- a/test/demo_mode_test.dart
+++ b/test/demo_mode_test.dart
@@ -1,6 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sonority/data/models/sonos_models.dart';
 import 'package:sonority/demo/demo_mode.dart';
+import 'package:sonority/state/sonos_controller.dart';
 
 /// The demo channel-map strings are hand-written and typo-prone; assert the
 /// fake system classifies exactly as the screenshots need it to.
@@ -50,6 +52,38 @@ void main() {
         }
       }
     }
+  });
+
+  // Demo mode must not emit real network I/O: the demo IPs are unrouteable
+  // TEST-NET, so any client that isn't stubbed silently waits out its full
+  // timeout (this leaked twice — SpeakerSettingsClient, then
+  // DeviceDescriptionClient — and made a diagnostics bundle take >15min).
+  // Every speaker-facing client reached through the overrides must fail fast.
+  group('demo mode emits no network I/O', () {
+    late ProviderContainer container;
+    setUp(() => container = ProviderContainer(overrides: demoOverrides()));
+    tearDown(() => container.dispose());
+
+    test('speaker settings reads resolve instantly and empty', () async {
+      final settings = await container
+          .read(speakerSettingsProvider)
+          .read('192.0.2.10', volume: true)
+          .timeout(const Duration(seconds: 1));
+      expect(settings.bass, isNull);
+      expect(settings.volume, isNull);
+      expect(settings.eq, isEmpty);
+    });
+
+    test('raw device descriptions fail fast instead of hanging', () {
+      // The bundle wraps this in _tryFetch, so throwing is the correct outcome.
+      expect(
+        container
+            .read(sonosRepositoryProvider)
+            .rawDeviceDescription('192.0.2.10')
+            .timeout(const Duration(seconds: 1)),
+        throwsA(isA<StateError>()),
+      );
+    });
   });
 
   test('demo profiles resolve cleanly against the demo system', () {

--- a/test/issue_note_dialog_test.dart
+++ b/test/issue_note_dialog_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sonority/features/widgets/issue_note_dialog.dart';
+import 'package:sonority/l10n/app_localizations.dart';
+
+/// The gate that stops an unexplained diagnostics bundle reaching the developer:
+/// Continue must stay dead until the description is long enough, and cancelling
+/// must yield null so the caller builds nothing.
+void main() {
+  /// Opens the dialog and returns the future holding its result.
+  Future<Future<String?>> open(WidgetTester tester) async {
+    late Future<String?> result;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (ctx) => TextButton(
+              onPressed: () => result = showIssueNoteDialog(ctx),
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return result;
+  }
+
+  VoidCallback? continueAction(WidgetTester tester) => tester
+      .widget<TextButton>(
+        find.ancestor(
+          of: find.text('Continue'),
+          matching: find.byType(TextButton),
+        ),
+      )
+      .onPressed;
+
+  testWidgets('Continue is disabled until the minimum length', (tester) async {
+    await open(tester);
+    expect(continueAction(tester), isNull, reason: 'empty');
+
+    await tester.enterText(find.byType(TextField), 'a' * (kMinIssueNoteLength - 1));
+    await tester.pump();
+    expect(continueAction(tester), isNull, reason: 'one char short');
+
+    await tester.enterText(find.byType(TextField), 'a' * kMinIssueNoteLength);
+    await tester.pump();
+    expect(continueAction(tester), isNotNull, reason: 'at the threshold');
+  });
+
+  testWidgets('whitespace does not count toward the minimum', (tester) async {
+    await open(tester);
+    await tester.enterText(
+      find.byType(TextField),
+      '${' ' * 40}${'a' * (kMinIssueNoteLength - 1)}${' ' * 40}',
+    );
+    await tester.pump();
+    expect(continueAction(tester), isNull);
+  });
+
+  testWidgets('Continue returns the trimmed text', (tester) async {
+    final result = await open(tester);
+    await tester.enterText(find.byType(TextField), '  fronts bond but stay silent  ');
+    await tester.pump();
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+    expect(await result, 'fronts bond but stay silent');
+  });
+
+  testWidgets('Cancel returns null so nothing is collected', (tester) async {
+    final result = await open(tester);
+    await tester.enterText(find.byType(TextField), 'a' * kMinIssueNoteLength);
+    await tester.pump();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(await result, isNull);
+  });
+}

--- a/test/issue_note_dialog_test.dart
+++ b/test/issue_note_dialog_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:sonority/features/widgets/issue_note_dialog.dart';
+import 'package:sonority/features/diagnostics/issue_note_dialog.dart';
 import 'package:sonority/l10n/app_localizations.dart';
 
 /// The gate that stops an unexplained diagnostics bundle reaching the developer:
@@ -8,7 +8,7 @@ import 'package:sonority/l10n/app_localizations.dart';
 /// must yield null so the caller builds nothing.
 void main() {
   /// Opens the dialog and returns the future holding its result.
-  Future<Future<String?>> open(WidgetTester tester) async {
+  Future<Future<String?>> open(WidgetTester tester, {String? initial}) async {
     late Future<String?> result;
     await tester.pumpWidget(
       MaterialApp(
@@ -17,7 +17,8 @@ void main() {
         home: Scaffold(
           body: Builder(
             builder: (ctx) => TextButton(
-              onPressed: () => result = showIssueNoteDialog(ctx),
+              onPressed: () =>
+                  result = showIssueNoteDialog(ctx, initial: initial),
               child: const Text('open'),
             ),
           ),
@@ -68,6 +69,17 @@ void main() {
     await tester.tap(find.text('Continue'));
     await tester.pumpAndSettle();
     expect(await result, 'fronts bond but stay silent');
+  });
+
+  testWidgets('initial text is kept, so a failed send costs nothing',
+      (tester) async {
+    const typed = 'fronts bond but stay silent on Arc Ultra';
+    final result = await open(tester, initial: typed);
+    expect(find.text(typed), findsOneWidget);
+    expect(continueAction(tester), isNotNull, reason: 'already long enough');
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+    expect(await result, typed);
   });
 
   testWidgets('Cancel returns null so nothing is collected', (tester) async {


### PR DESCRIPTION
## Why

Diagnostics zips keep arriving with an empty mail body. The old `diagEmailBody` was a *placeholder prompt* — "Describe what went wrong (…)" — typed into the OS mail composer, which people send unedited or delete outright. A bundle with no explanation costs a round-trip before triage can start.

The description is now collected **in the app** and travels twice: in the mail body, and inside the zip as `user_note.txt` — so it survives the composer and any onward forwarding of the file.

| | |
|---|---|
| Form | `AlertDialog` on press; Continue disabled below the minimum, cancel builds nothing |
| Scope | **email path only** — Share and Save stay frictionless and their bundles are unchanged |
| Minimum | 20 trimmed characters |

## Screenshots

Emulator + demo mode, SysUI demo mode (fixed clock, no notification icons).

| Empty — Continue disabled | Too short (8/20) | Long enough (counter clears) | Light theme |
|---|---|---|---|
| <img src="https://raw.githubusercontent.com/CasperVerswijvelt/Sonority/pr-shots-82/pr-82-empty.png" width="220"> | <img src="https://raw.githubusercontent.com/CasperVerswijvelt/Sonority/pr-shots-82/pr-82-short.png" width="220"> | <img src="https://raw.githubusercontent.com/CasperVerswijvelt/Sonority/pr-shots-82/pr-82-filled.png" width="220"> | <img src="https://raw.githubusercontent.com/CasperVerswijvelt/Sonority/pr-shots-82/pr-82-light.png" width="220"> |

The counter shows only while the text is too short — Material's `n/max` shape reads as an *exceeded* limit once past a minimum ("200/20").

## Also in here: two demo-mode leaks

Found while verifying this on the emulator. `SpeakerSettingsClient` was constructed inside `SonosController` and `DeviceDescriptionClient` was never passed to the demo repository, so building a bundle in demo mode waited out real timeouts against the unrouteable TEST-NET IPs — **>15 min, now 2 s**. Both go through injection now (`speakerSettingsProvider`, `descriptions: DeviceDescriptionClient(_DemoHttpClient())`; the HTTP path needs its own stub since it isn't SOAP). This invariant has now leaked twice, so it has two fail-fast assertions in `demo_mode_test.dart` rather than only a CLAUDE.md paragraph.

## Verification

- `flutter analyze` clean, `flutter test` **254 passing** (9 new).
- **Bundle contents confirmed on-device**, not just reasoned about — pulled the zip off the emulator:
  ```
  Archive:  bundle.zip
       49  user_note.txt          <- first entry
    13909  parsed_topology.json
    ...
  $ unzip -p bundle.zip user_note.txt
  fronts bond but stay silent on Arc Ultra with Amp
  ```
  and `README.txt` lists `user_note.txt — what the reporter said went wrong`.
- Email path end-to-end: Continue → bundle built → mail composer opens with the body. Share/Save show no dialog.
- A failed send keeps the text (`_pendingNote` re-seeds the dialog) — covered by a widget test; the emulator's composer always launches, so that branch wasn't exercised on-device.

## Review

`/code-review` (high), `/ponytail-review` and a fresh review subagent against CLAUDE.md's review guidelines; all findings addressed in 81e9316 except one deliberately skipped — plumbing the note through `_run`'s action signature instead of a closure + named param, which would push an ignored parameter onto `_share`/`_save` for no real gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
